### PR TITLE
Allow more flexibility when going beyond the buffer sizes

### DIFF
--- a/src/main/java/emissary/parser/FillingNIOParser.java
+++ b/src/main/java/emissary/parser/FillingNIOParser.java
@@ -43,7 +43,7 @@ public abstract class FillingNIOParser extends NIOSessionParser {
             }
         }
 
-        if (b == null) {
+        if (b == null || b.length == 0) {
             setFullyParsed(true);
             throw new ParserEOFException("Sessions completed");
         }

--- a/src/test/java/emissary/util/WindowedSeekableByteChannelTest.java
+++ b/src/test/java/emissary/util/WindowedSeekableByteChannelTest.java
@@ -264,4 +264,36 @@ public class WindowedSeekableByteChannelTest extends UnitTest {
         }
         assertTrue(hitEx);
     }
+
+    @Test
+    public void testPositionRollOff() throws Exception {
+        final byte[] buff = new byte[I_ALPHABET];
+        final byte[] alphabet = buildArry(I_ALPHABET);
+        final ByteBuffer destination = ByteBuffer.wrap(buff);
+        @SuppressWarnings({"resource"})
+        final WindowedSeekableByteChannel instance = new WindowedSeekableByteChannel(getChannel(I_ALPHABET * 2), 10);
+        // 2 full reads will get us to the end
+        instance.position(0);
+        instance.read(destination);
+        assertArrayEquals(alphabet, destination.array());
+        destination.put(0, NULL);
+        destination.position(0);
+
+        instance.read(destination);
+        assertArrayEquals(alphabet, destination.array());
+        destination.put(0, NULL);
+        destination.position(0);
+
+        // try to roll back to the set position
+        instance.position(0);
+        instance.read(destination);
+        assertArrayEquals(alphabet, destination.array());
+        destination.put(0, NULL);
+        destination.position(0);
+
+        // Last record should still exist
+        final int result = instance.read(destination);
+        assertEquals(26, result);
+    }
+
 }


### PR DESCRIPTION
1) WindowedSeekableByteChannel size() is unreliable so removed use from the NIOSessionParser
2) Resizes data array after filling from channel
3) Allow WindowedSeekable to grow to not roll off a set position