### PR TITLE
Closes #10 - Tweak logging in NIOSessionParser + subclasses

### DIFF
--- a/src/main/java/emissary/parser/FillingNIOParser.java
+++ b/src/main/java/emissary/parser/FillingNIOParser.java
@@ -1,5 +1,8 @@
 package emissary.parser;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.RandomAccessFile;
 import java.nio.channels.SeekableByteChannel;
 
@@ -7,6 +10,8 @@ import java.nio.channels.SeekableByteChannel;
  * Encapsulate the behavior necessary to slide a window through a channel and parse sessions from it.
  */
 public abstract class FillingNIOParser extends NIOSessionParser {
+
+    private final static Logger logger = LoggerFactory.getLogger(FillingNIOParser.class);
 
     protected int sessionStart = 0;
 
@@ -36,6 +41,7 @@ public abstract class FillingNIOParser extends NIOSessionParser {
             // trying to read too large a chunk size from the underlying
             // java.io.RandomAccessFile. Try reading it in smaller chunks
             try {
+                logger.debug("Falling back to fillNextRegion() due to memory constraints");
                 b = fillNextRegion(data);
             } catch (OutOfMemoryError oom2) {
                 logger.error("Tried to fill next region but failed", oom2);

--- a/src/main/java/emissary/parser/NIOSessionParser.java
+++ b/src/main/java/emissary/parser/NIOSessionParser.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class NIOSessionParser extends SessionParser {
     // Logger
-    protected final static Logger logger = LoggerFactory.getLogger(NIOSessionParser.class);
+    private final static Logger logger = LoggerFactory.getLogger(NIOSessionParser.class);
 
     // the input channel
     protected SeekableByteChannel channel = null;

--- a/src/main/java/emissary/parser/SimpleNioParser.java
+++ b/src/main/java/emissary/parser/SimpleNioParser.java
@@ -1,5 +1,8 @@
 package emissary.parser;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -13,6 +16,9 @@ import java.util.Map;
  * about headers and footers, just the basic session and not much of an idea about that.
  */
 public class SimpleNioParser extends NIOSessionParser {
+
+    private final static Logger logger = LoggerFactory.getLogger(SimpleNioParser.class);
+
     protected int currentSessionIndex = 0;
 
     /**


### PR DESCRIPTION
 - Forces NIOSessionParser subclasses to log using their class name,
   to make it clear which class the message originate from.
 - make the logger in NIOSessionParser private
 - add a logger for FillingNIOParser, SimpleNioParser
 - added a debug message to indicate when FillingNIOParser is going into
   chunk mode.