### PR TITLE
18: WhatCommand -h/--header parameter doesn't work as expected. Added…

### DIFF
--- a/src/main/java/emissary/command/WhatCommand.java
+++ b/src/main/java/emissary/command/WhatCommand.java
@@ -45,7 +45,7 @@ public class WhatCommand extends BaseCommand {
         return COMMAND_NAME;
     }
 
-    @Parameter(names = {"-h", "--header"}, description = "use header identification, defaults to true")
+    @Parameter(names = {"-h", "--header"}, description = "use header identification, defaults to true", arity = 1)
     private boolean headerIdentification = true;
 
     @Parameter(names = {"-i", "--input"}, description = "input file or directory", converter = PathExistsReadableConverter.class, required = true)
@@ -158,7 +158,8 @@ public class WhatCommand extends BaseCommand {
 
         if (!this.headerIdentification) {
             final IBaseDataObject payload =
-                    DataObjectFactory.getInstance(Executrix.readDataFromFile(path.toString()), path.toAbsolutePath(), Form.UNKNOWN);
+                    DataObjectFactory.getInstance(Executrix.readDataFromFile(path.toString()), path.toAbsolutePath().toString(),
+                            Form.UNKNOWN);
             final Identification id = identify(payload, this.headerIdentification);
             LOG.info(path + " - " + payload.getFilename() + ": " + id.getTypeString());
             return;

--- a/src/test/java/emissary/command/WhatCommandIT.java
+++ b/src/test/java/emissary/command/WhatCommandIT.java
@@ -30,8 +30,10 @@ public class WhatCommandIT extends UnitTest {
     public static final String[] PROJECT_BASE_ARGS = {"-b", "--projectBase"};
     @DataPoints("Input Options")
     public static final String[] INPUT_ARGS = {"-i", "--input"};
-    @DataPoints("Boolean Options")
-    public static final String[] BOOLEAN_ARGS = {"-h", "--header", "-r", "--recursive"};
+    @DataPoints("Boolean Options Without Value")
+    public static final String[] BOOLEAN_ARGS_WITHOUT_VALUE = {"-r", "--recursive"};
+    @DataPoints("Boolean Options With Value")
+    public static final String[] BOOLEAN_ARGS_WITH_VALUE = {"-h", "--header"};
     @DataPoints("String Options")
     public static final String[] STRING_ARGS = {"--logbackConfig"};
     private WhatCommand command;
@@ -50,7 +52,8 @@ public class WhatCommandIT extends UnitTest {
 
     @Theory
     public void verifyExpectedOptions(@FromDataPoints("ProjectBase Options") String baseDirArg, @FromDataPoints("Input Options") String inputDirArg,
-            @FromDataPoints("String Options") String stringArg, @FromDataPoints("Boolean Options") String booleanArg) throws Exception {
+            @FromDataPoints("String Options") String stringArg, @FromDataPoints("Boolean Options Without Value") String booleanArgWithoutValue,
+            @FromDataPoints("Boolean Options With Value") String booleanArgWithValue) throws Exception {
         // setup
         arguments.add(baseDirArg);
         arguments.add(baseDir.toString());
@@ -58,7 +61,9 @@ public class WhatCommandIT extends UnitTest {
         arguments.add(inputDir.toString());
         arguments.add(stringArg);
         arguments.add("validateStringArg");
-        arguments.add(booleanArg);
+        arguments.add(booleanArgWithoutValue);
+        arguments.add(booleanArgWithValue);
+        arguments.add(Boolean.FALSE.toString());
 
         // test (no exceptions thrown)
         WhatCommand.parse(WhatCommand.class, arguments);


### PR DESCRIPTION
… arity = 1 to parameter definition. true or false must be specified when using parameter now.

Apparently  a JCommander boolean parameter without a value does not toggle the value. Without specifying a value, a boolean with a default value of false will toggle to true., a boolean with a default value of true will not toggle to false. In order to override a boolean with a default value of true, the parameter must be dfined with an arity = 1 and then true or false must be passed as the value.