### PR TITLE
Further nio parser improvements

### DIFF
--- a/src/main/java/emissary/parser/NIOSessionParser.java
+++ b/src/main/java/emissary/parser/NIOSessionParser.java
@@ -11,22 +11,38 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Provide a basic NIO based session parser.
+ * Provide a basic NIO-based session parser that reads data in chunks from the underlying channel. A chunk might have
+ * zero or more complete sessions within it. The chunk buffer will begin at minChunkSize, but grow as large as
+ * maxChunkSize in order to accomodate a complete session. Sessions larger than maxChunkSize will lead to
+ * ParserExceptions
  */
 public abstract class NIOSessionParser extends SessionParser {
     // Logger
     private final static Logger logger = LoggerFactory.getLogger(NIOSessionParser.class);
 
-    // the input channel we will read from
+    protected static final int MIN_CHUNK_SIZE_DEFAULT = 2 * 1024 * 1024; // 2Mb
+    protected static final int MAX_CHUNK_SIZE_DEFAULT = 40 * 1024 * 1024; // 40Mb
+
+    /** The data source for this parser */
     protected SeekableByteChannel channel;
 
-    // Track where we are in the overall file and in the current chunk
+    /** The start position of the current chunk relative to the data source */
     protected int chunkStart = 0;
+
+    /** The current chunk buffer */
     protected byte[] data = null;
 
-    // Max chunk to read at a time, we will never be able to read a file with a session larger than this.
-    protected static final int MAP_MAX_DEFAULT = 40 * 1024 * 1024; // 40Mb
-    protected int chunkSize = MAP_MAX_DEFAULT;
+    /** The current write position for the current chunk buffer */
+    protected int writeOffset = 0;
+
+    /** Min chunk buffer size. */
+    protected int minChunkSize = MIN_CHUNK_SIZE_DEFAULT;
+
+    /** Max chunk to read at a time, we will never be able to read a file with a session larger than this. */
+    protected int maxChunkSize = MAX_CHUNK_SIZE_DEFAULT;
+
+    /** When we grow the chunk buffer to accomodate additional data, we will grow the buffer by this increment */
+    protected int chunkAllocationIncrement = (10 * 1024 * 1024) + 100;
 
     /**
      * Create the parser with the supplied data source
@@ -50,16 +66,16 @@ public abstract class NIOSessionParser extends SessionParser {
     /**
      * Get the chunking size
      */
-    public int getChunkSize() {
-        return chunkSize;
+    public int getMaxChunkSize() {
+        return maxChunkSize;
     }
 
     /**
      * Set the chunking size
      */
-    public void setChunkSize(int value) {
+    public void setMaxChunkSize(int value) {
         if (value > 0) {
-            chunkSize = value;
+            maxChunkSize = value;
         }
     }
 
@@ -68,49 +84,76 @@ public abstract class NIOSessionParser extends SessionParser {
      *
      * @param data the byte array to (re)load or null if one should be created
      * @return the byte array of data
+     * @throws ParserException in cases where a new array can't be read.
      */
-    protected byte[] loadNextRegion(byte[] data) {
-        logger.debug("loadOrFillNextRegion: data.length = {}, chunkSize = {}, chunkStart = {}",
-                data == null ? -1 : data.length, chunkSize, chunkStart);
+    protected byte[] loadNextRegion(byte[] data) throws ParserException {
+        logger.debug("loadNextRegion(): data.length = {}, maxChunkSize = {}, chunkStart = {}, writeOffset = {}",
+                data == null ? -1 : data.length, maxChunkSize, chunkStart, writeOffset);
 
-        // Position before checking remaining
-        try {
-            channel.position(chunkStart);
-        } catch (IOException iox) {
-            logger.error("Unable to seek to {}", chunkStart, iox);
-            return null;
+        if (!channel.isOpen()) {
+            logger.debug("loadNextRegion(): channel closed");
+            throw new ParserEOFException("Channel is closed, likely completely consumed");
+        }
+
+        // Position ourselves in the input stream at the beginning of the next session when starting a new chunk.
+        if (writeOffset == 0) {
+            // Position before checking remaining
+            try {
+                channel.position(chunkStart);
+            } catch (IOException ioe) {
+                throw new ParserException("Exception positioning channel to " + chunkStart, ioe);
+            }
         }
 
         // Optionally create the array or recreate if old is too small
-        if (data == null || data.length < chunkSize) {
-            data = new byte[chunkSize];
+        if (data == null) {
+            logger.debug("allocating new byte[] of size {}", minChunkSize);
+            data = new byte[minChunkSize];
+        }
+
+        if (writeOffset >= data.length) {
+            // grow the byte buffer to accomodate more data
+            int newSize = data.length + chunkAllocationIncrement;
+            if (newSize > maxChunkSize) {
+                newSize = maxChunkSize;
+            }
+
+            if (data.length >= maxChunkSize) {
+                // if the byte array is already maxChunkSize or larger, there isn't anything more we can do
+                throw new ParserException("buffer size required to read session " + chunkStart + " is larger than maxChunkSize " + maxChunkSize);
+            }
+
+            logger.debug("re-allocating new byte[] of size {}", newSize);
+            byte[] newData = new byte[newSize];
+            System.arraycopy(data, 0, newData, 0, data.length);
+            data = newData;
         }
 
         final ByteBuffer b = ByteBuffer.wrap(data);
-        b.limit(chunkSize);
+        logger.debug("Wrapping byte[] in new ByteBuffer = {}, position = {}, limit = {}", b, writeOffset, data.length);
+        b.position(writeOffset);
+        b.limit(data.length);
 
         try {
-            readFully(b);
-        } catch (EOFException ex) {
-            logger.warn("End of channel reached at {} instead of expected {}", chunkSize - b.remaining(), chunkSize, ex);
+            while (b.hasRemaining()) {
+                if (channel.read(b) == -1) {
+                    channel.close();
+                    logger.warn("Closing channel. End of channel reached at {} instead of expected {}", data.length - b.remaining(), data.length);
+                    break;
+                }
+            }
         } catch (IOException ex) {
-            logger.error("Count not read {} bytes into array", chunkSize, ex);
-            return null;
-        } finally {
-            logger.debug("After loadOrFillNextRegion, buffer state = {}, data length = {}", b, data.length);
-            int amountRead = chunkSize - b.remaining();
-            if (amountRead < data.length) {
-                data = Arrays.copyOfRange(data, 0, amountRead);
-            }
+            throw new ParserException("Exception reading from channel", ex);
         }
-        return data;
-    }
 
-    protected void readFully(ByteBuffer b) throws IOException {
-        while (b.hasRemaining()) {
-            if (channel.read(b) == -1) {
-                throw new EOFException();
-            }
+        writeOffset = data.length - b.remaining();
+        logger.debug("Finishing loadNextRegion(): buffer state = {}, data length = {}, remaining = {}, writeOffset = {}", b, data.length,
+                b.remaining(), writeOffset);
+        if (writeOffset < data.length) {
+            logger.debug("trimming byte[] from {} to size {}", data.length, writeOffset);
+            data = Arrays.copyOfRange(data, 0, writeOffset);
         }
+
+        return data;
     }
 }

--- a/src/main/java/emissary/parser/SessionParser.java
+++ b/src/main/java/emissary/parser/SessionParser.java
@@ -44,5 +44,5 @@ public abstract class SessionParser {
      * 
      * @return the next session from the input
      */
-    public abstract DecomposedSession getNextSession() throws ParserException, ParserEOFException;
+    public abstract DecomposedSession getNextSession() throws ParserException;
 }

--- a/src/main/java/emissary/parser/SessionProducer.java
+++ b/src/main/java/emissary/parser/SessionProducer.java
@@ -132,7 +132,7 @@ public class SessionProducer {
      * @param defaultSessionName name to use if we have nothing better
      * @return the IBaseDataObject implementation from the Factory
      */
-    public IBaseDataObject getNextSession(String defaultSessionName) throws ParserEOFException, ParserException {
+    public IBaseDataObject getNextSession(String defaultSessionName) throws ParserException {
         DecomposedSession d = sp.getNextSession();
         return createAndLoadDataObject(d, defaultSessionName);
     }

--- a/src/main/java/emissary/parser/SimpleNioParser.java
+++ b/src/main/java/emissary/parser/SimpleNioParser.java
@@ -150,8 +150,7 @@ public class SimpleNioParser extends NIOSessionParser {
 
     /**
      * Slice data from a buffer based on a single position record
-     * 
-     * @param channel the data to pull from
+     *
      * @param r the position record indicating absolute offsets
      */
     byte[] makeDataSlice(PositionRecord r) throws IOException {
@@ -163,7 +162,12 @@ public class SimpleNioParser extends NIOSessionParser {
 
         try {
             channel.position(r.getPosition());
-            readFully(n);
+            while (n.hasRemaining()) {
+                if (channel.read(n) == -1) {
+                    channel.close();
+                    break;
+                }
+            }
         } catch (BufferUnderflowException ex) {
             logger.warn("Underflow getting {} bytes at {}", n.capacity(), r.getPosition());
         }
@@ -172,9 +176,8 @@ public class SimpleNioParser extends NIOSessionParser {
 
     /**
      * Slice data from a buffer based on a single position record
-     * 
-     * @param channel the data to pull from
-     * @param r the position record indicating absolute offsets
+     *
+     * @param records the list of position records indicating absolute offsets
      */
     byte[] makeDataSlice(List<PositionRecord> records) throws IOException {
         if (records == null || records.isEmpty()) {
@@ -198,7 +201,12 @@ public class SimpleNioParser extends NIOSessionParser {
             channel.position(r.getPosition());
             limit += (int) r.getLength();
             n.limit(limit);
-            readFully(n);
+            while (n.hasRemaining()) {
+                if (channel.read(n) == -1) {
+                    channel.close();
+                    break;
+                }
+            }
         }
 
         return n.array();


### PR DESCRIPTION
- avoids allocating the entire `maxChunkSize` up-front, allocates `minChunkSize` and then re-allocates as necessary to read an entire session in `NIOSessionParser`
- eliminates some of the confusion around returning null vs. throwing an exception in loadNextRegion in `NIOSessionParser`
- adds documentation to `NIOSessionParser`
- `FillingNIOParser` now properly slides through the chunk, dropping the sessions that are successfully parsed. This should keep the size of the allocated chunkBuffer in `NIOSessionParser` to a minimum.