### PR TITLE
Updates strategy for handling partial session parser reads

### DIFF
--- a/src/main/java/emissary/parser/NIOSessionParser.java
+++ b/src/main/java/emissary/parser/NIOSessionParser.java
@@ -95,16 +95,6 @@ public abstract class NIOSessionParser extends SessionParser {
             throw new ParserEOFException("Channel is closed, likely completely consumed");
         }
 
-        // Position ourselves in the input stream at the beginning of the next session when starting a new chunk.
-        if (writeOffset == 0) {
-            // Position before checking remaining
-            try {
-                channel.position(chunkStart);
-            } catch (IOException ioe) {
-                throw new ParserException("Exception positioning channel to " + chunkStart, ioe);
-            }
-        }
-
         // Optionally create the array or recreate if old is too small
         if (data == null) {
             logger.debug("allocating new byte[] of size {}", minChunkSize);


### PR DESCRIPTION
 - When the entire buffer was not consumed but the buffer was
   not large enought to contain the entire session, we would reposition
   the channel at the beginning of the unread session and re-read
   that session into the beginning of the buffer.

   Instead of doing that, simply compact the buffer, which has
   the effect of moving the data in the buffer to the beginning of the buffer.
   Subsequent reads can be made from the current position of the channel.