### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <dep.commons-collections.version>3.2.1</dep.commons-collections.version>
     <dep.commons-el.version>1.0</dep.commons-el.version>
     <dep.commons-exec.version>1.2</dep.commons-exec.version>
-    <dep.commons-fileupload.version>1.2.2</dep.commons-fileupload.version>
+    <dep.commons-fileupload.version>1.4</dep.commons-fileupload.version>
     <dep.commons-io.version>2.4</dep.commons-io.version>
     <dep.commons-lang.version>2.6</dep.commons-lang.version>
     <dep.commons-logging.version>1.1.3</dep.commons-logging.version>
@@ -45,6 +45,8 @@
     <dep.httpcore.version>4.4.3</dep.httpcore.version>
     <dep.jackcess.version>2.1.2</dep.jackcess.version>
     <dep.jackson.version>2.8.11</dep.jackson.version>
+    <!-- jersey brings in 1.2; tika-parsers brings in 1.3.2; converge on latest -->
+    <dep.javax.annotation-api.version>1.3.2</dep.javax.annotation-api.version>
     <dep.jcommander.version>1.58</dep.jcommander.version>
     <dep.jdom.version>2.0.2</dep.jdom.version>
     <dep.jersey.version>2.27</dep.jersey.version>
@@ -59,7 +61,7 @@
     <dep.spullara.mustache.compiler.version>0.8.17</dep.spullara.mustache.compiler.version>
     <dep.spymemcached.version>2.11.4</dep.spymemcached.version>
     <dep.sun.mail.version>1.6.2</dep.sun.mail.version>
-    <dep.tika.version>1.19.1</dep.tika.version>
+    <dep.tika.version>1.20</dep.tika.version>
     <dep.xmlbeans.version>2.6.0</dep.xmlbeans.version>
     <eclipseFormatterStyle>${project.basedir}/contrib/formatter.xml</eclipseFormatterStyle>
     <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
@@ -197,6 +199,11 @@
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-servlets</artifactId>
         <version>${dep.dropwizard.metrics.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>${dep.javax.annotation-api.version}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -757,7 +764,7 @@
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>7.8.2</version>
+              <version>8.18</version>
             </dependency>
           </dependencies>
           <executions>


### PR DESCRIPTION
* checkstyle updated to 8.18 (CVE-2019-9658)
* tika updated to 1.20 (CVE-2018-17197)
* commons-fileupload (CVE-2016-1000031, CVE-2014-0050, CVE-2016-3092)