### PR TITLE
Fix lots of little issues

### DIFF
--- a/src/main/java/emissary/client/response/PeerList.java
+++ b/src/main/java/emissary/client/response/PeerList.java
@@ -21,7 +21,6 @@ public class PeerList {
     }
 
     // used by object mapper
-    @SuppressWarnings("usused")
     public PeerList() {}
 
     public String getHost() {

--- a/src/main/java/emissary/command/AgentsCommand.java
+++ b/src/main/java/emissary/command/AgentsCommand.java
@@ -6,12 +6,9 @@ import com.beust.jcommander.Parameters;
 import emissary.client.EmissaryClient;
 import emissary.client.response.AgentsResponseEntity;
 import org.apache.http.client.methods.HttpGet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Parameters(commandDescription = "List all the agents for a given node or all nodes in the cluster")
 public class AgentsCommand extends MonitorCommand<AgentsResponseEntity> {
-    private static final Logger LOG = LoggerFactory.getLogger(AgentsCommand.class);
 
     public static String COMMAND_NAME = "agents";
 

--- a/src/main/java/emissary/command/BaseCommand.java
+++ b/src/main/java/emissary/command/BaseCommand.java
@@ -144,9 +144,6 @@ public abstract class BaseCommand implements EmissaryCommand {
      * @param clazz the Class of return type class
      * @param args vararg of Strings
      * @return <T extends AbstractBaseCommand>
-     * @throws ClassNotFoundException
-     * @throws IllegalAccessException
-     * @throws InstantiationException
      */
     public static <T extends EmissaryCommand> T parse(Class<T> clazz, String... args) throws InstantiationException, IllegalAccessException,
             ClassNotFoundException {
@@ -164,9 +161,6 @@ public abstract class BaseCommand implements EmissaryCommand {
      * @param clazz the Class of return type class
      * @param args vararg of Strings
      * @return <T extends EmissaryCommand>
-     * @throws ClassNotFoundException
-     * @throws IllegalAccessException
-     * @throws InstantiationException
      */
     public static <T extends EmissaryCommand> T parse(Class<T> clazz, List<String> args) throws InstantiationException, IllegalAccessException,
             ClassNotFoundException {

--- a/src/main/java/emissary/config/ConfigUtil.java
+++ b/src/main/java/emissary/config/ConfigUtil.java
@@ -153,8 +153,6 @@ public class ConfigUtil {
     /**
      * Initialize system properties for this class, but make it so that test cases (and other interested parties) can reset
      * system properties and re-call this method when they need to.
-     * 
-     * @throws EmissaryException
      */
     public static void initialize() throws EmissaryException {
         // PlaceStarter.class.getName();
@@ -239,10 +237,6 @@ public class ConfigUtil {
 
     /**
      * Get a List of config directories.
-     * <p>
-     * 
-     * @throws EmissaryException
-     *
      */
     public static List<String> getConfigDirs() {
         if (configDirs == null) {
@@ -657,7 +651,6 @@ public class ConfigUtil {
      *
      * @return Configurator with all emissary.admin.MasterClassNames
      * @throws IOException If there is some I/O problem.
-     * @throws EmissaryException
      */
     public static Configurator getMasterClassNames() throws IOException, EmissaryException {
         final List<File> masterClassNames = new ArrayList<>();

--- a/src/main/java/emissary/core/ResourceWatcher.java
+++ b/src/main/java/emissary/core/ResourceWatcher.java
@@ -51,8 +51,6 @@ public class ResourceWatcher implements Runnable {
 
     /**
      * Create a resource watcher set it running and bind into the NamespaceException
-     * 
-     * @param metricsManager
      */
     public ResourceWatcher(final MetricsManager metricsManager) {
         this.metrics = metricsManager.getMetricRegistry();
@@ -93,7 +91,6 @@ public class ResourceWatcher implements Runnable {
      * Lookup the default ResourceWatcher in the Namespace
      * 
      * @return The registered ResourceWatcher
-     * @throws emissary.core.NamespaceException
      */
     public static ResourceWatcher lookup() throws NamespaceException {
         return (ResourceWatcher) Namespace.lookup(DEFAULT_NAMESPACE_NAME);

--- a/src/main/java/emissary/directory/DirectoryPlace.java
+++ b/src/main/java/emissary/directory/DirectoryPlace.java
@@ -177,13 +177,28 @@ public class DirectoryPlace extends ServiceProviderPlace implements IDirectoryPl
      * @param configStream config info
      * @param parentDir the parent directory or null if none
      * @param placeLoc key for this place
-     * @throws IOException when configuration failes
+     * @throws IOException when configuration fails
      */
     @Deprecated
     // need to pass in EmissaryNode
     public DirectoryPlace(final InputStream configStream, final String parentDir, final String placeLoc) throws IOException {
         super(configStream, parentDir, placeLoc);
         this.emissaryNode = new EmissaryNode();
+        setupDirectory(parentDir);
+    }
+
+    /**
+     * Create a new directory as specified by the config info with a parent for relaying through.
+     *
+     * @param configStream config info
+     * @param parentDir the parent directory or null if none
+     * @param placeLoc key for this place
+     * @param node node configuration details or null for defaults
+     * @throws IOException when configuration fails
+     */
+    public DirectoryPlace(final InputStream configStream, final String parentDir, final String placeLoc, final EmissaryNode node) throws IOException {
+        super(configStream, parentDir, placeLoc);
+        this.emissaryNode = node;
         setupDirectory(parentDir);
     }
 

--- a/src/main/java/emissary/kff/SpamSumSignature.java
+++ b/src/main/java/emissary/kff/SpamSumSignature.java
@@ -96,6 +96,11 @@ public class SpamSumSignature {
         return this.equals((SpamSumSignature) obj);
     }
 
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
     public boolean equals(SpamSumSignature other) {
         if (this.blockSize != other.blockSize) {
             return false;

--- a/src/main/java/emissary/kff/Ssdeep.java
+++ b/src/main/java/emissary/kff/Ssdeep.java
@@ -188,7 +188,8 @@ public final class Ssdeep {
 
         /**
          * Discard any existing hash state and prepare to compute a new hash. This should be followed by calls to
-         * {@link #applyBytes()} to provide the data, and then {@link #finishHashing()} to complete the computations.
+         * {@link #applyBytes(RollingState, byte[], int, int)} to provide the data, and then
+         * {@link #finishHashing(RollingState)} to complete the computations.
          */
         private void beginHashing() {
             this.fuzzLen1 = 0;
@@ -215,7 +216,7 @@ public final class Ssdeep {
 
         /**
          * Finish hashing and generate the final signature. This should be done after all bytes have been applied with
-         * {@link #applyBytes()}.
+         * {@link #applyBytes(RollingState, byte[], int, int)}.
          *
          * @param rollState The rolling hash state used during hashing.
          * @return The final signature.
@@ -447,9 +448,9 @@ public final class Ssdeep {
      *
      * @param s1 The first byte array for comparison.
      * @param s2 The second byte array for comparison.
-     * @param len The substring length to look for. Assumed greater than zero.
-     * @return {@code true} iff {@code s1} and {@code s2} have at least one byte sequence of length {@code len} in common at
-     *         arbitrary offsets.
+     * @param length The substring length to look for. Assumed greater than zero.
+     * @return {@code true} iff {@code s1} and {@code s2} have at least one byte sequence of length {@code length} in common
+     *         at arbitrary offsets.
      */
     private static boolean hasCommonSequence(final byte[] s1, final byte[] s2, final int length) {
         if ((s1.length < length) || (s2.length < length)) {

--- a/src/main/java/emissary/output/DropOffUtil.java
+++ b/src/main/java/emissary/output/DropOffUtil.java
@@ -3,6 +3,7 @@ package emissary.output;
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -682,7 +683,7 @@ public class DropOffUtil {
      */
     protected String datePath(final String dtg) {
         if (dtg == null) {
-            return emissary.util.TimeUtil.getDateAsPath(new Date());
+            return emissary.util.TimeUtil.getDateAsPath(Instant.now());
         } else {
             return dtg.substring(0, 4) + "-" + // yyyy
                     dtg.substring(4, 6) + "-" + // mm

--- a/src/main/java/emissary/output/filter/JsonOutputFilter.java
+++ b/src/main/java/emissary/output/filter/JsonOutputFilter.java
@@ -199,6 +199,8 @@ public class JsonOutputFilter extends AbstractRollableFilter {
      * Ibdo {@link Module} implementation that allows registration of serializers
      */
     class IbdoModule extends SimpleModule {
+        private static final long serialVersionUID = -8129967131240053241L;
+
         public IbdoModule() {
             addSerializer(IBaseDataObject.class, new IbdoSerializer());
         }

--- a/src/main/java/emissary/output/roller/JournaledCoalescer.java
+++ b/src/main/java/emissary/output/roller/JournaledCoalescer.java
@@ -29,7 +29,6 @@ import emissary.output.roller.journal.JournalEntry;
 import emissary.output.roller.journal.JournalReader;
 import emissary.output.roller.journal.JournaledChannelPool;
 import emissary.output.roller.journal.KeyedOutput;
-import emissary.roll.Rollable;
 import emissary.util.io.FileNameGenerator;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
@@ -91,7 +90,6 @@ public class JournaledCoalescer implements IJournaler, ICoalescer {
      * @see JournaledCoalescer#JournaledCoalescer(java.nio.file.Path, FileNameGenerator, int)
      * @param outPath The Path to use for reading input and writing combined output
      * @param fileNameGenerator The FileNameGenerator to use for unique destination file names
-     * @throws java.lang.InterruptedException
      * @throws IOException If there is some I/O problem.
      */
     public JournaledCoalescer(final Path outPath, final FileNameGenerator fileNameGenerator) throws IOException, InterruptedException {
@@ -104,8 +102,6 @@ public class JournaledCoalescer implements IJournaler, ICoalescer {
      * @param outPath The Path to use for reading input and writing combined output
      * @param fileNameGenerator The FileNameGenerator to use for unique destination file names
      * @param poolsize The max number of outputs for the pool.
-     * @throws IOException
-     * @throws InterruptedException
      */
     public JournaledCoalescer(final Path outPath, final FileNameGenerator fileNameGenerator, int poolsize) throws IOException, InterruptedException {
         this.outputPath = outPath.toAbsolutePath();
@@ -118,8 +114,6 @@ public class JournaledCoalescer implements IJournaler, ICoalescer {
 
     /**
      * Validate the Path we are using for combining files
-     *
-     * @throws Exception
      */
     private void validateOutputPath() throws IOException {
         if (!exists(this.outputPath)) {
@@ -135,8 +129,6 @@ public class JournaledCoalescer implements IJournaler, ICoalescer {
      * Sometimes the rolled files can hang around after a crash. If there is a rolled file, that means all of the files
      * coalesced successfully but cleanup failed. If there are not any files with the same name, just rename the rolled
      * file. Otherwise, the rolled file will get cleaned up with the normal process.
-     *
-     * @throws IOException
      */
     private void cleanupOrphanedRolledFiles() throws IOException {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(outputPath, "*" + ROLLED_EXT)) {
@@ -177,7 +169,6 @@ public class JournaledCoalescer implements IJournaler, ICoalescer {
      * SeekableByteChannel. This method will block if objects from the pool have been exhausted.
      *
      * @return a KeyedOutput
-     * @throws IOException
      */
     public final KeyedOutput getOutput() throws IOException {
         lock.lock();
@@ -284,7 +275,6 @@ public class JournaledCoalescer implements IJournaler, ICoalescer {
      *
      * @param journal The journal to combine in the output stream
      * @param rolledOutput The OutputStream object to use
-     * @throws IOException
      */
     protected void combineFiles(Journal journal, SeekableByteChannel rolledOutput) throws IOException {
         long startPos = rolledOutput.position();

--- a/src/main/java/emissary/output/roller/journal/Journal.java
+++ b/src/main/java/emissary/output/roller/journal/Journal.java
@@ -5,9 +5,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Tracks written progress of a corresponding file. Some formats within the framework don't lend themselves to knowing
  * length of output prior to writing as in many journaled formats. Our model allows us to track successful or complete
@@ -18,7 +15,6 @@ import org.slf4j.LoggerFactory;
  */
 public final class Journal {
 
-    private static final Logger logger = LoggerFactory.getLogger(Journal.class);
     static final byte SEP = 0x00;
     // 6 byte magic
     static final byte[] MAGIC = "BGJRNL".getBytes();

--- a/src/main/java/emissary/output/roller/journal/JournalReader.java
+++ b/src/main/java/emissary/output/roller/journal/JournalReader.java
@@ -193,9 +193,6 @@ public class JournalReader implements Closeable {
 
     /**
      * Prints contents of a Journal to stdout.
-     * 
-     * @param args
-     * @throws Exception
      */
     public static void main(String[] args) throws Exception {
         String path = args[0];

--- a/src/main/java/emissary/output/roller/journal/JournalWriter.java
+++ b/src/main/java/emissary/output/roller/journal/JournalWriter.java
@@ -64,9 +64,7 @@ public class JournalWriter implements Closeable {
 
     /**
      * 
-     * @param e
      * @return position difference between last entry and current
-     * @throws IOException
      */
     public long write(JournalEntry e) throws IOException {
         lock.lock();
@@ -125,8 +123,6 @@ public class JournalWriter implements Closeable {
 
     /**
      * Closes underlying journal channel.
-     * 
-     * @throws IOException
      */
     @Override
     public void close() throws IOException {

--- a/src/main/java/emissary/output/roller/journal/JournaledChannelPool.java
+++ b/src/main/java/emissary/output/roller/journal/JournaledChannelPool.java
@@ -86,7 +86,6 @@ public class JournaledChannelPool implements AutoCloseable {
      * Flushes underlying channel and writes journal entry, updating current position.
      * 
      * @param jc the JournaledChannel to flush
-     * @throws IOException If there is some I/O problem.
      */
     void free(final JournaledChannel jc) {
         if (jc == null) {

--- a/src/main/java/emissary/parser/PositionRecord.java
+++ b/src/main/java/emissary/parser/PositionRecord.java
@@ -10,9 +10,6 @@ public class PositionRecord {
 
     /**
      * position and length of something important in a data structure
-     * 
-     * @param position
-     * @param length
      */
     public PositionRecord(long position, long length) {
         this.position = position;

--- a/src/main/java/emissary/parser/SimpleNioParser.java
+++ b/src/main/java/emissary/parser/SimpleNioParser.java
@@ -23,9 +23,6 @@ public class SimpleNioParser extends NIOSessionParser {
 
     /**
      * Create a session parser on the data
-     * 
-     * @param channel
-     * @throws emissary.parser.ParserException
      */
     public SimpleNioParser(SeekableByteChannel channel) throws ParserException {
         super(channel);
@@ -37,7 +34,6 @@ public class SimpleNioParser extends NIOSessionParser {
      *
      * @param session The session to be decomposed into separate elements.
      * @return A map of session elements
-     * @throws emissary.parser.ParserException
      */
     protected DecomposedSession decomposeSession(InputSession session) throws ParserException {
         try {
@@ -78,7 +74,6 @@ public class SimpleNioParser extends NIOSessionParser {
      *
      * @param raw map of PositionRecord objects
      * @return map of metadata
-     * @throws java.io.IOException
      */
     protected Map<String, String> cookMetaRecords(Map<String, Object> raw) throws IOException {
 
@@ -126,8 +121,6 @@ public class SimpleNioParser extends NIOSessionParser {
      * session
      * 
      * @return next session
-     * @throws emissary.parser.ParserException
-     * @throws emissary.parser.ParserEOFException
      */
     @Override
     public DecomposedSession getNextSession() throws ParserException, ParserEOFException {

--- a/src/main/java/emissary/pickup/PickUpPlace.java
+++ b/src/main/java/emissary/pickup/PickUpPlace.java
@@ -251,7 +251,6 @@ public abstract class PickUpPlace extends emissary.place.ServiceProviderPlace im
      * @param f file to process
      * @return true if it worked
      * @throws IOException If there is some I/O problem.
-     * @throws emissary.core.EmissaryException
      */
     public boolean processDataFile(File f) throws IOException, EmissaryException {
         boolean isOversize = false;
@@ -273,7 +272,6 @@ public abstract class PickUpPlace extends emissary.place.ServiceProviderPlace im
      * @param fixedName name to use for the object
      * @param simpleMode simple flag from the input
      * @return true
-     * @throws emissary.core.EmissaryException
      */
     protected boolean handleOversizePayload(File theFile, String fixedName, boolean simpleMode) throws EmissaryException {
         // Send it away, blocks until an agent is ready
@@ -294,7 +292,6 @@ public abstract class PickUpPlace extends emissary.place.ServiceProviderPlace im
      * @param theFile the file that contains the data
      * @param fixedName name to use for the dataObject
      * @return true if the file is processed successfully
-     * @throws emissary.core.EmissaryException
      */
     protected boolean handleSimplePayload(File theFile, String fixedName) throws EmissaryException {
         byte[] theContent = Executrix.readDataFromFile(theFile.getAbsolutePath());
@@ -468,7 +465,6 @@ public abstract class PickUpPlace extends emissary.place.ServiceProviderPlace im
      * @param outputRoot the done area
      * @return true if it worked
      * @throws IOException If there is some I/O problem.
-     * @throws emissary.core.EmissaryException
      */
     public boolean processDataFile(File theFile, String fixedName, boolean isOversize, boolean simpleMode, String outputRoot) throws IOException,
             EmissaryException {
@@ -516,7 +512,6 @@ public abstract class PickUpPlace extends emissary.place.ServiceProviderPlace im
      * @param theFile where it came from
      * @param simpleMode simple flag from the input
      * @return true if it works
-     * @throws emissary.core.EmissaryException
      */
     protected boolean processDataObject(byte[] theContent, String fixedName, File theFile, boolean simpleMode) throws EmissaryException {
         IBaseDataObject d = DataObjectFactory.getInstance(new Object[] {theContent, fixedName});
@@ -531,7 +526,6 @@ public abstract class PickUpPlace extends emissary.place.ServiceProviderPlace im
      * @param theFile where it came from
      * @param simpleMode simple flag from the input
      * @return true if it works
-     * @throws emissary.core.EmissaryException
      */
     protected boolean processDataObject(IBaseDataObject d, String fixedName, File theFile, boolean simpleMode) throws EmissaryException {
         String currentForm = d.popCurrentForm();
@@ -559,7 +553,6 @@ public abstract class PickUpPlace extends emissary.place.ServiceProviderPlace im
      * @param fixedName the good short name of the file
      * @return count of sessions parsed
      * @throws IOException If there is some I/O problem.
-     * @throws emissary.parser.ParserException
      */
     public int processSessions(File theFile, String fixedName) throws IOException, ParserException {
         // We are going to prefer a RAF parser if one
@@ -665,7 +658,6 @@ public abstract class PickUpPlace extends emissary.place.ServiceProviderPlace im
     /**
      * Produce a legal tracking filename from the disk filename
      * 
-     * @param v
      * @return fixed filename
      */
     protected String fixFileName(String v) {

--- a/src/main/java/emissary/roll/RollScheduledExecutor.java
+++ b/src/main/java/emissary/roll/RollScheduledExecutor.java
@@ -55,8 +55,6 @@ public class RollScheduledExecutor extends ScheduledThreadPoolExecutor {
 
     /**
      * Wrapper for the Future to give us a handle to our Rollable object.
-     * 
-     * @param <V>
      */
     static class RollFuture<V> implements RunnableScheduledFuture<V> {
         private final RunnableScheduledFuture<V> rsf;

--- a/src/main/java/emissary/roll/RollUtil.java
+++ b/src/main/java/emissary/roll/RollUtil.java
@@ -13,7 +13,6 @@ public class RollUtil {
     /**
      * returns the time period from the current Configurator using the value from ROLLABLE_TIME_PERIOD. Defaults to 10L
      * 
-     * @param configG
      * @return the configured rollable time period
      */
     public static long getPeriod(Configurator configG) {
@@ -24,7 +23,6 @@ public class RollUtil {
      * Returns the TimeUnit by extracting the value from ROLLABLE_TIME_PERIOD. The time unit value must be one that exactly
      * matches those defined in the TimeUnit enum. Defaults to MINUTES.
      * 
-     * @param configG
      * @return the configured rollable TimeUnit
      */
     public static TimeUnit getTimeUnit(Configurator configG) {

--- a/src/main/java/emissary/scripting/RubyConsole.java
+++ b/src/main/java/emissary/scripting/RubyConsole.java
@@ -403,8 +403,6 @@ public class RubyConsole implements HttpSessionBindingListener, Runnable {
 
     /**
      * Simulate some type of context when running from a static main
-     * 
-     * @throws EmissaryException
      */
     public static void createEmissaryContext() throws EmissaryException {
         // Do some of the things that the normal context initializer does

--- a/src/main/java/emissary/server/EmissaryServer.java
+++ b/src/main/java/emissary/server/EmissaryServer.java
@@ -602,7 +602,8 @@ public class EmissaryServer {
         String trustStorePass = httpConnFactCfg.findStringEntry("javax.net.ssl.trustStorePassword", keystorePass);
         System.setProperty("javax.net.ssl.trustStorePassword", trustStorePass);
         // setup context to add to connector
-        SslContextFactory sslContextFactory = new SslContextFactory(keystore);
+        SslContextFactory sslContextFactory = new SslContextFactory.Server();
+        sslContextFactory.setKeyStorePath(keystore);
         sslContextFactory.setKeyStorePassword(keystorePass);
         KeyStore trustStoreInstance = KeyStore.getInstance("JKS");
         try (final InputStream is = new FileInputStream(trustStore)) {

--- a/src/main/java/emissary/test/core/UnitTest.java
+++ b/src/main/java/emissary/test/core/UnitTest.java
@@ -210,7 +210,6 @@ public class UnitTest {
      *
      * @param configPath The path to use for config.dir, or null if the value should not be changed.
      * @param pkg use this.pkg for config.pkg
-     * @throws EmissaryException
      */
     protected void setConfig(final String configPath, boolean pkg) throws EmissaryException {
         // TODO: refactor this. Changing the pkg affected toResourceName, which could have the
@@ -229,8 +228,6 @@ public class UnitTest {
 
     /**
      * Restore config dir and pkg to original values
-     * 
-     * @throws EmissaryException
      */
     protected void restoreConfig() throws EmissaryException {
         // Restore config paths

--- a/src/main/java/emissary/util/CharacterCounterSet.java
+++ b/src/main/java/emissary/util/CharacterCounterSet.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
  * A set of named counters for keeping counts on various classes of characters encountered
  */
 public class CharacterCounterSet extends CounterSet {
+    private static final long serialVersionUID = -7111758159975960091L;
     public static final String[] CHARACTER_TYPE_KEYS = {"CHARACTER_LETTER", "CHARACTER_DIGIT", "CHARACTER_WHITESPACE", "CHARACTER_ISO_CONTROL",
             "CHARACTER_PUNCTUATION", "CHARACTER_OTHER"};
 

--- a/src/main/java/emissary/util/ClassLookupCache.java
+++ b/src/main/java/emissary/util/ClassLookupCache.java
@@ -28,7 +28,7 @@ public final class ClassLookupCache {
         /** The class name. */
         private final String className;
 
-        /** A class object that matches {@link #name}. */
+        /** A class object that matches {@link #className}. */
         private final Class<T> clazz;
 
         /**

--- a/src/main/java/emissary/util/CounterSet.java
+++ b/src/main/java/emissary/util/CounterSet.java
@@ -9,6 +9,7 @@ import java.util.Set;
  * A set of named counters that can be easily incremented
  */
 public class CounterSet extends HashMap<String, Integer> {
+    private static final long serialVersionUID = 3741872528399600810L;
     // Controls whether unknown keys will be counted, no if false
     protected boolean flexentry = false;
 

--- a/src/main/java/emissary/util/MagicNumberUtil.java
+++ b/src/main/java/emissary/util/MagicNumberUtil.java
@@ -242,7 +242,6 @@ public final class MagicNumberUtil {
             throw new IOException("Security Exception reading file: " + se.getMessage());
         }
 
-        final MagicNumberUtil util = new MagicNumberUtil();
         final List<MagicNumber> magicNumberList =
                 MagicNumberFactory.buildMagicNumberList(Executrix.readDataFromFile(magicConfig.getAbsolutePath()), null, null);
 
@@ -349,7 +348,6 @@ public final class MagicNumberUtil {
         sb.append("\nPARTIALLY SUCCESSFUL ENTRIES (failed on some extensions)\n\n");
 
         for (final String entry : continuationErrorMap.keySet()) {
-            final List<String> ext = continuationErrorMap.get(entry);
             sb.append('\n');
             sb.append("MAIN ENTRY (STATUS:SUCCESSFUL): ");
             sb.append(entry);

--- a/src/main/java/emissary/util/magic/ByteArrayPrecisionException.java
+++ b/src/main/java/emissary/util/magic/ByteArrayPrecisionException.java
@@ -5,6 +5,8 @@ package emissary.util.magic;
  */
 
 public class ByteArrayPrecisionException extends NumberFormatException {
+    private static final long serialVersionUID = -50977746714895277L;
+
     public ByteArrayPrecisionException(String msg) {
         super(msg);
     }

--- a/src/main/java/emissary/util/magic/MagicNumberFactory.java
+++ b/src/main/java/emissary/util/magic/MagicNumberFactory.java
@@ -164,20 +164,6 @@ public class MagicNumberFactory {
      *
      * @param entry the magic number String entry
      * @param storage a {@link List} where the MagicNumber instances will be placed
-     * @return the MagicNumber instance created
-     * @throws Exception if one occurs while parsing the entry
-     * @see #buildMagicNumber(java.lang.String)
-     */
-    private static MagicNumber parseAndStore(List<MagicNumber> storage, String entry) throws Exception {
-        return parseAndStore(storage, entry, false);
-    }
-
-    /**
-     * Private method for parsing entries and storing them into the target storage data structure which is a list.
-     *
-     *
-     * @param entry the magic number String entry
-     * @param storage a {@link List} where the MagicNumber instances will be placed
      * @param swallowParseException should we swallow Ignorable ParseException or bubble them up
      * @return the MagicNumber instance created
      * @throws Exception if one occurs while parsing the entry

--- a/src/main/java/emissary/util/magic/ParseException.java
+++ b/src/main/java/emissary/util/magic/ParseException.java
@@ -5,6 +5,8 @@ package emissary.util.magic;
  */
 
 public class ParseException extends Exception {
+    private static final long serialVersionUID = -58614520195826109L;
+
     public ParseException(String message) {
         super(message);
     }

--- a/src/main/java/emissary/util/roll/RollableFileOutputStream.java
+++ b/src/main/java/emissary/util/roll/RollableFileOutputStream.java
@@ -164,8 +164,6 @@ public class RollableFileOutputStream extends OutputStream implements Rollable {
     /**
      * Closes the underlying outputs and renames the current file to its final name. A new file is NOT opened. Further use
      * of the instance of this class is not guaranteed to function after calling this method.
-     * 
-     * @throws IOException
      */
     @Override
     public void close() throws IOException {
@@ -183,7 +181,6 @@ public class RollableFileOutputStream extends OutputStream implements Rollable {
      * Thread safe write of a byte
      * 
      * @param b byte to write
-     * @throws IOException
      */
     @Override
     public void write(int b) throws IOException {
@@ -203,7 +200,6 @@ public class RollableFileOutputStream extends OutputStream implements Rollable {
      * @param b the data
      * @param off the start offset of the data
      * @param len the number of bytes to write
-     * @throws IOException
      */
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
@@ -237,8 +233,6 @@ public class RollableFileOutputStream extends OutputStream implements Rollable {
     /**
      * Determines whether to delete zero byte files on a roll. If true, both bytes written and the size of the output file
      * are checked. If both are zero, and deleteZeroByteFiles is true, the file is deleted.
-     * 
-     * @param deleteZeroByteFiles
      */
     public void setDeleteZeroByteFiles(boolean deleteZeroByteFiles) {
         this.deleteZeroByteFiles = deleteZeroByteFiles;

--- a/src/test/java/emissary/command/HttpCommandIT.java
+++ b/src/test/java/emissary/command/HttpCommandIT.java
@@ -1,7 +1,5 @@
 package emissary.command;
 
-import static org.junit.Assert.*;
-
 import org.junit.Test;
 
 public class HttpCommandIT {

--- a/src/test/java/emissary/directory/DirectoryPlaceTest.java
+++ b/src/test/java/emissary/directory/DirectoryPlaceTest.java
@@ -40,13 +40,13 @@ public class DirectoryPlaceTest extends UnitTest {
         // master directory
         InputStream configStream = new ResourceReader().getConfigDataAsStream(this);
 
-        this.master = spy(new DirectoryPlace(configStream, null, this.masterloc));
+        this.master = spy(new DirectoryPlace(configStream, this.masterloc, new EmissaryNode()));
         configStream.close();
         Namespace.bind(this.masterloc, this.master);
 
         // non-master directory
         configStream = new ResourceReader().getConfigDataAsStream(this);
-        this.client = spy(new DirectoryPlace(configStream, this.master.getDirectoryEntry().getKey(), this.clientloc));
+        this.client = spy(new DirectoryPlace(configStream, this.master.getDirectoryEntry().getKey(), this.clientloc, new EmissaryNode()));
         configStream.close();
         Namespace.bind(this.clientloc, this.client);
     }

--- a/src/test/java/emissary/directory/RoutingAlgorithmTest.java
+++ b/src/test/java/emissary/directory/RoutingAlgorithmTest.java
@@ -349,7 +349,7 @@ public class RoutingAlgorithmTest extends UnitTest {
      */
     class MyDirectoryPlace extends DirectoryPlace {
         public MyDirectoryPlace(final String placeLoc) throws IOException {
-            super(new ResourceReader().getConfigDataAsStream(thisPackage + ".MyDirectoryPlace.cfg"), null, placeLoc);
+            super(new ResourceReader().getConfigDataAsStream(thisPackage + ".MyDirectoryPlace.cfg"), placeLoc, new EmissaryNode());
         }
 
         public void clearAllEntries() {

--- a/src/test/java/emissary/output/DropOffUtilTest.java
+++ b/src/test/java/emissary/output/DropOffUtilTest.java
@@ -432,19 +432,19 @@ public class DropOffUtilTest extends UnitTest {
         Date start = new Date(); // use this for relative comparison
 
         // hit on child EventDate
-        assertEquals("2015-02-13 23:13:03", TimeUtil.getDateAsISO8601(this.util.getEventDate(d, tld)));
+        assertEquals("2015-02-13 23:13:03", TimeUtil.getDateAsISO8601(this.util.getEventDate(d, tld).toInstant()));
 
         // removing child EventDate should hit on child FILE_DATE
         d.deleteParameter("EventDate");
-        assertEquals("2015-01-05 17:45:53", TimeUtil.getDateAsISO8601(this.util.getEventDate(d, tld)));
+        assertEquals("2015-01-05 17:45:53", TimeUtil.getDateAsISO8601(this.util.getEventDate(d, tld).toInstant()));
 
         // removing child FILE_DATE should hit on tld EventDate
         d.deleteParameter("FILE_DATE");
-        assertEquals("2016-02-13 23:13:03", TimeUtil.getDateAsISO8601(this.util.getEventDate(d, tld)));
+        assertEquals("2016-02-13 23:13:03", TimeUtil.getDateAsISO8601(this.util.getEventDate(d, tld).toInstant()));
 
         // removing tld EventDate should hit on tld FILE_DATE
         tld.deleteParameter("EventDate");
-        assertEquals("2016-01-05 17:45:53", TimeUtil.getDateAsISO8601(this.util.getEventDate(d, tld)));
+        assertEquals("2016-01-05 17:45:53", TimeUtil.getDateAsISO8601(this.util.getEventDate(d, tld).toInstant()));
 
         // removing tld FILE_DATE should default to now as configured by default
         tld.deleteParameter("FILE_DATE");

--- a/src/test/java/emissary/output/roller/journal/JournaledChannelPoolTest.java
+++ b/src/test/java/emissary/output/roller/journal/JournaledChannelPoolTest.java
@@ -65,9 +65,10 @@ public class JournaledChannelPoolTest extends UnitTest {
         }
         final ArrayList<JournalEntry> result = new ArrayList<>();
         for (final Path journalPath : JournalReader.getJournalPaths(this.directory)) {
-            final JournalReader jr = new JournalReader(journalPath);
-            Journal j = jr.getJournal();
-            result.addAll(j.getEntries());
+            try (final JournalReader jr = new JournalReader(journalPath)) {
+                Journal j = jr.getJournal();
+                result.addAll(j.getEntries());
+            }
         }
         assertTrue("Expected 4 Journal Entries " + result.size(), result.size() == 4);
         int jrnltot = 0;

--- a/src/test/java/emissary/server/EmissaryServerIT.java
+++ b/src/test/java/emissary/server/EmissaryServerIT.java
@@ -38,7 +38,6 @@ public class EmissaryServerIT extends UnitTest {
         try {
             server.startServer();
             EmissaryClient client = new EmissaryClient();
-            MapResponseEntity entity = new MapResponseEntity();
             String hostPort = cmd.getHost() + ":" + cmd.getPort(); // will be key in response
             String endpoint = cmd.getScheme() + "://" + hostPort + "/api/version";
             MapResponseEntity versionMap = client.send(new HttpGet(endpoint)).getContent(MapResponseEntity.class);

--- a/src/test/java/emissary/util/ClassLookupCacheTest.java
+++ b/src/test/java/emissary/util/ClassLookupCacheTest.java
@@ -17,7 +17,7 @@ public class ClassLookupCacheTest extends UnitTest {
     private static final String TEST_CLASS_NAME = TEST_CLASS_OBJECT.getName();
 
     /**
-     * Call {@link ClassLookupCache#lookup(className)} and ensure that it returns the given class.
+     * Call {@link ClassLookupCache#lookup(String)} and ensure that it returns the given class.
      *
      * @param className The class name to look up.
      * @param expectedClazz The expected class object.

--- a/src/test/java/emissary/util/TimeUtilTest.java
+++ b/src/test/java/emissary/util/TimeUtilTest.java
@@ -51,16 +51,19 @@ public class TimeUtilTest extends UnitTest {
         TimeUtil.getDate("yyyy", "BAD");
     }
 
+    @Deprecated
     @Test
     public void testGetDateAsPath() {
         assertEquals("GetDateAsPath", "2016-12-25/15/30", TimeUtil.getDateAsPath(testUtilDate));
     }
 
+    @Deprecated
     @Test
     public void testGetDateOrdinal() {
         assertEquals("GetDateOrdinal", "2016360", TimeUtil.getDateOrdinal(testUtilDate));
     }
 
+    @Deprecated
     @Test
     public void testGetDateAsISO8601() {
         assertEquals("GetDateAsISO8601", "2016-12-25 15:30:25", TimeUtil.getDateAsISO8601(testUtilDate));
@@ -71,21 +74,25 @@ public class TimeUtilTest extends UnitTest {
         assertEquals("GetDateAsISO8601Long", "2016-12-25 15:30:25", TimeUtil.getDateAsISO8601(testUtilDate.getTime()));
     }
 
+    @Deprecated
     @Test
     public void testGetDateAsFullISO8601() {
         assertEquals("GetDateAsFullISO8601", "2016-12-25T15:30:25Z", TimeUtil.getDateAsFullISO8601(testUtilDate));
     }
 
+    @Deprecated
     @Test
     public void testGetDateFromISO8601() throws DateTimeParseException {
         assertEquals("GetDateFromISO8601", testUtilDate.getTime(), TimeUtil.getDateFromISO8601("2016-12-25 15:30:25").getTime());
     }
 
+    @Deprecated
     @Test(expected = java.time.format.DateTimeParseException.class)
     public void testGetDateFromISO8601Exception() throws DateTimeParseException {
         TimeUtil.getDateFromISO8601("Bad Date");
     }
 
+    @Deprecated
     @Test
     public void testGetZonedDateFromISO8601() {
         ZonedDateTime zdt = TimeUtil.getZonedDateFromISO8601("2016-12-25 15:30:25");
@@ -99,6 +106,7 @@ public class TimeUtilTest extends UnitTest {
         assertEquals("GMT", zdt.getZone().getId());
     }
 
+    @Deprecated
     @Test
     public void testDatePath() {
         assertTrue("Date with slashes must have slashes", TimeUtil.getDateAsPath(new Date()).indexOf("/") > -1);
@@ -109,6 +117,7 @@ public class TimeUtilTest extends UnitTest {
         assertTrue("Date with ordinal must be 7 long", TimeUtil.getCurrentDateOrdinal().length() == 7);
     }
 
+    @Deprecated
     @Test
     public void testISO8601RoundTrip() throws Exception {
         final String s = TimeUtil.getCurrentDateISO8601();


### PR DESCRIPTION
Javadoc warnings:

* Remove useless javadocs (those without descriptions)
* Fix param names for some misspelled javadoc params
* Correct misspelling of "failes" to "fails"
* Fix javadoc links to methods with correct signatures

Deprecation warnings (avoid use of deprecated methods):

* Create new DirectoryPlace constructor which accepts EmissaryNode
  instance, since no other constructor was suitable, and update callers
* Update SslContextFactory construction
* Use newer TimeUtil method which accepts Instant instead of Date
* Use newer method for 8601 date parsing
* Add `@Deprecated` annotation for tests of deprecated methods

Miscellaneous warnings:

* Remove unused imports
* Remove unnecessary warnings suppressions
* Remove unused private LOG members
* Override hashCode implementation in SpamSumSignature since equals is overridden
* Add explicit serialVersionUID (generated) to some Serializables
* Remove unused MagicNumberUtil local variables
* Close resource leaks in test code