### PR TITLE
Work in progress: update to Jackson 2.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <dep.httpclient.version>4.5.1</dep.httpclient.version>
     <dep.httpcore.version>4.4.3</dep.httpcore.version>
     <dep.jackcess.version>2.1.2</dep.jackcess.version>
-    <dep.jackson.version>2.8.11</dep.jackson.version>
+    <dep.jackson.version>2.9.9</dep.jackson.version>
     <!-- jersey brings in 1.2; tika-parsers brings in 1.3.2; converge on latest -->
     <dep.javax.annotation-api.version>1.3.2</dep.javax.annotation-api.version>
     <dep.jcommander.version>1.58</dep.jcommander.version>
@@ -103,7 +103,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${dep.jackson.version}.3</version>
+        <version>${dep.jackson.version}.1</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>

--- a/src/main/java/emissary/output/filter/JsonOutputFilter.java
+++ b/src/main/java/emissary/output/filter/JsonOutputFilter.java
@@ -104,7 +104,7 @@ public class JsonOutputFilter extends AbstractRollableFilter {
 
             String key = writer.getName();
             @SuppressWarnings("unchecked")
-            Collection<Object> values = (Collection<Object>) pojo;
+            Collection<Object> values = (Collection<Object>) ((Map<?, ?>) pojo).get(key);
 
             if (includeParameter(key)) {
                 Collection<Object> write = filter(key, values);


### PR DESCRIPTION
This is a work in progress.

Behavior changed upstream in Jackson 2.9's MapSerializer to pass entire
map object to the filter instead of the entry.getValue() for the
specific entry.getKey() being filtered. This means that the object
received by the filter is of an unexpected Map type instead of the
Collection (in the JsonOutputFilter, the value is a Collection, because
it's the set of values coming from a Multimap).

This change occurred to address FasterXML/jackson-databind#1655 and
occurred in commit a2c667b9b8482581e64bb8752963984efb1214b5
(https://github.com/FasterXML/jackson-databind/commit/a2c667b9b8482581e64bb8752963984efb1214b5)

Another change seems to have affected the filtered output. The output
that is emitted is not the filtered output, but the unfiltered output,
as if the filter is running, but its output does not affect
serialization.

This is a very strange and buggy result.

Earlier versions of Jackson databind are affected by numerous CVEs, but
I'm not sure how to work around this (possibly broken) behavior change
in order to upgrade to 2.9.9

This commit demonstrates a partial workaround, fixing the type change...
but I have not yet figured out how to fix the second issue to have the
filter affect the serialized output properly, and this is demonstrated
by a test case which continues to fail.