### PR TITLE
EM-4270: Resource time limit improvements

### DIFF
--- a/src/main/java/emissary/core/HDMobileAgent.java
+++ b/src/main/java/emissary/core/HDMobileAgent.java
@@ -413,7 +413,7 @@ public class HDMobileAgent extends MobileAgent {
         logger.debug("In atPlaceHD {} with {} payload items", place, payloadListArg.size());
 
         List<IBaseDataObject> ret = Collections.emptyList();
-        try (TimedResource tr = resourceWatcherStart(place)) {
+        try (TimedResource tr = resourceWatcherStart(place, payloadListArg.size())) {
             // Process and get back a list of sprouted payloads
             lastPlaceProcessed = place.getDirectoryEntry().getKey();
 

--- a/src/main/java/emissary/core/MobileAgent.java
+++ b/src/main/java/emissary/core/MobileAgent.java
@@ -386,7 +386,7 @@ public abstract class MobileAgent implements Serializable, IMobileAgent, MobileA
     protected void atPlace(final IServiceProviderPlace place, final IBaseDataObject payloadArg) {
         logger.debug("In atPlace {} with {}", place, payloadArg.shortName());
 
-        try (TimedResource timer = resourceWatcherStart(place)) {
+        try (TimedResource timer = resourceWatcherStart(place, 1)) {
             this.lastPlaceProcessed = place.getDirectoryEntry().getKey();
             if (this.moveErrorsOccurred > 0) {
                 payloadArg.setParameter("AGENT_MOVE_ERRORS", Integer.toString(this.moveErrorsOccurred));
@@ -426,12 +426,12 @@ public abstract class MobileAgent implements Serializable, IMobileAgent, MobileA
         }
     }
 
-    protected TimedResource resourceWatcherStart(final IServiceProviderPlace place) {
+    protected TimedResource resourceWatcherStart(final IServiceProviderPlace place, int payloadCount) {
         TimedResource tr = TimedResource.EMPTY;
         // CoordinationPlaces are tracked individually
         if (!(place instanceof CoordinationPlace)) {
             try {
-                tr = ResourceWatcher.lookup().starting(this, place);
+                tr = ResourceWatcher.lookup().starting(this, place, payloadCount);
             } catch (EmissaryException ex) {
                 logger.debug("No resource monitoring enabled");
             }
@@ -474,7 +474,7 @@ public abstract class MobileAgent implements Serializable, IMobileAgent, MobileA
 
         // Stop looping from occuring
         if (payloadArg.transformHistory().size() > this.MAX_ITINERARY_STEPS &&
-                payloadArg.currentForm() != ERROR_FORM) {
+                !payloadArg.currentForm().equals(ERROR_FORM)) {
             payloadArg.replaceCurrentForm(ERROR_FORM);
             payloadArg.addProcessingError("Agent stopped due to larger than max transform history size (looping?)");
         }

--- a/src/main/java/emissary/core/ResourceWatcher.java
+++ b/src/main/java/emissary/core/ResourceWatcher.java
@@ -78,13 +78,13 @@ public class ResourceWatcher implements Runnable {
 
     /**
      * Register an agent to start tracking it
-     * 
+     *
      * @param agent the agent to track
      * @param place place executing
      * @return TimedResource for the place and agent
      */
-    public TimedResource starting(final IMobileAgent agent, final IServiceProviderPlace place) {
-        TimedResource tr = new TimedResource(agent, place, getPlaceDuration(place), metrics.timer(place.getPlaceName()));
+    public TimedResource starting(final IMobileAgent agent, final IServiceProviderPlace place, int payloadCount) {
+        TimedResource tr = new TimedResource(agent, place, getPlaceDuration(place), metrics.timer(place.getPlaceName()), payloadCount);
         tracking.offer(tr);
         return tr;
     }
@@ -143,6 +143,7 @@ public class ResourceWatcher implements Runnable {
                 final long now = System.currentTimeMillis();
                 final TimedResource val = it.next();
                 if (val.checkState(now)) {
+                    LOG.debug("Removing {} TimedResource {}", val.getPlaceName(), val.toString());
                     it.remove();
                 }
             }

--- a/src/main/java/emissary/core/TimedResource.java
+++ b/src/main/java/emissary/core/TimedResource.java
@@ -38,14 +38,19 @@ public class TimedResource implements AutoCloseable {
         timerContext = null;
     }
 
-    public TimedResource(final IMobileAgent agent, final IServiceProviderPlace place, final long allowedDuration, final Timer timer) {
+    public TimedResource(final IMobileAgent agent, final IServiceProviderPlace place, final long allowedDuration, final Timer timer,
+            int payloadCount) {
         this.started = System.currentTimeMillis();
         this.agent = agent;
-        this.payloadCount = agent.payloadCount();
+        this.payloadCount = payloadCount;
         this.placeName = place.getPlaceName();
         this.timerContext = timer.time();
         this.allowedDuration = allowedDuration;
 
+    }
+
+    public String getPlaceName() {
+        return this.placeName;
     }
 
     // checks the state of the current place, returns true if it's closed
@@ -65,7 +70,7 @@ public class TimedResource implements AutoCloseable {
         lock.lock();
         try {
             if (!isClosed) {
-                LOG.debug("Found agent that needs interrupting {} in place {}", agent.getName(), placeName);
+                LOG.debug("Found agent that needs interrupting {} in place {} - {}", agent.getName(), placeName, this.toString());
                 agent.interrupt();
             }
         } catch (Exception e) {

--- a/src/main/java/emissary/place/CoordinationPlace.java
+++ b/src/main/java/emissary/place/CoordinationPlace.java
@@ -184,7 +184,7 @@ public class CoordinationPlace extends ServiceProviderPlace {
             List<IBaseDataObject> sprouts = null;
 
             // Like an agent would do it
-            try (TimedResource tr = ResourceWatcher.lookup().starting(getAgent(), p)) {
+            try (TimedResource tr = ResourceWatcher.lookup().starting(getAgent(), p, 1)) {
                 if (hd) {
                     // Do the normal HD processing
                     sprouts = p.agentProcessHeavyDuty(d);

--- a/src/test/java/emissary/core/ResourceWatcherTest.java
+++ b/src/test/java/emissary/core/ResourceWatcherTest.java
@@ -91,7 +91,7 @@ public class ResourceWatcherTest extends UnitTest {
         public void run() {
             try {
                 for (int i = 0; i < this.times; i++) {
-                    try (TimedResource tr = ResourceWatcherTest.this.resourceWatcher.starting(this, ResourceWatcherTest.this.place)) {
+                    try (TimedResource tr = ResourceWatcherTest.this.resourceWatcher.starting(this, ResourceWatcherTest.this.place, 1)) {
                         Thread.sleep(rand.nextInt(100));
                     } catch (InterruptedException ex) {
                         // empty catch block

--- a/src/test/java/emissary/core/TimedResourceTest.java
+++ b/src/test/java/emissary/core/TimedResourceTest.java
@@ -33,7 +33,7 @@ public class TimedResourceTest extends UnitTest {
 
         TestMobileAgent tma = new TestMobileAgent();
 
-        try (TimedResource tr = new TimedResource(tma, tp, -2, new Timer())) {
+        try (TimedResource tr = new TimedResource(tma, tp, -2, new Timer(), 1)) {
             // should never time out
             assertFalse(tr.checkState(System.currentTimeMillis()));
             // still running
@@ -47,7 +47,7 @@ public class TimedResourceTest extends UnitTest {
     public void test() throws Exception {
         TestMobileAgent tma = new TestMobileAgent();
         // timeout almost immediately
-        try (TimedResource tr = new TimedResource(tma, tp, 1, new Timer())) {
+        try (TimedResource tr = new TimedResource(tma, tp, 1, new Timer(), 1)) {
             Thread.sleep(100);
             // still running, but should be interrupted by this
             assertFalse(tr.checkState(System.currentTimeMillis()));
@@ -60,10 +60,10 @@ public class TimedResourceTest extends UnitTest {
     public void testDontInterruptAgent() throws Exception {
         TestMobileAgent tma = new TestMobileAgent();
         // little time
-        TimedResource first = new TimedResource(tma, tp, 1, new Timer());
+        TimedResource first = new TimedResource(tma, tp, 1, new Timer(), 1);
         first.close();
         // long time
-        TimedResource second = new TimedResource(tma, tp, 1000000, new Timer());
+        TimedResource second = new TimedResource(tma, tp, 1000000, new Timer(), 1);
         // simulate finished processing within place
         // should indicate complete
         assertTrue(first.checkState(System.currentTimeMillis()));


### PR DESCRIPTION
- Updated the TimedResource constructor to include the payloadCount as an argument rather than getting it from the agent.
- Updated  the HDMobileAgent to get a TimedResource that uses the number of payloads to set its time limit duration.
- Updated the ServiceProviderPlace to check whether the Thread has been interrupted after processing each payload and stop processing any remaining payloads upon reaching its time limit.