### PR TITLE
EM-4461: Fix directory name collisions

### DIFF
--- a/src/main/java/emissary/util/io/FileManipulator.java
+++ b/src/main/java/emissary/util/io/FileManipulator.java
@@ -6,6 +6,7 @@ package emissary.util.io;
 
 import java.io.File;
 import java.io.Serializable;
+import java.security.SecureRandom;
 
 /**
  * A class of utility methods for manipulating files.
@@ -21,10 +22,14 @@ public class FileManipulator implements Serializable {
      */
     private static String FS = System.getProperty("file.separator", "/");
 
+    // Use ThreadLocal to allocate a SecureRandom instance per thread instead
+    // of Math.random() which uses the same instance of Random for all threads
+    // that causes resource contention and is not as secure.
+    private static final ThreadLocal<SecureRandom> secureRandomThreadLocal = ThreadLocal.withInitial(() -> new SecureRandom());
+
     public static String mkTempFile(final String dirPath, final String file) {
-        // Date now = new Date(System.currentTimeMillis());
-        String theFullPath = "";
-        String tempName = file + (int) (Math.rint(Math.random() * 10000));
+        String theFullPath;
+        String tempName = file + (secureRandomThreadLocal.get().nextLong() & Long.MAX_VALUE);
         if (dirPath.endsWith(FS) || dirPath.endsWith("/")) {
             theFullPath = dirPath + tempName;
         } else {
@@ -34,8 +39,7 @@ public class FileManipulator implements Serializable {
         // Check to make sure file does not already exist
         File theTempFile = new File(theFullPath);
         if (theTempFile.exists()) {
-            tempName = "temp" + (int) (Math.rint(Math.random() * 10000));
-
+            tempName = "temp" + (secureRandomThreadLocal.get().nextLong() & Long.MAX_VALUE);
             if (dirPath.endsWith("/")) {
                 theFullPath = dirPath + tempName;
             } else {

--- a/src/main/java/emissary/util/shell/Executrix.java
+++ b/src/main/java/emissary/util/shell/Executrix.java
@@ -129,7 +129,7 @@ public class Executrix {
     public String[] makeTempFilenames() {
         final String[] names = new String[7];
         final String dir = FileManipulator.mkTempFile(this.tmpDir, this.placeName);
-        final String base = Long.toString(System.currentTimeMillis());
+        final String base = Long.toString(System.nanoTime());
         names[DIR] = dir;
         names[BASE] = base;
         names[BASE_PATH] = dir + File.separator + base;

--- a/src/test/java/emissary/util/shell/ExecutrixTest.java
+++ b/src/test/java/emissary/util/shell/ExecutrixTest.java
@@ -15,8 +15,12 @@ import java.io.File;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
 
 import emissary.test.core.UnitTest;
 import org.junit.After;
@@ -78,6 +82,26 @@ public class ExecutrixTest extends UnitTest {
         assertNotNull("names array has null OUTPATH", names[Executrix.OUTPATH]);
         assertTrue("names must use out file ending", names[Executrix.OUT].endsWith(".out"));
         assertTrue("names must use in file ending", names[Executrix.IN].endsWith(".in"));
+    }
+
+    @Test
+    public void testExecutrixUniqueBase() {
+        this.e.setInFileEnding(".in");
+        this.e.setOutFileEnding(".out");
+        this.e.setOrder("NORMAL");
+
+        final int COUNT = 1000;
+        final Set<String> basePathSet = Collections.synchronizedSet(new HashSet<>(COUNT));
+
+        // Generate COUNT sets of names
+        IntStream.range(0, COUNT).parallel().forEach(number -> {
+            final String[] name = this.e.makeTempFilenames();
+            assertNotNull("name null DIR", name[Executrix.DIR]);
+            assertNotNull("name null BASE", name[Executrix.BASE]);
+            assertNotNull("name null BASE_PATH", name[Executrix.BASE_PATH]);
+            basePathSet.add(name[Executrix.BASE_PATH]);
+        });
+        assertEquals("Some BASE_PATH entries mismatch", COUNT, basePathSet.size());
     }
 
     @Test


### PR DESCRIPTION
Replace use of System.currentTimeMillis() with System.nanoTime() to generate part of temporary directory names to avoid name collisions when these are generated by from different threads at about the same time.