### PR TITLE
Resource Watcher Fix

### DIFF
--- a/src/main/java/emissary/core/MetricsFormatter.java
+++ b/src/main/java/emissary/core/MetricsFormatter.java
@@ -48,7 +48,7 @@ public class MetricsFormatter {
     public String formatTimer(final String name, final Timer timer) {
         final Snapshot snapshot = timer.getSnapshot();
         return String.format("STAT: %s => min=%2.2f,  max=%2.2f, avg=%2.2f, events=%d", name, convertDuration(snapshot.getMin()),
-                convertDuration(snapshot.getMax()), convertDuration(snapshot.getMedian()), timer.getCount());
+                convertDuration(snapshot.getMax()), convertDuration(snapshot.getMean()), timer.getCount());
     }
 
     protected double convertDuration(final double duration) {

--- a/src/test/java/emissary/core/ResourceWatcherTest.java
+++ b/src/test/java/emissary/core/ResourceWatcherTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 
+import com.codahale.metrics.Timer;
 import emissary.directory.DirectoryEntry;
 import emissary.place.IServiceProviderPlace;
 import emissary.place.sample.DevNullPlace;
@@ -65,7 +66,10 @@ public class ResourceWatcherTest extends UnitTest {
         assertEquals("Events must not be lost", (long) (threadCount * iterations), s.getCount());
 
         this.resourceWatcher.resetStats();
-        assertEquals("Stats must be cleared", 0, this.resourceWatcher.getStats().size());
+        assertTrue("Namespaces were not preserved", resourceWatcher.getStats().size() > 0);
+        for (Timer timer : this.resourceWatcher.getStats().values()) {
+            assertEquals("Stats must be cleared", 0, timer.getCount());
+        }
 
         this.resourceWatcher.quit();
     }


### PR DESCRIPTION
Currently the reset deletes the namespace and any active timers will not report once they complete. The new system deletes saved values while preserving the namespace.