### PR TITLE
Improve performance of emissary.output.DropOffUtil.processMetadata() by eliminating String.split()

### DIFF
--- a/src/main/java/emissary/output/DropOffUtil.java
+++ b/src/main/java/emissary/output/DropOffUtil.java
@@ -1014,7 +1014,7 @@ public class DropOffUtil {
         }
 
         for (final IBaseDataObject p : payloadList) {
-            final int level = p.shortName().split(emissary.core.Family.SEP).length;
+            final int level = StringUtils.countMatches(p.shortName(), emissary.core.Family.SEP) + 1;
             // save specified metadata items for children to grab
             parentTypes.put("" + level, p.getFileType());
 
@@ -1086,8 +1086,7 @@ public class DropOffUtil {
                 final List<IBaseDataObject> childObjList = p.getExtractedRecords();
                 Collections.sort(childObjList, new emissary.util.ShortNameComparator());
                 for (final IBaseDataObject child : childObjList) {
-                    final int level2 = child.shortName().split("-att-").length;
-                    final int parentLevel = level2 - 1;
+                    final int parentLevel = StringUtils.countMatches(child.shortName(), emissary.core.Family.SEP);
                     final String parentFileType = parentTypes.get("" + parentLevel);
                     if (parentFileType != null) {
                         child.setParameter("PARENT_FILETYPE", parentFileType);


### PR DESCRIPTION
This method is called for each BaseDataObject and String.split() is a very expensive call in terms of objects created. The new code does the same job without creating any objects.