### PR TITLE
Improve performance of emissary.output.DropOffUtil.processMetadata() by improving getCookedParameters.

### DIFF
--- a/src/main/java/emissary/output/DropOffUtil.java
+++ b/src/main/java/emissary/output/DropOffUtil.java
@@ -679,6 +679,7 @@ public class DropOffUtil {
      * @param metaData map of payload metadata
      * @return the file type (also added to metaData if not present)
      */
+    @Deprecated
     public String getFileType(final Map<String, String> metaData) {
         return getFileType(metaData, null);
     }
@@ -690,6 +691,7 @@ public class DropOffUtil {
      * @param formsArg space separated string of current forms
      * @return the file type (also added to metaData if not present)
      */
+    @Deprecated
     public String getFileType(final Map<String, String> metaData, final String formsArg) {
         String forms = formsArg;
         if (forms == null) {
@@ -736,7 +738,76 @@ public class DropOffUtil {
     }
 
     /**
-     * Parameters that are used to determine filetype in {@link #getFileType(Map, String)}
+     * Get the file type from the metadata or the form string passed in
+     *
+     * @param bdo IBaseDataObject
+     * @return the file type
+     */
+    public static String getFileType(final IBaseDataObject bdo) {
+        return getAndPutFileType(bdo, null, null);
+    }
+
+    /**
+     * Get the file type from the IBaseDataObject or the form string passed in
+     *
+     * @param bdo IBaseDataObject
+     * @param metaData Optional map of metadata that might be modified.
+     * @param formsArg Optional space separated string of current forms
+     * @return the file type
+     */
+    public static String getAndPutFileType(final IBaseDataObject bdo, final Map<String, String> metaData, final String formsArg) {
+        String forms = formsArg;
+        if (forms == null) {
+            forms = bdo.getStringParameter(FileTypeCheckParameter.POPPED_FORMS.getFieldName());
+            if (forms == null) {
+                forms = "";
+            }
+        }
+
+        String fileType;
+        if (bdo.hasParameter(FileTypeCheckParameter.FILETYPE.getFieldName())) {
+            fileType = bdo.getStringParameter(FileTypeCheckParameter.FILETYPE.getFieldName());
+        } else if (bdo.hasParameter(FileTypeCheckParameter.FINAL_ID.getFieldName())) {
+            fileType = bdo.getStringParameter(FileTypeCheckParameter.FINAL_ID.getFieldName());
+            logger.debug("FINAL_ID FileType is ({})", fileType);
+            if (metaData != null) {
+                metaData.put(FileTypeCheckParameter.FILETYPE.getFieldName(), fileType);
+            }
+        } else {
+            if (forms.contains(" ")) {
+                fileType = forms.substring(0, forms.indexOf(" ")).trim();
+                if (metaData != null) {
+                    metaData.put(FileTypeCheckParameter.COMPLETE_FILETYPE.getFieldName(), forms);
+                }
+            } else {
+                fileType = forms;
+            }
+            if (StringUtils.isEmpty(fileType)) {
+                if (bdo.hasParameter(FileTypeCheckParameter.FONT_ENCODING.getFieldName())) {
+                    fileType = "TEXT";
+                } else {
+                    fileType = "UNKNOWN";
+                }
+            }
+
+            if (metaData != null) {
+                metaData.put(FileTypeCheckParameter.FILETYPE.getFieldName(), fileType);
+            }
+        }
+
+        if ("UNKNOWN".equals(fileType) && forms.contains("MSWORD")) {
+            fileType = "MSWORD_FRAGMENT";
+        }
+
+        if ("QUOTED-PRINTABLE".equals(fileType) || fileType.startsWith("LANG-") || fileType.startsWith("ENCODING(")) {
+            fileType = "TEXT";
+        }
+
+        return fileType;
+    }
+
+    /**
+     * Parameters that are used to determine filetype in {@link #getAndPutFileType(IBaseDataObject, Map, String)}
      */
     public enum FileTypeCheckParameter {
         COMPLETE_FILETYPE("COMPLETE_FILETYPE"), FILETYPE("FILETYPE"), FINAL_ID("FINAL_ID"), FONT_ENCODING("FontEncoding"), POPPED_FORMS(
@@ -1021,7 +1092,7 @@ public class DropOffUtil {
                     }
                 }
                 if (!extended_filetypes.isEmpty()) {
-                    final StringBuilder extft = new StringBuilder(getFileType(p.getCookedParameters()));
+                    final StringBuilder extft = new StringBuilder(getFileType(p));
                     for (int j = 0; j < extended_filetypes.size(); j++) {
                         final String s = extended_filetypes.get(j);
                         extft.append("//").append(s);

--- a/src/main/java/emissary/output/filter/AbstractFilter.java
+++ b/src/main/java/emissary/output/filter/AbstractFilter.java
@@ -458,7 +458,7 @@ public abstract class AbstractFilter implements IDropOffFilter {
     protected Set<String> getTypesToCheckForNamedView(final IBaseDataObject d, final String viewName) {
         final Set<String> checkTypes = new HashSet<String>();
         final String lang = this.dropOffUtil.getLanguage(d);
-        final String fileType = this.dropOffUtil.getFileType(d.getCookedParameters());
+        final String fileType = DropOffUtil.getFileType(d);
         final String currentForm = d.currentForm();
 
         // skip over blacklisted alt views

--- a/src/main/java/emissary/output/filter/DataFilter.java
+++ b/src/main/java/emissary/output/filter/DataFilter.java
@@ -10,6 +10,7 @@ import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
 import emissary.core.IBaseDataObject;
 import emissary.output.DropOffPlace;
+import emissary.output.DropOffUtil;
 
 /**
  * Filter that writes unadorned data as raw bytes
@@ -49,7 +50,7 @@ public class DataFilter extends AbstractFilter {
 
         // Set up base location from configured spec
         final String baseFileName = dropOffUtil.getPathFromSpec(outputSpec, d, tld);
-        final String fileType = dropOffUtil.getFileType(d.getCookedParameters());
+        final String fileType = DropOffUtil.getFileType(d);
         final String currentForm = d.currentForm();
         getCharset(d, "UTF-8");
         final String lang = dropOffUtil.getLanguage(d);
@@ -91,7 +92,7 @@ public class DataFilter extends AbstractFilter {
         }
 
         // Set up base location from configured spec
-        final String fileType = dropOffUtil.getFileType(d.getCookedParameters());
+        final String fileType = DropOffUtil.getFileType(d);
         final String currentForm = d.currentForm();
         final String lang = dropOffUtil.getLanguage(d);
 

--- a/src/test/java/emissary/output/DropOffUtilTest.java
+++ b/src/test/java/emissary/output/DropOffUtilTest.java
@@ -20,6 +20,7 @@ import emissary.config.ServiceConfigGuide;
 import emissary.core.BaseDataObject;
 import emissary.core.DataObjectFactory;
 import emissary.core.IBaseDataObject;
+import emissary.output.DropOffUtil.FileTypeCheckParameter;
 import emissary.test.core.UnitTest;
 import emissary.util.TimeUtil;
 import org.junit.After;
@@ -471,51 +472,108 @@ public class DropOffUtilTest extends UnitTest {
     }
 
     @Test
-    public void testGetFileType() {
+    public void testDeprecatedGetFileType() {
         Map<String, String> metadata = new HashMap<>();
-        testFileType(metadata, "UNKNOWN", null);
+        testDeprecatedFileType(metadata, "UNKNOWN", null);
 
         String poppedForms = "myPoppedForms";
-        setupMetadata(metadata, poppedForms, DropOffUtil.FileTypeCheckParameter.POPPED_FORMS);
-        testFileType(metadata, poppedForms, null);
+        setupDeprecatedMetadata(metadata, poppedForms, DropOffUtil.FileTypeCheckParameter.POPPED_FORMS);
+        testDeprecatedFileType(metadata, poppedForms, null);
 
         String formsArg = "myFile";
-        setupMetadata(metadata, formsArg, DropOffUtil.FileTypeCheckParameter.FILETYPE);
-        testFileType(metadata, formsArg, formsArg);
+        setupDeprecatedMetadata(metadata, formsArg, DropOffUtil.FileTypeCheckParameter.FILETYPE);
+        testDeprecatedFileType(metadata, formsArg, formsArg);
 
         String finalId = "myFinalId";
-        setupMetadata(metadata, finalId, DropOffUtil.FileTypeCheckParameter.FINAL_ID);
+        setupDeprecatedMetadata(metadata, finalId, DropOffUtil.FileTypeCheckParameter.FINAL_ID);
         formsArg = "differentFileType";
-        testFileType(metadata, finalId, formsArg);
+        testDeprecatedFileType(metadata, finalId, formsArg);
 
         formsArg = "myFile  ";
         metadata.clear();
-        testFileType(metadata, "myFile", formsArg);
+        testDeprecatedFileType(metadata, "myFile", formsArg);
         assertEquals(formsArg,
                 metadata.get(DropOffUtil.FileTypeCheckParameter.COMPLETE_FILETYPE.getFieldName()));
 
         formsArg = "";
         String fontEncoding = "fontEncoding";
-        setupMetadata(metadata, fontEncoding, DropOffUtil.FileTypeCheckParameter.FONT_ENCODING);
-        testFileType(metadata, "TEXT", formsArg);
+        setupDeprecatedMetadata(metadata, fontEncoding, DropOffUtil.FileTypeCheckParameter.FONT_ENCODING);
+        testDeprecatedFileType(metadata, "TEXT", formsArg);
 
         metadata.clear();
         formsArg = " MSWORD";
-        testFileType(metadata, "MSWORD_FRAGMENT", formsArg);
+        testDeprecatedFileType(metadata, "MSWORD_FRAGMENT", formsArg);
 
         metadata.clear();
         formsArg = "QUOTED-PRINTABLE";
-        testFileType(metadata, "TEXT", formsArg);
+        testDeprecatedFileType(metadata, "TEXT", formsArg);
     }
 
-    private void setupMetadata(Map<String, String> metadata, String fieldValue, DropOffUtil.FileTypeCheckParameter fileTypeCheckParameter) {
+    private void setupDeprecatedMetadata(Map<String, String> metadata, String fieldValue, DropOffUtil.FileTypeCheckParameter fileTypeCheckParameter) {
         metadata.clear();
         metadata.put(fileTypeCheckParameter.getFieldName(), fieldValue);
     }
 
-    private void testFileType(Map<String, String> metadata, String expectedResults, String formsArg) {
+    private void testDeprecatedFileType(Map<String, String> metadata, String expectedResults, String formsArg) {
         String fileType;
         fileType = util.getFileType(metadata, formsArg);
+        assertEquals(expectedResults, fileType);
+    }
+
+    @Test
+    public void testGetFileType() {
+        final IBaseDataObject bdo = new BaseDataObject();
+
+        testFileType(bdo, null, "UNKNOWN", null);
+
+        Map<String, String> metadata = new HashMap<>();
+        testFileType(bdo, metadata, "UNKNOWN", null);
+
+        String poppedForms = "myPoppedForms";
+        setupMetadata(bdo, poppedForms, DropOffUtil.FileTypeCheckParameter.POPPED_FORMS);
+        testFileType(bdo, metadata, poppedForms, null);
+
+        String formsArg = "myFile";
+        setupMetadata(bdo, formsArg, DropOffUtil.FileTypeCheckParameter.FILETYPE);
+        testFileType(bdo, metadata, formsArg, formsArg);
+
+        String finalId = "myFinalId";
+        setupMetadata(bdo, finalId, DropOffUtil.FileTypeCheckParameter.FINAL_ID);
+        formsArg = "differentFileType";
+        testFileType(bdo, null, finalId, formsArg);
+        testFileType(bdo, metadata, finalId, formsArg);
+
+        formsArg = "myFile  ";
+        bdo.clearParameters();
+        metadata.clear();
+        testFileType(bdo, null, "myFile", formsArg);
+        testFileType(bdo, metadata, "myFile", formsArg);
+        assertEquals(formsArg,
+                metadata.get(DropOffUtil.FileTypeCheckParameter.COMPLETE_FILETYPE.getFieldName()));
+
+        formsArg = "";
+        String fontEncoding = "fontEncoding";
+        setupMetadata(bdo, fontEncoding, DropOffUtil.FileTypeCheckParameter.FONT_ENCODING);
+        testFileType(bdo, metadata, "TEXT", formsArg);
+
+        bdo.clearParameters();
+        metadata.clear();
+        formsArg = " MSWORD";
+        testFileType(bdo, metadata, "MSWORD_FRAGMENT", formsArg);
+
+        metadata.clear();
+        formsArg = "QUOTED-PRINTABLE";
+        testFileType(bdo, metadata, "TEXT", formsArg);
+    }
+
+    private void setupMetadata(IBaseDataObject bdo, String fieldValue, DropOffUtil.FileTypeCheckParameter fileTypeCheckParameter) {
+        bdo.clearParameters();
+        bdo.putParameter(fileTypeCheckParameter.getFieldName(), fieldValue);
+    }
+
+    private void testFileType(IBaseDataObject bdo, Map<String, String> metadata, String expectedResults, String formsArg) {
+        String fileType;
+        fileType = DropOffUtil.getAndPutFileType(bdo, metadata, formsArg);
         assertEquals(expectedResults, fileType);
     }
 }


### PR DESCRIPTION
This method is called for each BaseDataObject and creates a new TreeMap each time along with a bunch of TreeMap$Entry objects. This can be reduced to reusing a single Map object with no Entry objects being created.