### PR TITLE
extractFileExtensions should only extract extensions after a '.'

### DIFF
--- a/src/main/java/emissary/output/DropOffUtil.java
+++ b/src/main/java/emissary/output/DropOffUtil.java
@@ -1030,12 +1030,20 @@ public class DropOffUtil {
         return date;
     }
 
-    private void extractFileExtensions(IBaseDataObject p) {
+    /**
+     * Extracts from the provided {@link IBaseDataObject} the last file extension from each value in the "Original-Filename"
+     * parameter, if that value contains "." before its last character. If one or more file extensions are extracted, the
+     * IBaseDataObject's "FILEXT" parameter is set as the list of extracted file extensions, converted to lowercase.
+     *
+     * @param p IBaseDataObject to process
+     *
+     */
+    void extractFileExtensions(IBaseDataObject p) {
         if (p.hasParameter("Original-Filename")) {
             final List<String> extensions = new ArrayList<>();
             for (Object filename : p.getParameter("Original-Filename")) {
                 final String fn = (String) filename;
-                if (StringUtils.isNotEmpty(fn)) {
+                if (StringUtils.isNotEmpty(fn) && fn.lastIndexOf('.') > -1) {
                     final int pos = fn.lastIndexOf('.') + 1;
                     if (pos < fn.length()) {
                         final String fext = fn.substring(pos).toLowerCase();

--- a/src/test/java/emissary/output/DropOffUtilTest.java
+++ b/src/test/java/emissary/output/DropOffUtilTest.java
@@ -20,7 +20,6 @@ import emissary.config.ServiceConfigGuide;
 import emissary.core.BaseDataObject;
 import emissary.core.DataObjectFactory;
 import emissary.core.IBaseDataObject;
-import emissary.output.DropOffUtil.FileTypeCheckParameter;
 import emissary.test.core.UnitTest;
 import emissary.util.TimeUtil;
 import org.junit.After;
@@ -564,6 +563,34 @@ public class DropOffUtilTest extends UnitTest {
         metadata.clear();
         formsArg = "QUOTED-PRINTABLE";
         testFileType(bdo, metadata, "TEXT", formsArg);
+    }
+
+    @Test
+    public void testExtractFileExtensions() {
+        // these should be constants
+        final String FILEXT = "FILEXT";
+        final String ORIGINAL_FILENAME = "Original-Filename";
+        DropOffUtil util = new DropOffUtil();
+
+        final IBaseDataObject bdo = new BaseDataObject();
+        bdo.appendParameter(ORIGINAL_FILENAME, "name_with_no_period");
+
+        util.extractFileExtensions(bdo);
+
+        List<Object> fileExts = bdo.getParameter(FILEXT);
+        assertNull("FILEXT value should be null if no Original-Filename contains a period", fileExts);
+
+        bdo.appendParameter(ORIGINAL_FILENAME, "lower.case.zip");
+        bdo.appendParameter(ORIGINAL_FILENAME, "UPPER.CASE.MP3");
+        assertEquals("bdo should now have 3 Original-Filename values", 3, bdo.getParameter(ORIGINAL_FILENAME).size());
+
+        util.extractFileExtensions(bdo);
+        fileExts = bdo.getParameter(FILEXT);
+
+        // validate extracted FILEXT values
+        assertEquals("bdo should now have 2 FILEXT values ", 2, fileExts.size());
+        assertTrue("FILEXT values should contain \"zip\"", fileExts.contains("zip"));
+        assertTrue("FILEXT values should contain \"mp3\"", fileExts.contains("mp3"));
     }
 
     private void setupMetadata(IBaseDataObject bdo, String fieldValue, DropOffUtil.FileTypeCheckParameter fileTypeCheckParameter) {


### PR DESCRIPTION
Corrects minor regression in PR #160