### PR TITLE
#180: WIP reworked process of adding forms to prevent dupes

### DIFF
--- a/src/main/java/emissary/core/BaseDataObject.java
+++ b/src/main/java/emissary/core/BaseDataObject.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -393,35 +392,21 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
     }
 
     @Override
-    public int deleteCurrentForm(final String form) {
-        int count = 0;
-
-        if (this.currentForm == null || this.currentForm.isEmpty()) {
-            return count;
-        }
-
-        // Remove all matching
-        for (final Iterator<String> i = this.currentForm.iterator(); i.hasNext();) {
-            final String val = i.next();
-            if (val.equals(form)) {
-                i.remove();
-                count++;
-            }
-        }
-        return count;
+    public void deleteCurrentForm(final String form) {
+        if (this.currentForm.contains(form))
+            this.currentForm.remove(form);
     }
 
     @Override
-    public int deleteCurrentFormAt(final int i) {
-        // Make sure its a legal position.
+    public void deleteCurrentFormAt(final int i) {
+        // Make sure it's a legal position.
         if ((i >= 0) && (i < this.currentForm.size())) {
             this.currentForm.remove(i);
         }
-        return this.currentForm.size();
     }
 
     @Override
-    public int addCurrentFormAt(final int i, final String newForm) {
+    public void addCurrentFormAt(final int i, final String newForm) {
         if (newForm == null) {
             throw new IllegalArgumentException("caller attempted to add a null form value at position " + i);
         }
@@ -431,26 +416,26 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
         } else {
             this.currentForm.add(newForm);
         }
-        return this.currentForm.size();
     }
 
     @Override
-    public int enqueueCurrentForm(final String newForm) {
+    public void enqueueCurrentForm(final String newForm) {
         if (newForm == null) {
             throw new IllegalArgumentException("caller attempted to enqueue a null form value");
         }
 
         this.currentForm.add(newForm);
-        return this.currentForm.size();
     }
 
     @Override
-    public int pushCurrentForm(final String newForm) {
+    public void pushCurrentForm(final String newForm) {
         if (newForm == null) {
             throw new IllegalArgumentException("caller attempted to push a null form value");
         }
-
-        return addCurrentFormAt(0, newForm);
+        if (this.currentForm.contains(newForm)) {
+            deleteCurrentForm(newForm);
+        }
+        addCurrentFormAt(0, newForm);
     }
 
     @Override
@@ -480,14 +465,11 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
 
     @Override
     public void pullFormToTop(final String curForm) {
-        if (this.currentForm.size() > 1) {
+        if (this.currentForm.contains(curForm)) {
             // Delete it
-            final int count = deleteCurrentForm(curForm);
-
-            // If deleted, add it back on top
-            if (count > 0) {
-                this.currentForm.add(0, curForm);
-            }
+            deleteCurrentForm(curForm);
+            // add it back on top
+            this.currentForm.add(0, curForm);
         }
     }
 

--- a/src/main/java/emissary/core/IBaseDataObject.java
+++ b/src/main/java/emissary/core/IBaseDataObject.java
@@ -560,7 +560,7 @@ public interface IBaseDataObject {
      * @param form the value to remove
      * @return the number of elements removed from the stack
      */
-    int deleteCurrentForm(String form);
+    void deleteCurrentForm(String form);
 
     /**
      * Remove a form at the specified location of the itinerary stack
@@ -568,7 +568,7 @@ public interface IBaseDataObject {
      * @param i the position to delete
      * @return the new size of the itinerary stack
      */
-    int deleteCurrentFormAt(int i);
+    void deleteCurrentFormAt(int i);
 
     /**
      * Add current form newForm at idx
@@ -577,7 +577,7 @@ public interface IBaseDataObject {
      * @param val the value to insert
      * @return size of the new stack
      */
-    int addCurrentFormAt(int i, String val);
+    void addCurrentFormAt(int i, String val);
 
     /**
      * Add a form to the end of the list (the bottom of the stack)
@@ -585,7 +585,7 @@ public interface IBaseDataObject {
      * @param val the new value to add to the tail of the stack
      * @return the new size of the itinerary stack
      */
-    int enqueueCurrentForm(String val);
+    void enqueueCurrentForm(String val);
 
     /**
      * Push a form onto the head of the list
@@ -593,7 +593,7 @@ public interface IBaseDataObject {
      * @param val the new value to push on the stack
      * @return the new size of the itinerary stack
      */
-    int pushCurrentForm(String val);
+    void pushCurrentForm(String val);
 
     /**
      * Replaces the current form of the data with a new form Does a pop() followed by a push(newForm) to simulate what would

--- a/src/main/java/emissary/core/MobileAgent.java
+++ b/src/main/java/emissary/core/MobileAgent.java
@@ -451,18 +451,10 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
         // clean up and try for error drop off
         final String curKey = payloadArg.currentForm();
         if (ERROR_FORM.equals(curKey)) {
-            if (payloadArg.currentFormSize() > 1 && ERROR_FORM.equals(payloadArg.currentFormAt(1))) {
-                logger.error("ERROR handling place produced an error, purging all current forms");
-                while (payloadArg.currentFormSize() > 0) {
-                    payloadArg.popCurrentForm();
-                }
-                payloadArg.appendTransformHistory("ERROR.SKIP.*.http://Previous_Error_Bypass$99999");
-            } else {
-                if (payloadArg.currentFormSize() > 1) {
-                    logger.warn("Got current form of ERROR, clearing form stack on {}: {}", payloadArg.shortName(), payloadArg.getAllCurrentForms());
-                }
-                purgeNonFinalForms(payloadArg);
+            if (payloadArg.currentFormSize() > 1) {
+                logger.warn("Got current form of ERROR, clearing form stack on {}: {}", payloadArg.shortName(), payloadArg.getAllCurrentForms());
             }
+            purgeNonFinalForms(payloadArg);
         }
 
         // If we have a fully specified key as current form
@@ -588,7 +580,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      * before calling this method again.
      */
     protected DirectoryEntry nextKeyFromDirectory(final String dataID, final IServiceProviderPlace place, final DirectoryEntry lastEntry,
-            final IBaseDataObject payloadArg) {
+                                                  final IBaseDataObject payloadArg) {
 
         try {
             logger.debug("Trying nextKey for {} with last={}, atPlace={}", dataID, lastEntry, place);
@@ -670,7 +662,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      */
     @Override
     public synchronized void arrive(final Object dataObject, final IServiceProviderPlace arrivalPlaceArg, final int moveErrorCount,
-            final List<DirectoryEntry> queuedItineraryItems) throws Exception {
+                                    final List<DirectoryEntry> queuedItineraryItems) throws Exception {
 
         if (dataObject instanceof IBaseDataObject) {
             clear();

--- a/src/test/java/emissary/core/BaseDataObjectTest.java
+++ b/src/test/java/emissary/core/BaseDataObjectTest.java
@@ -251,8 +251,8 @@ public class BaseDataObjectTest extends UnitTest {
 
     @Test
     public void testCurrentFormEnqueue() {
-        final int i = this.b.enqueueCurrentForm("FOUR");
-        assertEquals("Enqueue return value", 4, i);
+        this.b.enqueueCurrentForm("FOUR");
+        assertEquals("New size of form list", 4, this.b.currentFormSize());
         assertEquals("Current form push", "THREE", this.b.currentForm());
         assertEquals("Prev bottom form", "ONE", this.b.currentFormAt(2));
         assertEquals("Bottom form", "FOUR", this.b.currentFormAt(3));
@@ -332,8 +332,8 @@ public class BaseDataObjectTest extends UnitTest {
 
     @Test
     public void testDeleteFormFromMiddle() {
-        final int i = this.b.deleteCurrentFormAt(1);
-        assertEquals("Delete return value", 2, i);
+        this.b.deleteCurrentFormAt(1);
+        assertEquals("New size of form list", 2, this.b.currentFormSize());
         assertEquals("Form remaining on top", "THREE", this.b.currentForm());
         assertEquals("Form remaining on bottom", "ONE", this.b.currentFormAt(1));
         assertEquals("Stack size after delete", 2, this.b.currentFormSize());
@@ -352,7 +352,12 @@ public class BaseDataObjectTest extends UnitTest {
         while (this.b.currentFormSize() > 0) {
             this.b.popCurrentForm();
         }
-        assertEquals("Delete from empty current forms failed", 0, this.b.deleteCurrentFormAt(0));
+        assertNull("Delete from empty current forms failed", this.b.popCurrentForm());
+    }
+
+    @Test
+    public void testNoDuplicateFormInStack() {
+        // this.b.
     }
 
     @Test

--- a/src/test/java/emissary/directory/RoutingAlgorithmTest.java
+++ b/src/test/java/emissary/directory/RoutingAlgorithmTest.java
@@ -260,11 +260,11 @@ public class RoutingAlgorithmTest extends UnitTest {
         loadAllTestEntries();
         final DirectoryEntry eplace = new DirectoryEntry("ERROR.e1.IO.http://example.com:8001/E$5050");
         this.dir.addTestEntry(eplace);
-        this.payload.pushCurrentForm(emissary.core.Form.ERROR);
-        this.payload.pushCurrentForm(emissary.core.Form.ERROR);
+        this.payload.pushCurrentForm("OTHER1");
+        this.payload.pushCurrentForm("OTHER2");
         this.payload.pushCurrentForm(emissary.core.Form.ERROR);
         final DirectoryEntry result = this.agent.getNextKeyAccess(this.dir, this.payload);
-        assertEquals("Error in error handling place removes all forms", 0, this.payload.currentFormSize());
+        assertEquals("Error in error handling place removes all other forms", 1, this.payload.currentFormSize());
         assertNull("Error in Error handling must not re-route to error handler but we got " + result, result);
     }
 


### PR DESCRIPTION
This work aims to prevent IBDOs from having duplicate forms in the form stack. This seems to break some tests that currently exist and I'm unsure if the tests should be reworked or removed, or what the new outcome of those cases should be.

I've also reworked a lot of the methods that are used to change the form stack: they all seem to return an int value strictly for testing purposes. They now all return void and those tests have been changed to be more obvious about what is being tested. This work has also seemed to cause some methods to be obsolete/redundant, and some of these methods just seem to be wrappers to methods that Collections already provides. Would like another pair of eyes to let me know if I'm going down the right path before I proceed.