### PR TITLE
#180: do not allow dupe forms in the IBDO stack

### DIFF
--- a/src/main/java/emissary/core/BaseDataObject.java
+++ b/src/main/java/emissary/core/BaseDataObject.java
@@ -426,7 +426,7 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
             throw new IllegalArgumentException("caller attempted to add a null form value at position " + i);
         }
 
-        this.currentForm.remove(newForm); // this will remove the form if already in the stack, preventing duplicates
+        checkForDuplicates(newForm);
         if (i < this.currentForm.size()) {
             this.currentForm.add(i, newForm);
         } else {
@@ -441,9 +441,15 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
             throw new IllegalArgumentException("caller attempted to enqueue a null form value");
         }
 
-        this.currentForm.remove(newForm); // this will remove the form if already in the stack, preventing duplicates
+        checkForDuplicates(newForm);
         this.currentForm.add(newForm);
         return this.currentForm.size();
+    }
+
+    private void checkForDuplicates(String newForm) {
+        if (!newForm.equals(Form.ERROR.intern())) {
+            this.currentForm.remove(newForm); // this will remove the form if already in the stack, preventing duplicates
+        }
     }
 
     @Override

--- a/src/main/java/emissary/core/BaseDataObject.java
+++ b/src/main/java/emissary/core/BaseDataObject.java
@@ -426,6 +426,7 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
             throw new IllegalArgumentException("caller attempted to add a null form value at position " + i);
         }
 
+        this.currentForm.remove(newForm); //this will remove the form if already in the stack, preventing duplicates
         if (i < this.currentForm.size()) {
             this.currentForm.add(i, newForm);
         } else {
@@ -440,6 +441,7 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
             throw new IllegalArgumentException("caller attempted to enqueue a null form value");
         }
 
+        this.currentForm.remove(newForm); //this will remove the form if already in the stack, preventing duplicates
         this.currentForm.add(newForm);
         return this.currentForm.size();
     }

--- a/src/main/java/emissary/core/BaseDataObject.java
+++ b/src/main/java/emissary/core/BaseDataObject.java
@@ -426,7 +426,7 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
             throw new IllegalArgumentException("caller attempted to add a null form value at position " + i);
         }
 
-        this.currentForm.remove(newForm); //this will remove the form if already in the stack, preventing duplicates
+        this.currentForm.remove(newForm); // this will remove the form if already in the stack, preventing duplicates
         if (i < this.currentForm.size()) {
             this.currentForm.add(i, newForm);
         } else {
@@ -441,7 +441,7 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
             throw new IllegalArgumentException("caller attempted to enqueue a null form value");
         }
 
-        this.currentForm.remove(newForm); //this will remove the form if already in the stack, preventing duplicates
+        this.currentForm.remove(newForm); // this will remove the form if already in the stack, preventing duplicates
         this.currentForm.add(newForm);
         return this.currentForm.size();
     }

--- a/src/test/java/emissary/core/BaseDataObjectTest.java
+++ b/src/test/java/emissary/core/BaseDataObjectTest.java
@@ -356,6 +356,22 @@ public class BaseDataObjectTest extends UnitTest {
     }
 
     @Test
+    public void testNoDuplicateFormsAllowed() {
+        final String newForm = "NEWFORM";
+        this.b.addCurrentFormAt(0, newForm);
+        this.b.enqueueCurrentForm(newForm);
+        this.b.pushCurrentForm(newForm);
+        this.b.setCurrentForm(newForm);
+        int count = 0;
+        for (int i = 0; i < this.b.currentFormSize(); i++) {
+            if (this.b.currentFormAt(i).equals(newForm)) {
+                count++;
+            }
+        }
+        assertEquals("Only one instance of NEWFORM exists after adding it multiple times in different ways: ", 1, count);
+    }
+
+    @Test
     public void testPrintMeta() {
         this.b.putParameter("FOO", "QUUZ");
         assertTrue("PrintMeta returnss valid params", this.b.printMeta().indexOf("QUUZ") > -1);


### PR DESCRIPTION
This work simply adds a "remove(newForm)" call before any attempt to add a new form to the IBDO's form stack. This will remove any already existing matching forms (or do nothing if it doesn't already exist) and then continue as before. The test I wrote adds the same form multiple times in different ways and then checks to see that only one of that form exists in the stack.

As an aside, it may be worth revisiting BaseDataObject for a little bit of refactoring, but that's outside the scope of this ticket.

