### PR TITLE
Improved error message on config IMPORT_FILE fail

### DIFF
--- a/src/main/java/emissary/config/ConfigUtil.java
+++ b/src/main/java/emissary/config/ConfigUtil.java
@@ -327,7 +327,14 @@ public class ConfigUtil {
                 c = getConfigInfo(s);
                 return c;
             } catch (IOException ex) {
-                logger.debug("Preference {} not found", s);
+                String exception = ex.getMessage();
+                if (exception.contains("IMPORT_FILE")) {
+                    exception = exception.replace("<none>", s);
+                    logger.debug("IMPORT_FILE not found in {}", s);
+                    throw new IOException(exception);
+                } else {
+                    logger.debug("Preference {} not found", s);
+                }
             }
         }
         throw new IOException("None of the " + preferences.size() + " preferences could be found: " + preferences);

--- a/src/main/java/emissary/config/ServiceConfigGuide.java
+++ b/src/main/java/emissary/config/ServiceConfigGuide.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.io.StreamTokenizer;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -323,7 +324,10 @@ public class ServiceConfigGuide implements Configurator, Serializable {
                 } catch (IOException e) {
                     // Throw exception if it is an IMPORT_FILE and the base file is not found
                     if ("IMPORT_FILE".equals(parmName) && i == 0) {
-                        throw new IOException("IMPORT_FILE = " + sval + " : Directive failed. Called from " + filename, e);
+                        String importFileName = Paths.get(svalArg).getFileName().toString();
+                        throw new IOException("In " + filename + ", cannot find IMPORT_FILE: " + sval
+                                + " on the specified path. \nMake sure IMPORT_FILE (" + importFileName + ") exists, and the file path is correct.",
+                                e);
                     }
                 }
             }

--- a/src/main/java/emissary/config/ServiceConfigGuide.java
+++ b/src/main/java/emissary/config/ServiceConfigGuide.java
@@ -326,7 +326,7 @@ public class ServiceConfigGuide implements Configurator, Serializable {
                     if ("IMPORT_FILE".equals(parmName) && i == 0) {
                         String importFileName = Paths.get(svalArg).getFileName().toString();
                         throw new IOException("In " + filename + ", cannot find IMPORT_FILE: " + sval
-                                + " on the specified path. \nMake sure IMPORT_FILE (" + importFileName + ") exists, and the file path is correct.",
+                                + " on the specified path. Make sure IMPORT_FILE (" + importFileName + ") exists, and the file path is correct.",
                                 e);
                     }
                 }

--- a/src/test/java/emissary/config/ServiceConfigGuideTest.java
+++ b/src/test/java/emissary/config/ServiceConfigGuideTest.java
@@ -526,7 +526,6 @@ public class ServiceConfigGuideTest extends UnitTest {
         final byte[] primary = new String("IMPORT_FILE = \"" + impname + "\"\n").getBytes();
         final byte[] importfile = new String("FOO = \"BAR\"\n").getBytes();
 
-        boolean importFileFound = true;
         String result = "";
 
         final Configurator c;
@@ -536,18 +535,17 @@ public class ServiceConfigGuideTest extends UnitTest {
             c = new ServiceConfigGuide(priname);
         } catch (IOException iox) {
             // should not be reached due to IMPORT_FILE existing
-            importFileFound = false;
             result = iox.toString();
         } finally {
             Files.deleteIfExists(Paths.get(priname));
             Files.deleteIfExists(Paths.get(impname));
         }
 
-        assertTrue(result, importFileFound);
+        assertEquals(result, 0, result.length());
 
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void testImportFileWhenFileDoesNotExist() throws IOException {
         // Write the config bytes out to a temp file
         final String dir = System.getProperty("java.io.tmpdir");
@@ -556,8 +554,8 @@ public class ServiceConfigGuideTest extends UnitTest {
 
         final byte[] primary = new String("IMPORT_FILE = \"" + impname + "\"\n").getBytes();
 
-        boolean importFileFound = true;
         String result = "";
+        String importFileName = Paths.get(impname).getFileName().toString();
 
         final Configurator c;
         try {
@@ -565,15 +563,16 @@ public class ServiceConfigGuideTest extends UnitTest {
             c = new ServiceConfigGuide(priname);
         } catch (IOException iox) {
             // will catch as IMPORT_FILE is not created/found, String result will be thrown IO Exception Message
-            importFileFound = false;
             result = iox.toString();
         } finally {
             Files.deleteIfExists(Paths.get(priname));
             Files.deleteIfExists(Paths.get(impname));
         }
 
-        // fails, because IMPORT_FILE is not found
-        assertTrue(result, importFileFound);
+        String noImportExpectedMessage = "In " + priname + ", cannot find IMPORT_FILE: " + impname
+                + " on the specified path. \nMake sure IMPORT_FILE (" + importFileName + ") exists, and the file path is correct.";
+
+        assertTrue("IMPORT_FAIL Message Not What Was Expected.", result.contains(noImportExpectedMessage));
     }
 
     @Test

--- a/src/test/java/emissary/config/ServiceConfigGuideTest.java
+++ b/src/test/java/emissary/config/ServiceConfigGuideTest.java
@@ -526,23 +526,17 @@ public class ServiceConfigGuideTest extends UnitTest {
         final byte[] primary = new String("IMPORT_FILE = \"" + impname + "\"\n").getBytes();
         final byte[] importfile = new String("FOO = \"BAR\"\n").getBytes();
 
-        String result = "";
-
-        final Configurator c;
         try {
             Executrix.writeDataToFile(primary, priname);
             Executrix.writeDataToFile(importfile, impname);
-            c = new ServiceConfigGuide(priname);
+            new ServiceConfigGuide(priname);
         } catch (IOException iox) {
             // should not be reached due to IMPORT_FILE existing
-            result = iox.toString();
+            fail("IMPORT_FILE not found.");
         } finally {
             Files.deleteIfExists(Paths.get(priname));
             Files.deleteIfExists(Paths.get(impname));
         }
-
-        assertEquals(result, 0, result.length());
-
     }
 
     @Test
@@ -557,13 +551,12 @@ public class ServiceConfigGuideTest extends UnitTest {
         String result = "";
         String importFileName = Paths.get(impname).getFileName().toString();
 
-        final Configurator c;
         try {
             Executrix.writeDataToFile(primary, priname);
-            c = new ServiceConfigGuide(priname);
+            new ServiceConfigGuide(priname);
         } catch (IOException iox) {
             // will catch as IMPORT_FILE is not created/found, String result will be thrown IO Exception Message
-            result = iox.toString();
+            result = iox.getMessage();
         } finally {
             Files.deleteIfExists(Paths.get(priname));
             Files.deleteIfExists(Paths.get(impname));
@@ -572,7 +565,7 @@ public class ServiceConfigGuideTest extends UnitTest {
         String noImportExpectedMessage = "In " + priname + ", cannot find IMPORT_FILE: " + impname
                 + " on the specified path. \nMake sure IMPORT_FILE (" + importFileName + ") exists, and the file path is correct.";
 
-        assertTrue("IMPORT_FAIL Message Not What Was Expected.", result.contains(noImportExpectedMessage));
+        assertEquals("IMPORT_FAIL Message Not What Was Expected.", result, noImportExpectedMessage);
     }
 
     @Test

--- a/src/test/java/emissary/config/ServiceConfigGuideTest.java
+++ b/src/test/java/emissary/config/ServiceConfigGuideTest.java
@@ -517,6 +517,66 @@ public class ServiceConfigGuideTest extends UnitTest {
     }
 
     @Test
+    public void testImportFileWhenFileExists() throws IOException {
+        // Write the config bytes out to a temp file
+        final String dir = System.getProperty("java.io.tmpdir");
+        final String priname = dir + "/primary.cfg";
+        final String impname = dir + "/import.cfg";
+
+        final byte[] primary = new String("IMPORT_FILE = \"" + impname + "\"\n").getBytes();
+        final byte[] importfile = new String("FOO = \"BAR\"\n").getBytes();
+
+        boolean importFileFound = true;
+        String result = "";
+
+        final Configurator c;
+        try {
+            Executrix.writeDataToFile(primary, priname);
+            Executrix.writeDataToFile(importfile, impname);
+            c = new ServiceConfigGuide(priname);
+        } catch (IOException iox) {
+            // should not be reached due to IMPORT_FILE existing
+            importFileFound = false;
+            result = iox.toString();
+        } finally {
+            Files.deleteIfExists(Paths.get(priname));
+            Files.deleteIfExists(Paths.get(impname));
+        }
+
+        assertTrue(result, importFileFound);
+
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testImportFileWhenFileDoesNotExist() throws IOException {
+        // Write the config bytes out to a temp file
+        final String dir = System.getProperty("java.io.tmpdir");
+        final String priname = dir + "/primary.cfg";
+        final String impname = dir + "/import.cfg";
+
+        final byte[] primary = new String("IMPORT_FILE = \"" + impname + "\"\n").getBytes();
+
+        boolean importFileFound = true;
+        String result = "";
+
+        final Configurator c;
+        try {
+            Executrix.writeDataToFile(primary, priname);
+            c = new ServiceConfigGuide(priname);
+        } catch (IOException iox) {
+            // will catch as IMPORT_FILE is not created/found, String result will be thrown IO Exception Message
+            importFileFound = false;
+            result = iox.toString();
+        } finally {
+            Files.deleteIfExists(Paths.get(priname));
+            Files.deleteIfExists(Paths.get(impname));
+        }
+
+        // fails, because IMPORT_FILE is not found
+        assertTrue(result, importFileFound);
+    }
+
+    @Test
     public void testOptImportWhenOptionalFileExists() throws IOException {
         // Write the config bytes out to a temp file
         final String dir = System.getProperty("java.io.tmpdir");

--- a/src/test/java/emissary/config/ServiceConfigGuideTest.java
+++ b/src/test/java/emissary/config/ServiceConfigGuideTest.java
@@ -563,7 +563,7 @@ public class ServiceConfigGuideTest extends UnitTest {
         }
 
         String noImportExpectedMessage = "In " + priname + ", cannot find IMPORT_FILE: " + impname
-                + " on the specified path. \nMake sure IMPORT_FILE (" + importFileName + ") exists, and the file path is correct.";
+                + " on the specified path. Make sure IMPORT_FILE (" + importFileName + ") exists, and the file path is correct.";
 
         assertEquals("IMPORT_FAIL Message Not What Was Expected.", result, noImportExpectedMessage);
     }


### PR DESCRIPTION
This is in reference to NationalSecurityAgency/burrito-grande#803.
Updated the error message that is output when an IMPORT_FILE within a config file cannot be found or DNE to make it more clear to Devs what is wrong.