### PR TITLE
Remove expensive debug print from MagicNumber

### DIFF
--- a/src/main/java/emissary/util/magic/MagicNumber.java
+++ b/src/main/java/emissary/util/magic/MagicNumber.java
@@ -122,7 +122,6 @@ public class MagicNumber {
      * Tests the sample and if successful provides the description
      */
     public String describe(byte[] data) {
-        log.debug("COMPARING AGAINST: " + toString());
         String desc = describeSelf(data);
         if (desc == null)
             return null;


### PR DESCRIPTION
This debug statement is not parameterized and ends up being rather expensive when done many many times. I opted to just remove it in this pr for simplicity.