### PR TITLE
Fixing a single line mistake within Executrix.java

### DIFF
--- a/src/main/java/emissary/util/shell/Executrix.java
+++ b/src/main/java/emissary/util/shell/Executrix.java
@@ -649,7 +649,7 @@ public class Executrix {
             out.append(bout.toString());
         }
         if ((err != null) && (berr != null)) {
-            err.append(err.toString());
+            err.append(berr.toString());
         }
         return status;
     }


### PR DESCRIPTION
While going through the "execute" methods within the Executrix, I found a mistake.
https://github.com/NationalSecurityAgency/emissary/blob/0326a8c391a00371709f2d21f29d537e9dabf098/src/main/java/emissary/util/shell/Executrix.java#L652
The above line should be formatted like:
https://github.com/NationalSecurityAgency/emissary/blob/0326a8c391a00371709f2d21f29d537e9dabf098/src/main/java/emissary/util/shell/Executrix.java#L649

This updates the line to err.append(berr.toString()); rather than appending the err.toString().