### PR TITLE
dependabot: update jackson to 2.12.6 and jackson-databind to 2.12.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <dep.hamcrest-junit.version>2.0.0.0</dep.hamcrest-junit.version>
     <dep.httpclient.version>4.5.13</dep.httpclient.version>
     <dep.httpcore.version>4.4.14</dep.httpcore.version>
-    <dep.jackson.version>2.12.3</dep.jackson.version>
+    <dep.jackson.version>2.12.6</dep.jackson.version>
     <!-- jersey brings in 2.3.3; tika brings in 2.3.2; converge on latest -->
     <dep.jakarta.xml.bind-api.version>2.3.3</dep.jakarta.xml.bind-api.version>
     <!-- jersey brings in 1.2; tika-parsers brings in 1.3.2; converge on latest -->
@@ -112,7 +112,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${dep.jackson.version}</version>
+        <version>${dep.jackson.version}.1</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>


### PR DESCRIPTION
Covers dependabot alert attempted to be handled in https://github.com/NationalSecurityAgency/emissary/pull/217 

https://github.com/NationalSecurityAgency/emissary/security/dependabot/5