### PR TITLE
B63 - Remove redundant sorting from output filters

### DIFF
--- a/src/main/java/emissary/output/filter/AbstractFilter.java
+++ b/src/main/java/emissary/output/filter/AbstractFilter.java
@@ -234,10 +234,6 @@ public abstract class AbstractFilter implements IDropOffFilter {
     @Override
     public int filter(final List<IBaseDataObject> list, final Map<String, Object> params) {
         // Important to process them in order, if not already sorted
-        if (params.get(PRE_SORTED) == null) {
-            Collections.sort(list, new emissary.util.ShortNameComparator()); // unsafe?
-            params.put(PRE_SORTED, Boolean.TRUE);
-        }
 
         int status = 0;
         for (final IBaseDataObject d : list) {
@@ -256,11 +252,6 @@ public abstract class AbstractFilter implements IDropOffFilter {
      */
     @Override
     public int filter(final List<IBaseDataObject> list, final Map<String, Object> params, final OutputStream output) {
-        // Important to process them in order, if not already sorted
-        if (params.get(PRE_SORTED) == null) {
-            Collections.sort(list, new emissary.util.ShortNameComparator()); // unsafe?
-            params.put(PRE_SORTED, Boolean.TRUE);
-        }
 
         int status = 0;
         for (final IBaseDataObject d : list) {
@@ -268,16 +259,6 @@ public abstract class AbstractFilter implements IDropOffFilter {
         }
         return status;
     }
-
-    /**
-     * The method that all filter have to provide
-     * 
-     * @param payload the payload to run the filter on
-     * @param params map of params
-     * @return status value
-     */
-    @Override
-    public abstract int filter(IBaseDataObject payload, Map<String, Object> params);
 
     /**
      * The method that all filter have to provide for stream based output

--- a/src/main/java/emissary/output/filter/AbstractRollableFilter.java
+++ b/src/main/java/emissary/output/filter/AbstractRollableFilter.java
@@ -157,13 +157,11 @@ public abstract class AbstractRollableFilter extends AbstractFilter {
 
     @Override
     public int filter(final IBaseDataObject payload, final Map<String, Object> params) {
-        params.put(PRE_SORTED, "true");
         return filter(Collections.singletonList(payload), params);
     }
 
     @Override
     public int filter(final IBaseDataObject payload, final Map<String, Object> params, final OutputStream output) {
-        params.put(PRE_SORTED, "true");
         return filter(Collections.singletonList(payload), params, output);
     }
 
@@ -186,11 +184,6 @@ public abstract class AbstractRollableFilter extends AbstractFilter {
 
     @Override
     public int filter(final List<IBaseDataObject> list, final Map<String, Object> params, final OutputStream output) {
-        // Important to process them in order if not already sorted
-        if (params.get(PRE_SORTED) == null) {
-            Collections.sort(list, new emissary.util.ShortNameComparator());
-            params.put(IDropOffFilter.PRE_SORTED, Boolean.TRUE);
-        }
 
         // We subtract 1 from the list because the first element is currently assumed to be the TLD
         list.get(0).putParameter("DESCENDANT_COUNT", list.size() - 1);


### PR DESCRIPTION
It was noticed that when data goes through DropOffPlace, it can be sorted twice, which is redundant. This work aims to remove the possibility of that happening.