### PR TITLE
adding coordination place visits to the transform history

### DIFF
--- a/src/main/java/emissary/place/CoordinationPlace.java
+++ b/src/main/java/emissary/place/CoordinationPlace.java
@@ -11,6 +11,7 @@ import emissary.core.Namespace;
 import emissary.core.NamespaceException;
 import emissary.core.ResourceWatcher;
 import emissary.core.TimedResource;
+import emissary.directory.DirectoryEntry;
 import emissary.directory.KeyManipulator;
 
 /**
@@ -34,7 +35,8 @@ public class CoordinationPlace extends ServiceProviderPlace {
 
     protected String outputForm = null; // What we call it when we are finished
     protected boolean pushForm = true; // push or set on the form
-
+    protected boolean updateTransformHistory = false;
+    protected String transformHistoryIndent = "";
 
     /**
      * Create the place using the supplied configuration and location
@@ -90,6 +92,8 @@ public class CoordinationPlace extends ServiceProviderPlace {
     protected void configurePlace() {
         outputForm = configG.findStringEntry("OUTPUT_FORM", null);
         pushForm = configG.findBooleanEntry("PUSH_OUTPUT_FORM", true);
+        updateTransformHistory = configG.findBooleanEntry("UPDATE_TRANSFORM_HISTORY", false);
+        transformHistoryIndent = configG.findStringEntry("TRANSFORM_HISTORY_INDENT", "");
 
         placeKeys = configG.findEntries("SERVICE_COORDINATION");
         logger.debug("We got {} entries to coordinate", placeKeys.size());
@@ -177,6 +181,12 @@ public class CoordinationPlace extends ServiceProviderPlace {
                 break;
             } else if (shouldSkip(d, p)) {
                 continue;
+            }
+
+            if (updateTransformHistory) {
+                DirectoryEntry de = p.getDirectoryEntry();
+                de.setDataType(d.currentForm());
+                d.appendTransformHistory(transformHistoryIndent + de.getKey());
             }
 
             // Collect attachments for hd processing


### PR DESCRIPTION
Two patch files attached for testing:

Test 1, simple coordination place:
[coordination_xform.patch.txt](https://github.com/NationalSecurityAgency/emissary/files/8844285/coordination_xform.patch.txt)

Test 2, coordination place that calls coordination places:
[coord_x_coord_xform.patch.txt](https://github.com/NationalSecurityAgency/emissary/files/8844286/coord_x_coord_xform.patch.txt)

