### PR TITLE
Bump jetty to 9.4.48.v20220622

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <dep.jcommander.version>1.58</dep.jcommander.version>
     <dep.jdom2.version>2.0.6.1</dep.jdom2.version>
     <dep.jersey.version>2.35</dep.jersey.version>
-    <dep.jetty.version>10.0.10</dep.jetty.version>
+    <dep.jetty.version>9.4.48.v20220622</dep.jetty.version>
     <dep.junit-jupiter.version>5.8.2</dep.junit-jupiter.version>
     <!-- junit-vintage, hamcrest and jersey disagree, but this works for everyone -->
     <dep.junit.version>4.13.2</dep.junit.version>


### PR DESCRIPTION
The 10 line goes too far since it needs java 11. This is the latest 9 series. We plan to update to 10.x+ as part of the jdk11/emissary 8 effort.