### PR TITLE
tests :: updated fail method calls

### DIFF
--- a/src/test/java/emissary/config/ConfigUtilTest.java
+++ b/src/test/java/emissary/config/ConfigUtilTest.java
@@ -230,7 +230,7 @@ class ConfigUtilTest extends UnitTest {
             assertNotNull(p, "Properties returned");
             assertTrue(p.size() > 0, "Non-empty properties returned");
         } catch (IOException iox) {
-            fail("Should not throw on property info get: " + iox.getMessage());
+            fail("Should not throw on property info get", iox);
         }
     }
 

--- a/src/test/java/emissary/config/ServiceConfigGuideTest.java
+++ b/src/test/java/emissary/config/ServiceConfigGuideTest.java
@@ -523,7 +523,7 @@ class ServiceConfigGuideTest extends UnitTest {
             new ServiceConfigGuide(priname);
         } catch (IOException iox) {
             // should not be reached due to IMPORT_FILE existing
-            throw new AssertionError("IMPORT_FILE not found.", iox);
+            fail("IMPORT_FILE not found.", iox);
         } finally {
             FileUtils.deleteDirectory(dir.toFile());
         }

--- a/src/test/java/emissary/core/BaseDataObjectTest.java
+++ b/src/test/java/emissary/core/BaseDataObjectTest.java
@@ -603,7 +603,7 @@ class BaseDataObjectTest extends UnitTest {
             this.b.addAlternateView("FLUBBER", null);
             assertEquals(0, this.b.getAlternateViewNames().size(), "View removed by orig name");
         } catch (Exception ex) {
-            fail("Could not configure test: " + ex.getMessage());
+            fail("Could not configure test", ex);
         } finally {
             // Clean up
             Namespace.unbind(MetadataDictionary.DEFAULT_NAMESPACE_NAME);
@@ -969,7 +969,7 @@ class BaseDataObjectTest extends UnitTest {
             this.b.popCurrentForm();
             assertEquals(this.b.currentFormSize(), clone.currentFormSize() - 1, "Current form stack must be detached after clone");
         } catch (CloneNotSupportedException ex) {
-            throw new AssertionError("Clone must be supported on BaseDataObject", ex);
+            fail("Clone must be supported on BaseDataObject", ex);
         }
     }
 
@@ -1106,7 +1106,7 @@ class BaseDataObjectTest extends UnitTest {
             assertEquals(this.b.getExtractedRecordCount(), this.b.clone()
                     .getExtractedRecordCount(), "Cloned IBDO should have same sized extracted record list");
         } catch (CloneNotSupportedException ex) {
-            fail("Clone method should have been called not " + ex.getMessage());
+            fail("Clone method should have been called", ex);
         }
     }
 }

--- a/src/test/java/emissary/core/FTestMovingAgent.java
+++ b/src/test/java/emissary/core/FTestMovingAgent.java
@@ -3,6 +3,7 @@ package emissary.core;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 
@@ -102,7 +103,7 @@ class FTestMovingAgent extends FunctionalTest {
                 logger.debug("Found pool after reset to " + agentClass);
                 spool.resetPool();
             } catch (emissary.core.NamespaceException ex) {
-                throw new AssertionError("Agent pool is missing after reset to " + agentClass, ex);
+                fail("Agent pool is missing after reset to " + agentClass, ex);
             }
         } else if (agentClass != null) {
             logger.debug("Factory already using " + agentClass);

--- a/src/test/java/emissary/core/MetadataDictionaryTest.java
+++ b/src/test/java/emissary/core/MetadataDictionaryTest.java
@@ -23,7 +23,7 @@ public class MetadataDictionaryTest extends UnitTest {
                 m = new MetadataDictionary(TEST_NAMESPACE, conf);
             }
         } catch (Exception ex) {
-            fail("Exception configuring dictionary: " + ex.getMessage());
+            fail("Exception configuring dictionary", ex);
         }
         assertNotNull(m, "Metadata Dictionary must be created");
         return m;
@@ -87,7 +87,7 @@ public class MetadataDictionaryTest extends UnitTest {
             MetadataDictionary d2 = MetadataDictionary.lookup(TEST_NAMESPACE);
             assertEquals(d1, d2, "INitialize must bind by default lookup name");
         } catch (Exception ex) {
-            fail("Exception doing namespace lookup: " + ex.getMessage());
+            fail("Exception doing namespace lookup", ex);
         } finally {
             clearNamespace();
         }

--- a/src/test/java/emissary/core/NamespaceTest.java
+++ b/src/test/java/emissary/core/NamespaceTest.java
@@ -36,7 +36,7 @@ class NamespaceTest extends UnitTest {
             final Object o = Namespace.lookup("myObject1");
             assertEquals(one, o, "Namespace retrieval");
         } catch (NamespaceException e) {
-            fail("Object not found: " + e);
+            fail("Object not found", e);
         }
     }
 
@@ -57,7 +57,7 @@ class NamespaceTest extends UnitTest {
             final Object o = Namespace.lookup("StuffPlace");
             assertEquals(thePlace, o, "Tail match on Namespace lookup");
         } catch (NamespaceException e) {
-            fail("Lookup failed: " + e.getMessage());
+            fail("Lookup failed", e);
         }
         assertThrows(NamespaceException.class, () -> Namespace.lookup("BadStuffPlace"));
     }
@@ -87,7 +87,7 @@ class NamespaceTest extends UnitTest {
             final Object o = Namespace.lookup("a");
             assertEquals(a[0], o, "Found by name");
         } catch (NamespaceException e) {
-            fail("Could not find object a " + e);
+            fail("Could not find object a", e);
         }
     }
 }

--- a/src/test/java/emissary/kff/ChecksumCalculatorTest.java
+++ b/src/test/java/emissary/kff/ChecksumCalculatorTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.security.NoSuchAlgorithmException;
 import java.util.Iterator;
@@ -39,7 +40,7 @@ class ChecksumCalculatorTest extends UnitTest {
             assertTrue(algs.contains("CRC32"), "CRC-32 alg used for default ctor");
             assertEquals(DATA_SHA1, cr.getHashString("SHA-1"), "SHA-1 computation");
         } catch (NoSuchAlgorithmException ex) {
-            throw new AssertionError("Unable to get SHA-1 algorithm", ex);
+            fail("Unable to get SHA-1 algorithm", ex);
         }
     }
 
@@ -58,7 +59,7 @@ class ChecksumCalculatorTest extends UnitTest {
             assertTrue(algs.contains("CRC32"), "Using CRC and in alg set");
             assertNotEquals(-1L, cr.getCrc(), "CRC computed");
         } catch (NoSuchAlgorithmException ex) {
-            throw new AssertionError("Unable to get SHA-1 algorithm", ex);
+            fail("Unable to get SHA-1 algorithm", ex);
         }
     }
 
@@ -76,7 +77,7 @@ class ChecksumCalculatorTest extends UnitTest {
             assertFalse(cc.getUseCRC(), "Not using CRC");
             assertEquals(-1L, cr.getCrc(), "CRC not computed");
         } catch (NoSuchAlgorithmException ex) {
-            throw new AssertionError("Unable to get SHA-1 algorithm", ex);
+            fail("Unable to get SHA-1 algorithm", ex);
         }
     }
 
@@ -95,7 +96,7 @@ class ChecksumCalculatorTest extends UnitTest {
             assertTrue(cc.getUseCRC(), "Using CRC");
             assertNotEquals(-1L, cr.getCrc(), "CRC computed");
         } catch (NoSuchAlgorithmException ex) {
-            throw new AssertionError("Unable to get SHA-1 algorithm", ex);
+            fail("Unable to get SHA-1 algorithm", ex);
         }
     }
 
@@ -114,7 +115,7 @@ class ChecksumCalculatorTest extends UnitTest {
             assertFalse(cc.getUseCRC(), "Not using CRC");
             assertEquals(-1L, cr.getCrc(), "CRC not computed");
         } catch (NoSuchAlgorithmException ex) {
-            throw new AssertionError("Unable to get SHA-1 algorithm", ex);
+            fail("Unable to get SHA-1 algorithm", ex);
         }
     }
 
@@ -140,7 +141,7 @@ class ChecksumCalculatorTest extends UnitTest {
             assertFalse(cc.getUseCRC(), "Not using CRC");
             assertEquals(-1L, cr.getCrc(), "CRC not computed");
         } catch (NoSuchAlgorithmException ex) {
-            throw new AssertionError("Unable to get SHA-1 or SHA-256 algorithm", ex);
+            fail("Unable to get SHA-1 or SHA-256 algorithm", ex);
         }
     }
 }

--- a/src/test/java/emissary/kff/ChecksumResultsTest.java
+++ b/src/test/java/emissary/kff/ChecksumResultsTest.java
@@ -2,6 +2,7 @@ package emissary.kff;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.security.NoSuchAlgorithmException;
 import java.util.Iterator;
@@ -27,7 +28,7 @@ class ChecksumResultsTest extends UnitTest {
             assertEquals("SHA-1", i.next(), "SHA-1 alg present");
             assertEquals("SHA-256", i.next(), "SHA-256 alg present");
         } catch (NoSuchAlgorithmException ex) {
-            throw new AssertionError("Unable to get SHA-1 or SHA-256 algorithm", ex);
+            fail("Unable to get SHA-1 or SHA-256 algorithm", ex);
         }
     }
 }

--- a/src/test/java/emissary/kff/KffChainTest.java
+++ b/src/test/java/emissary/kff/KffChainTest.java
@@ -3,6 +3,7 @@ package emissary.kff;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -35,7 +36,7 @@ class KffChainTest extends UnitTest {
             assertEquals("SHA-1", i.next(), "SHA-1 alg present");
             assertEquals("SHA-256", i.next(), "SHA-256 alg present");
         } catch (Exception ex) {
-            throw new AssertionError("Could not compute results: " + ex.getMessage());
+            fail("Could not compute results", ex);
         }
     }
 
@@ -58,7 +59,7 @@ class KffChainTest extends UnitTest {
             assertEquals("SHA-1", i.next(), "SHA-1 alg present");
             assertEquals("SHA-256", i.next(), "SHA-256 alg present");
         } catch (Exception ex) {
-            throw new AssertionError("Could not compute results: " + ex.getMessage());
+            fail("Could not compute results", ex);
         }
     }
 
@@ -96,7 +97,7 @@ class KffChainTest extends UnitTest {
 
             assertFalse(kr.isHit(), "Cannot have a hit on zero length chain");
         } catch (Exception ex) {
-            throw new AssertionError("Could not compute results: " + ex.getMessage());
+            fail("Could not compute results", ex);
         }
     }
 

--- a/src/test/java/emissary/kff/KffDataObjectHandlerTest.java
+++ b/src/test/java/emissary/kff/KffDataObjectHandlerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -57,7 +58,7 @@ class KffDataObjectHandlerTest extends UnitTest {
             String defaultCurrentForm = "test";
             payload = DataObjectFactory.getInstance(data, resource, defaultCurrentForm);
         } catch (IOException e) {
-            throw new AssertionError("Error getting resource file");
+            fail("Error getting resource file");
         }
     }
 

--- a/src/test/java/emissary/kff/KffFileTest.java
+++ b/src/test/java/emissary/kff/KffFileTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import emissary.test.core.UnitTest;
 import emissary.util.io.ResourceReader;
@@ -44,7 +45,7 @@ class KffFileTest extends UnitTest {
         try {
             assertTrue(kffFile.check(expectedShaHash, results));
         } catch (Exception e) {
-            throw new AssertionError();
+            fail(e);
         }
         byte[] incorrectSha1Bytes = {(byte) 0, (byte) 0, (byte) 0, (byte) 32, (byte) 103, (byte) 56, (byte) 116,
                 (byte) -114, (byte) -35, (byte) -110, (byte) -60, (byte) -29, (byte) -46, (byte) -24, (byte) 35, (byte) -119,
@@ -54,7 +55,7 @@ class KffFileTest extends UnitTest {
         try {
             assertFalse(kffFile.check(expectedShaHash, results));
         } catch (Exception e) {
-            throw new AssertionError();
+            fail(e);
         }
     }
 

--- a/src/test/java/emissary/kff/SsdeepTest.java
+++ b/src/test/java/emissary/kff/SsdeepTest.java
@@ -1,6 +1,7 @@
 package emissary.kff;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -33,7 +34,7 @@ final class SsdeepTest extends UnitTest {
         final byte[] input = getStringAsUtf8(text);
         final String hash = ss.fuzzy_hash(input);
         if (!expectedHash.equals(hash)) {
-            throw new AssertionError("input \"" + text + "\" hashed to " + hash + " instead of the expected " + expectedHash);
+            fail("input \"" + text + "\" hashed to " + hash + " instead of the expected " + expectedHash);
         }
     }
 
@@ -80,7 +81,7 @@ final class SsdeepTest extends UnitTest {
         new Random(BIG_RANDOM_ARRAY_SEED).nextBytes(input);
         final String hash = ss.fuzzy_hash(input);
         if (!BIG_RANDOM_EXPECTED_HASH.equals(hash)) {
-            throw new AssertionError("random array (length=" + BIG_RANDOM_ARRAY_LENGTH + ", seed=" + BIG_RANDOM_ARRAY_SEED + ") hashed to \"" + hash
+            fail("random array (length=" + BIG_RANDOM_ARRAY_LENGTH + ", seed=" + BIG_RANDOM_ARRAY_SEED + ") hashed to \"" + hash
                     + "\" instead of the expected \"" + BIG_RANDOM_EXPECTED_HASH + "\"");
         }
     }
@@ -131,7 +132,7 @@ final class SsdeepTest extends UnitTest {
 
         if ((totalInputBytes != MANY_RANDOM_EXPECTED_INPUT_BYTES) || (totalHashChars != MANY_RANDOM_EXPECTED_HASH_CHARS)
                 || !digestHex.equals(MANY_RANDOM_EXPECTED_HEX_DIGEST)) {
-            throw new AssertionError("mismatch in random arrays: expected " + MANY_RANDOM_EXPECTED_INPUT_BYTES + " bytes, "
+            fail("mismatch in random arrays: expected " + MANY_RANDOM_EXPECTED_INPUT_BYTES + " bytes, "
                     + MANY_RANDOM_EXPECTED_HASH_CHARS
                     + " hash characters, digest \"" + MANY_RANDOM_EXPECTED_HEX_DIGEST + "\" but got " + totalInputBytes + ", " + totalHashChars
                     + ", \"" + digestHex + "\"");
@@ -194,7 +195,7 @@ final class SsdeepTest extends UnitTest {
                     b.append(String.format(" (%d: got %d expected %d)", i, scores[i], RANDOM_COMPARE_EXPECTED_SCORES[i]));
                 }
             }
-            throw new AssertionError(b.toString());
+            fail(b.toString());
         }
     }
 }

--- a/src/test/java/emissary/parser/SimpleNioParserTest.java
+++ b/src/test/java/emissary/parser/SimpleNioParserTest.java
@@ -34,7 +34,7 @@ class SimpleNioParserTest extends UnitTest {
             SimpleNioParser sp = new SimpleNioParser(channel);
             assertTrue(sp instanceof SessionParser, "SimpleParser interface definition");
         } catch (ParserException ex) {
-            fail(ex.getMessage());
+            fail("SimpleNioParser is not a SessionParser", ex);
         }
     }
 

--- a/src/test/java/emissary/pickup/WorkBundleTest.java
+++ b/src/test/java/emissary/pickup/WorkBundleTest.java
@@ -145,7 +145,7 @@ class WorkBundleTest extends UnitTest {
         try {
             xml = w.toXml();
         } catch (Exception ex) {
-            fail("Cannot generate xml " + ex);
+            fail("Cannot generate xml", ex);
         }
         assertNotNull(xml, "Generated xml");
         WorkBundle w2 = WorkBundle.buildWorkBundle(xml);
@@ -180,7 +180,7 @@ class WorkBundleTest extends UnitTest {
         try {
             xml = w.toXml();
         } catch (Exception ex) {
-            fail("Cannot generate xml " + ex);
+            fail("Cannot generate xml", ex);
         }
         assertNotNull(xml, "Generated xml");
         WorkBundle w2 = WorkBundle.buildWorkBundle(xml);
@@ -212,7 +212,7 @@ class WorkBundleTest extends UnitTest {
         try {
             xml = w.toXml();
         } catch (Exception ex) {
-            fail("Cannot generate xml " + ex);
+            fail("Cannot generate xml", ex);
         }
         assertNotNull(xml, "Generated xml");
         WorkBundle w2 = WorkBundle.buildWorkBundle(xml);

--- a/src/test/java/emissary/pickup/WorkSpaceTest.java
+++ b/src/test/java/emissary/pickup/WorkSpaceTest.java
@@ -23,7 +23,7 @@ class WorkSpaceTest extends UnitTest {
         try {
             mws = new MyWorkSpace();
         } catch (Exception ex) {
-            fail("Cannot start workspace: " + ex.getMessage());
+            fail("Cannot start workspace", ex);
         }
     }
 

--- a/src/test/java/emissary/pickup/file/FTestSpacePlaceInteraction.java
+++ b/src/test/java/emissary/pickup/file/FTestSpacePlaceInteraction.java
@@ -216,7 +216,7 @@ class FTestSpacePlaceInteraction extends FunctionalTest {
 
             assertEquals(0, space.getPendingQueueSize(), "File no lnger marked pending");
         } catch (IOException ex) {
-            fail("Cannot create extra test file " + ex.getMessage());
+            fail("Cannot create extra test file", ex);
         }
 
         // restart the client with the space already online

--- a/src/test/java/emissary/place/MainTest.java
+++ b/src/test/java/emissary/place/MainTest.java
@@ -45,7 +45,7 @@ final class MainTest extends UnitTest {
         try (OutputStream ros = Files.newOutputStream(dataFile)) {
             ros.write("abcdefghijklmnopqrstuvwxyz".getBytes());
         } catch (IOException ex) {
-            fail("Unable to create test file: " + ex.getMessage());
+            fail("Unable to create test file", ex);
         }
     }
 
@@ -190,7 +190,7 @@ final class MainTest extends UnitTest {
         try {
             m.run();
         } catch (Throwable t) {
-            fail("Main runner allowed exception to escape: " + t);
+            fail("Main runner allowed exception to escape", t);
         }
     }
 
@@ -220,7 +220,7 @@ final class MainTest extends UnitTest {
         try {
             m.run();
         } catch (Throwable t) {
-            fail("Main runner allowed exception to escape: " + t);
+            fail("Main runner allowed exception to escape", t);
         }
         IBaseDataObject payload = DataObjectFactory.getInstance("aaa".getBytes(), "test", "UNKNOWN");
         List<IBaseDataObject> atts = new ArrayList<>();

--- a/src/test/java/emissary/place/ServiceProviderPlaceTest.java
+++ b/src/test/java/emissary/place/ServiceProviderPlaceTest.java
@@ -194,7 +194,7 @@ class ServiceProviderPlaceTest extends UnitTest {
 
             mtp.shutDown();
         } catch (IOException iox) {
-            fail("Could not initialize MyStreamConfigedTestPlace with one arg constructor: " + iox);
+            fail("Could not initialize MyStreamConfigedTestPlace with one arg constructor", iox);
         }
     }
 
@@ -241,7 +241,7 @@ class ServiceProviderPlaceTest extends UnitTest {
 
             mtp.shutDown();
         } catch (IOException iox) {
-            fail("Could not initialize MyFileConfigedTestPlace with one arg constructor: " + iox);
+            fail("Could not initialize MyFileConfigedTestPlace with one arg constructor", iox);
         } finally {
             // Clean up the tmp config settings
             restoreConfig();
@@ -354,7 +354,7 @@ class ServiceProviderPlaceTest extends UnitTest {
             assertEquals(1, proxies.size(), "Size of proxies set");
             assertTrue(proxies.contains("TPROXY"), "Proxies contains original in set");
         } catch (IOException iox) {
-            fail("Place should have configured with SERVICE_KEY: " + iox.getMessage());
+            fail("Place should have configured with SERVICE_KEY", iox);
         }
     }
 
@@ -387,7 +387,7 @@ class ServiceProviderPlaceTest extends UnitTest {
             assertTrue(proxies.contains("TPROXY"), "Proxies contains original in set");
             assertTrue(proxies.contains("TPROXY2"), "Proxies contains original in set");
         } catch (IOException iox) {
-            fail("Place should have configured with SERVICE_KEY: " + iox.getMessage());
+            fail("Place should have configured with SERVICE_KEY: ", iox);
         }
     }
 
@@ -404,7 +404,7 @@ class ServiceProviderPlaceTest extends UnitTest {
             assertEquals(1, keys.size(), "Size of Keys");
 
         } catch (IOException iox) {
-            fail("Place should have configured with SERVICE_KEY: " + iox.getMessage());
+            fail("Place should have configured with SERVICE_KEY", iox);
         }
     }
 
@@ -415,7 +415,7 @@ class ServiceProviderPlaceTest extends UnitTest {
             PlaceTest tp = new PlaceTest(config, null, "PlaceTest");
             assertEquals("TPlaceName", tp.getPlaceName(), "Configured place name");
         } catch (IOException iox) {
-            fail("Place should have configured with SERVICE_KEY: " + iox.getMessage());
+            fail("Place should have configured with SERVICE_KEY", iox);
         }
     }
 
@@ -443,7 +443,7 @@ class ServiceProviderPlaceTest extends UnitTest {
             PlaceTest tp = new PlaceTest();
             assertEquals("TestFooPlace", tp.getPlaceName(), "Configured place name");
         } catch (IOException iox) {
-            fail("Place should have configured with no arg ctor: " + iox.getMessage());
+            fail("Place should have configured with no arg ctor", iox);
         } finally {
             restoreConfig();
         }
@@ -482,7 +482,7 @@ class ServiceProviderPlaceTest extends UnitTest {
                     assertNotNull(place, "Place must be found by service location");
                     assertSame(place, tp, "Place bound by service location must be correct object");
                 } catch (Exception ex) {
-                    throw new AssertionError("Should have found " + sl + " in namespace", ex);
+                    fail("Should have found " + sl + " in namespace", ex);
                 }
             }
 
@@ -495,7 +495,7 @@ class ServiceProviderPlaceTest extends UnitTest {
             assertTrue(proxies.contains("TP3"), "Proxies does not contain original in set");
             assertTrue(proxies.contains("TP4"), "Proxies does not contain original in set");
         } catch (IOException iox) {
-            fail("Place should have configured with SERVICE_KEY: " + iox.getMessage());
+            fail("Place should have configured with SERVICE_KEY", iox);
         }
     }
 
@@ -511,7 +511,7 @@ class ServiceProviderPlaceTest extends UnitTest {
             assertEquals(0, tp.getKeys().size(), "Key size after removal must be 0");
             assertEquals(0, tp.getProxies().size(), "Proxy size after removal must be 0");
         } catch (IOException iox) {
-            fail("Place should have configured with SERVICE_KEY: " + iox.getMessage());
+            fail("Place should have configured with SERVICE_KEY", iox);
         }
     }
 
@@ -526,7 +526,7 @@ class ServiceProviderPlaceTest extends UnitTest {
             assertEquals("TPROXY", tp.getPrimaryProxy(), "Primary proxy present after bogus key removal");
             assertEquals(1, tp.getKeys().size(), "Key size after bogus removal must be 1");
         } catch (IOException iox) {
-            fail("Place should have configured with SERVICE_KEY: " + iox.getMessage());
+            fail("Place should have configured with SERVICE_KEY", iox);
         }
     }
 

--- a/src/test/java/emissary/place/ServiceProviderPlaceTest.java
+++ b/src/test/java/emissary/place/ServiceProviderPlaceTest.java
@@ -387,7 +387,7 @@ class ServiceProviderPlaceTest extends UnitTest {
             assertTrue(proxies.contains("TPROXY"), "Proxies contains original in set");
             assertTrue(proxies.contains("TPROXY2"), "Proxies contains original in set");
         } catch (IOException iox) {
-            fail("Place should have configured with SERVICE_KEY: ", iox);
+            fail("Place should have configured with SERVICE_KEY", iox);
         }
     }
 

--- a/src/test/java/emissary/util/ClassLookupCacheTest.java
+++ b/src/test/java/emissary/util/ClassLookupCacheTest.java
@@ -27,7 +27,7 @@ class ClassLookupCacheTest extends UnitTest {
             final Class<?> clazz = ClassLookupCache.lookup(className);
             assertEquals(expectedClazz, clazz, "lookup of " + className + " should return known class object");
         } catch (ClassNotFoundException e) {
-            fail("could not find the class " + className + ": " + e);
+            fail("could not find the class " + className, e);
         }
     }
 

--- a/src/test/java/emissary/util/MetadataDictionaryUtilTest.java
+++ b/src/test/java/emissary/util/MetadataDictionaryUtilTest.java
@@ -2,6 +2,7 @@ package emissary.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -44,7 +45,7 @@ class MetadataDictionaryUtilTest extends UnitTest {
             assertEquals(1, map.get("key").size());
             assertTrue(map.get("key").contains("val1"));
         } catch (IOException e) {
-            throw new AssertionError("Exception occurred while converting lines to map", e);
+            fail("Exception occurred while converting lines to map", e);
         }
     }
 

--- a/src/test/java/emissary/util/ShortNameComparatorTest.java
+++ b/src/test/java/emissary/util/ShortNameComparatorTest.java
@@ -76,7 +76,7 @@ class ShortNameComparatorTest extends UnitTest {
             l.sort(new ShortNameComparator());
             checkList(l);
         } catch (Exception ex) {
-            fail("Cannot operate Comparator in subclass: " + ex.getMessage());
+            fail("Cannot operate Comparator in subclass", ex);
         } finally {
             DataObjectFactory.setImplementingClass(defaultPayloadClass);
         }

--- a/src/test/java/emissary/util/search/FastBoyerMooreTest.java
+++ b/src/test/java/emissary/util/search/FastBoyerMooreTest.java
@@ -31,7 +31,7 @@ class FastBoyerMooreTest extends UnitTest {
             assertEquals(0, result.get(0)[1], "First result check id");
             assertEquals(3, result.get(0)[2], "First result check length");
         } catch (Exception ex) {
-            fail("Creation of scanner failure: " + ex);
+            fail("Creation of scanner failure", ex);
         }
     }
 


### PR DESCRIPTION
In junit 4, we needed to move fail calls to throw AssertionError because the stacktrace was not printed. As we've updated to junit 5, we can change the methods back to fail because there is an overloaded method to accept the throwable. 