### PR TITLE
io :: remove deprecated observer from the roller framework

### DIFF
--- a/src/main/java/emissary/roll/RollManager.java
+++ b/src/main/java/emissary/roll/RollManager.java
@@ -6,12 +6,12 @@ import emissary.config.Configurator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Observable;
-import java.util.Observer;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * RollManager handles all incremental rolls for configured objects within the framework
  */
-public class RollManager implements Observer {
+public class RollManager implements PropertyChangeListener {
     static final Logger log = LoggerFactory.getLogger(RollManager.class);
     public static final String CFG_ROLL_MANAGER_THREADS = "ROLL_MANAGER_THREADS";
     int executorThreadCount = 10;
@@ -82,7 +82,7 @@ public class RollManager implements Observer {
             exec.scheduleAtFixedRate(r, r.getPeriod(), r.getPeriod(), r.getTimeUnit());
         }
         if (progress) {
-            r.addObserver(this);
+            r.addPropertyChangeListener(this);
         }
         if (time || progress) {
             rollers.add(r);
@@ -93,12 +93,12 @@ public class RollManager implements Observer {
     }
 
     @Override
-    public void update(Observable o, Object arg) {
-        if (rollers.contains(o)) {
-            Roller r = (Roller) o;
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (rollers.contains((Roller) evt.getNewValue())) {
+            Roller r = (Roller) evt.getNewValue();
             // only schedule one time when we're notified
             if (r.setProgressScheduled()) {
-                exec.execute((Roller) o);
+                exec.execute((Roller) evt.getNewValue());
             }
 
         }

--- a/src/test/java/emissary/roll/RollManagerTest.java
+++ b/src/test/java/emissary/roll/RollManagerTest.java
@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.io.IOException;
-import java.util.Observable;
-import java.util.Observer;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -34,7 +34,7 @@ class RollManagerTest extends UnitTest {
         RollManager rm = new RollManager(ConfigUtil.getConfigInfo(this.getClass()));
         Roller r = new Roller(1, TimeUnit.DAYS, 1, new RollableTest());
         RollTestObserver o = new RollTestObserver();
-        r.addObserver(o);
+        r.addPropertyChangeListener(o);
         rm.addRoller(r);
         r.incrementProgress();
         Assertions.assertNotNull(o.o, "Roller notified");
@@ -85,14 +85,14 @@ class RollManagerTest extends UnitTest {
         assertFalse(rm.exec.getQueue().contains(r));
     }
 
-    static class RollTestObserver implements Observer {
-        Observable o;
-        Object arg;
+    static class RollTestObserver implements PropertyChangeListener {
+        Object o;
+        String prop;
 
         @Override
-        public void update(Observable o, Object arg) {
-            this.o = o;
-            this.arg = arg;
+        public void propertyChange(PropertyChangeEvent evt) {
+            this.prop = evt.getPropertyName();
+            this.o = evt.getNewValue();
         }
 
     }

--- a/src/test/java/emissary/roll/RollableTest.java
+++ b/src/test/java/emissary/roll/RollableTest.java
@@ -2,13 +2,13 @@ package emissary.roll;
 
 import emissary.test.core.junit5.UnitTest;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.io.IOException;
-import java.util.Observable;
-import java.util.Observer;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-public class RollableTest extends UnitTest implements Rollable, Observer {
+public class RollableTest extends UnitTest implements Rollable, PropertyChangeListener {
     boolean wasRolled;
     long updateCount;
     ArrayBlockingQueue<Object> x = new ArrayBlockingQueue<>(1);
@@ -36,9 +36,9 @@ public class RollableTest extends UnitTest implements Rollable, Observer {
 
     @SuppressWarnings("unused")
     @Override
-    public void update(Observable o, Object arg) {
-        if (o instanceof Roller) {
-            Roller r = (Roller) o;
+    public void propertyChange(PropertyChangeEvent evt) {
+        if (evt.getNewValue() instanceof Roller) {
+            Roller r = (Roller) evt.getNewValue();
 
             updateCount++;
         }

--- a/src/test/java/emissary/roll/RollerTest.java
+++ b/src/test/java/emissary/roll/RollerTest.java
@@ -15,7 +15,7 @@ class RollerTest extends UnitTest {
     void testRoller() {
         final RollableTest tr = new RollableTest();
         final Roller r = new Roller(1, TimeUnit.DAYS, 1, tr);
-        r.addObserver(tr);
+        r.addPropertyChangeListener(tr);
         r.incrementProgress();
 
         r.run();
@@ -28,7 +28,7 @@ class RollerTest extends UnitTest {
     void testShouldRoll() {
         RollableTest tr = new RollableTest();
         Roller r = new Roller(1, TimeUnit.MILLISECONDS, 1, tr);
-        r.addObserver(tr);
+        r.addPropertyChangeListener(tr);
         r.incrementProgress();
 
         r.run();


### PR DESCRIPTION
Observer/Observable is deprecated as of Java 9, so this updates to use PropertyChangeListener. 