### PR TITLE
(Minor) Use native git with commit-id plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1057,6 +1057,8 @@
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
           <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
           <commitIdGenerationMode>full</commitIdGenerationMode>
+          <!-- Using native git until JGit (which this plugin uses) supports git worktrees -->
+          <useNativeGit>true</useNativeGit>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Since JGit doesn't support git worktrees, the commit-id plugin for Maven also doesn't support them. This is a small tweak to tell it to use native git instead. There wasn't any significant performance degradation from what I saw locally.

See issue 215 on that plugin's GH repo for more details.