### PR TITLE
pom :: allow for native git for git commit id plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <dep.webjars.popper.version>2.9.3</dep.webjars.popper.version>
     <dep.xmlbeans.version>5.0.3</dep.xmlbeans.version>
     <eclipseFormatterStyle>${project.basedir}/contrib/formatter.xml</eclipseFormatterStyle>
+    <git.useNative>false</git.useNative>
     <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -1057,6 +1058,7 @@
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
           <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
           <commitIdGenerationMode>full</commitIdGenerationMode>
+          <useNativeGit>${git.useNative}</useNativeGit>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
follow up to #298 -- use local settings.xml to control the git config. Add to local ~/.m2/settings.xml for testing:
```
  <profiles>
    <profile>
      <id>git-sample-profile</id>
      <properties>
        <git.useNative>true</git.useNative>
      </properties>
    </profile>
  </profiles>
  <activeProfiles>
    <activeProfile>git-sample-profile</activeProfile>
  </activeProfiles>
```