### PR TITLE
Created GitRepositoryState struct for storing git properties and log Git version during server startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1056,7 +1056,7 @@
         <version>4.9.9</version>
         <configuration>
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
-          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+          <generateGitPropertiesFilename>${project.build.outputDirectory}/emissary.git.properties</generateGitPropertiesFilename>
           <commitIdGenerationMode>full</commitIdGenerationMode>
           <useNativeGit>${git.useNative}</useNativeGit>
         </configuration>

--- a/src/main/java/emissary/Emissary.java
+++ b/src/main/java/emissary/Emissary.java
@@ -30,6 +30,7 @@ import emissary.command.StopCommand;
 import emissary.command.TopologyCommand;
 import emissary.command.VersionCommand;
 import emissary.command.WhatCommand;
+import emissary.util.GitRepositoryState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,6 +106,7 @@ public class Emissary {
             }
             EmissaryCommand cmd = commands.get(commandName);
             dumpBanner(cmd);
+            dumpVersionInfo();
             cmd.run(jc);
             // don't exit(0) here or things like server will not continue to run
         } catch (MissingCommandException e) {
@@ -133,6 +135,10 @@ public class Emissary {
 
     private void dumpBanner() {
         dumpBanner(null);
+    }
+
+    protected void dumpVersionInfo() {
+        LOG.info(GitRepositoryState.dumpVersionInfo(GitRepositoryState.getRepositoryState()));
     }
 
     @VisibleForTesting

--- a/src/main/java/emissary/command/ServerCommand.java
+++ b/src/main/java/emissary/command/ServerCommand.java
@@ -12,6 +12,7 @@ import emissary.command.validator.ServerModeValidator;
 import emissary.core.EmissaryException;
 import emissary.server.EmissaryServer;
 import emissary.server.api.Pause;
+import emissary.util.GitRepositoryState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,7 +100,8 @@ public class ServerCommand extends ServiceCommand {
     @Override
     protected void startService() {
         try {
-            LOG.info("Running Emissary Server");
+            LOG.info("Starting Emissary Server - version: {} - built on {} - git hash: {}", GitRepositoryState.getRepositoryState().getBuildVersion(),
+                    GitRepositoryState.getRepositoryState().getBuildTime(), GitRepositoryState.getRepositoryState().getCommitIdAbbrev());
             new EmissaryServer(this).startServer();
         } catch (EmissaryException e) {
             LOG.error("Unable to start server", e);

--- a/src/main/java/emissary/command/ServerCommand.java
+++ b/src/main/java/emissary/command/ServerCommand.java
@@ -12,7 +12,6 @@ import emissary.command.validator.ServerModeValidator;
 import emissary.core.EmissaryException;
 import emissary.server.EmissaryServer;
 import emissary.server.api.Pause;
-import emissary.util.GitRepositoryState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,8 +99,7 @@ public class ServerCommand extends ServiceCommand {
     @Override
     protected void startService() {
         try {
-            LOG.info("Starting Emissary Server - version: {} - built on {} - git hash: {}", GitRepositoryState.getRepositoryState().getBuildVersion(),
-                    GitRepositoryState.getRepositoryState().getBuildTime(), GitRepositoryState.getRepositoryState().getCommitIdAbbrev());
+            LOG.info("Running Emissary Server");
             new EmissaryServer(this).startServer();
         } catch (EmissaryException e) {
             LOG.error("Unable to start server", e);

--- a/src/main/java/emissary/util/GitRepositoryState.java
+++ b/src/main/java/emissary/util/GitRepositoryState.java
@@ -74,6 +74,11 @@ public class GitRepositoryState {
         return new GitRepositoryState(properties);
     }
 
+    public static String dumpVersionInfo(GitRepositoryState gitRepositoryState) {
+        return String.format("Version: %s - built by: %s - built on %s - git hash: %s", gitRepositoryState.buildVersion,
+                gitRepositoryState.buildUserName, gitRepositoryState.buildTime, gitRepositoryState.getCommitIdAbbrev());
+    }
+
     public String getTags() {
         return tags;
     }

--- a/src/main/java/emissary/util/GitRepositoryState.java
+++ b/src/main/java/emissary/util/GitRepositoryState.java
@@ -1,0 +1,152 @@
+package emissary.util;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * POJO for parsing and returning values from a git properties file. The properties file is created during the maven
+ * build process by the git-commit-id-maven-plugin
+ *
+ */
+public class GitRepositoryState {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GitRepositoryState.class);
+
+    private final String tags;
+    private final String branch;
+    private final String dirty;
+    private final String remoteOriginUrl;
+    private final String commitIdAbbrev;
+    private final String describe;
+    private final String describeShort;
+    private final String commitUserName;
+    private final String commitUserEmail;
+    private final String commitMessageFull;
+    private final String commitMessageShort;
+    private final String commitTime;
+    private final String closestTagName;
+    private final String closestTagCommitCount;
+    private final String buildUserName;
+    private final String buildUserEmail;
+    private final String buildTime;
+    private final String buildHost;
+    private final String buildVersion;
+
+    private GitRepositoryState(Properties properties) {
+
+        this.tags = properties.get("git.tags").toString();
+        this.branch = properties.get("git.branch").toString();
+        this.dirty = properties.get("git.dirty").toString();
+        this.remoteOriginUrl = properties.get("git.remote.origin.url").toString();
+
+        this.commitIdAbbrev = properties.get("git.commit.id.abbrev").toString();
+        this.describe = properties.get("git.commit.id.describe").toString();
+        this.describeShort = properties.get("git.commit.id.describe-short").toString();
+        this.commitUserName = properties.get("git.commit.user.name").toString();
+        this.commitUserEmail = properties.get("git.commit.user.email").toString();
+        this.commitMessageFull = properties.get("git.commit.message.full").toString();
+        this.commitMessageShort = properties.get("git.commit.message.short").toString();
+        this.commitTime = properties.get("git.commit.time").toString();
+        this.closestTagName = properties.get("git.closest.tag.name").toString();
+        this.closestTagCommitCount = properties.get("git.closest.tag.commit.count").toString();
+
+        this.buildUserName = properties.get("git.build.user.name").toString();
+        this.buildUserEmail = properties.get("git.build.user.email").toString();
+        this.buildTime = properties.get("git.build.time").toString();
+        this.buildHost = properties.get("git.build.host").toString();
+        this.buildVersion = properties.get("git.build.version").toString();
+    }
+
+    public static GitRepositoryState getRepositoryState() {
+        return getRepositoryState("emissary.git.properties");
+    }
+
+    public static GitRepositoryState getRepositoryState(String gitProperties) {
+        Properties properties = new Properties();
+        try {
+            properties.load(GitRepositoryState.class.getClassLoader().getResourceAsStream(gitProperties));
+        } catch (IOException ie) {
+            LOG.error("Failed to get repository state", ie);
+        }
+        return new GitRepositoryState(properties);
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public String getBranch() {
+        return branch;
+    }
+
+    public String getDirty() {
+        return dirty;
+    }
+
+    public String getRemoteOriginUrl() {
+        return remoteOriginUrl;
+    }
+
+    public String getCommitIdAbbrev() {
+        return commitIdAbbrev;
+    }
+
+    public String getDescribe() {
+        return describe;
+    }
+
+    public String getDescribeShort() {
+        return describeShort;
+    }
+
+    public String getCommitUserName() {
+        return commitUserName;
+    }
+
+    public String getCommitUserEmail() {
+        return commitUserEmail;
+    }
+
+    public String getCommitMessageFull() {
+        return commitMessageFull;
+    }
+
+    public String getCommitMessageShort() {
+        return commitMessageShort;
+    }
+
+    public String getCommitTime() {
+        return commitTime;
+    }
+
+    public String getClosestTagName() {
+        return closestTagName;
+    }
+
+    public String getClosestTagCommitCount() {
+        return closestTagCommitCount;
+    }
+
+    public String getBuildUserName() {
+        return buildUserName;
+    }
+
+    public String getBuildUserEmail() {
+        return buildUserEmail;
+    }
+
+    public String getBuildTime() {
+        return buildTime;
+    }
+
+    public String getBuildHost() {
+        return buildHost;
+    }
+
+    public String getBuildVersion() {
+        return buildVersion;
+    }
+}


### PR DESCRIPTION
Knowing what version of emissary was actually deployed and running would have been helpful in troubleshooting an issue today.
The goal of this PR was to use the git.properties file that is created by the git-commit-id plugin and store the values in a way that is accessible by the running application. 

I did not create tests yet for GitRepositoryState() If that is something that is deemed necessary then I will do that. 

Sample log message:
```
2022-09-07 23:10:28,537 localhost-8001  INFO emissary.command.ServerCommand -   - Starting Emissary Server - version: 7.9.0-SNAPSHOT - built on 2022-09-07T23:08:38+0000 - git hash: 68d40dc
```