### PR TITLE
Add application name to git version log output and remove build username

### DIFF
--- a/src/main/java/emissary/Emissary.java
+++ b/src/main/java/emissary/Emissary.java
@@ -138,7 +138,7 @@ public class Emissary {
     }
 
     protected void dumpVersionInfo() {
-        LOG.info(GitRepositoryState.dumpVersionInfo(GitRepositoryState.getRepositoryState()));
+        LOG.info(GitRepositoryState.dumpVersionInfo(GitRepositoryState.getRepositoryState(), "Emissary"));
     }
 
     @VisibleForTesting

--- a/src/main/java/emissary/util/GitRepositoryState.java
+++ b/src/main/java/emissary/util/GitRepositoryState.java
@@ -74,8 +74,8 @@ public class GitRepositoryState {
         return new GitRepositoryState(properties);
     }
 
-    public static String dumpVersionInfo(GitRepositoryState gitRepositoryState) {
-        return String.format("Version: %s - built by: %s - built on %s - git hash: %s", gitRepositoryState.buildVersion,
+    public static String dumpVersionInfo(GitRepositoryState gitRepositoryState, String applicationName) {
+        return String.format("%s Version: %s - built by: %s - built on %s - git hash: %s", applicationName, gitRepositoryState.buildVersion,
                 gitRepositoryState.buildUserName, gitRepositoryState.buildTime, gitRepositoryState.getCommitIdAbbrev());
     }
 

--- a/src/main/java/emissary/util/GitRepositoryState.java
+++ b/src/main/java/emissary/util/GitRepositoryState.java
@@ -75,8 +75,8 @@ public class GitRepositoryState {
     }
 
     public static String dumpVersionInfo(GitRepositoryState gitRepositoryState, String applicationName) {
-        return String.format("%s Version: %s - built by: %s - built on %s - git hash: %s", applicationName, gitRepositoryState.buildVersion,
-                gitRepositoryState.buildUserName, gitRepositoryState.buildTime, gitRepositoryState.getCommitIdAbbrev());
+        return String.format("%s Version: %s - built on %s - git hash: %s", applicationName, gitRepositoryState.buildVersion,
+                gitRepositoryState.buildTime, gitRepositoryState.getCommitIdAbbrev());
     }
 
     public String getTags() {


### PR DESCRIPTION
When integrating the new version log output I found it to be confusing to not have the application in the message. Especially if the banner above is for a different down stream component.

Sample message:
```
Emissary Version: 7.9.0-SNAPSHOT - built on 2022-09-16T18:59:59+0000 - git hash: 4781a14
```