### PR TITLE
WIP Adding DateTimeFormats class to load date/time formats used in the application

### DIFF
--- a/src/main/java/emissary/spi/DateTimeFormatsInitializationProvider.java
+++ b/src/main/java/emissary/spi/DateTimeFormatsInitializationProvider.java
@@ -1,0 +1,11 @@
+package emissary.spi;
+
+import emissary.util.DateTimeFormats;
+
+public class DateTimeFormatsInitializationProvider implements InitializationProvider {
+
+    @Override
+    public void initialize() {
+        DateTimeFormats.initialize();
+    }
+}

--- a/src/main/java/emissary/util/DateTimeFormats.java
+++ b/src/main/java/emissary/util/DateTimeFormats.java
@@ -1,0 +1,46 @@
+package emissary.util;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import emissary.config.ConfigEntry;
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DateTimeFormats {
+
+    protected final Logger logger = LoggerFactory.getLogger(DateTimeFormats.class);
+    private static HashMap<String, String> formats;
+
+    public DateTimeFormats() {
+
+        formats = new HashMap<>();
+
+        try {
+            Configurator configG = ConfigUtil.getConfigInfo(DateTimeFormats.class);
+            for (ConfigEntry entry : configG.getEntries()) {
+                formats.put(entry.getKey(), entry.getValue());
+            }
+        } catch (IOException e) {
+            logger.error("There was an error loading DateTime formats: {}", e);
+        }
+    }
+
+    public static DateTimeFormats initialize() {
+        DateTimeFormats dtf = new DateTimeFormats();
+        return dtf;
+    }
+
+    /**
+     * Given the name of a date/time format, return the format as a string
+     * 
+     * @param formatName The name of the format to retrieve
+     * @return The corresponding date/time format, or null if it does not exist
+     */
+    public static String getFormat(String formatName) {
+        return formats.get(formatName);
+    }
+
+}

--- a/src/main/resources/META-INF/services/emissary.spi.InitializationProvider
+++ b/src/main/resources/META-INF/services/emissary.spi.InitializationProvider
@@ -1,2 +1,3 @@
 emissary.spi.JavaCharSetInitializationProvider
 emissary.spi.MetadataDictionaryInitializationProvider
+emissary.spi.DateTimeFormatsInitializationProvider

--- a/src/main/resources/emissary/util/DateTimeFormats.cfg
+++ b/src/main/resources/emissary/util/DateTimeFormats.cfg
@@ -1,0 +1,7 @@
+
+DATE_FORMAT_YEAR = "yyyy"
+DATE_FORMAT_YEAR_DAY = "yyyy-DD"
+
+DATE_TIME_1 = "yyyy MMM dd HH ss mm"
+
+DATE_TIME_ZONED_1 = "yyyy-MM-dd'T'HH:mm:ss z"

--- a/src/test/java/emissary/util/TimeUtilTest.java
+++ b/src/test/java/emissary/util/TimeUtilTest.java
@@ -15,6 +15,7 @@ import java.time.zone.ZoneRulesException;
 import java.util.Date;
 
 import emissary.test.core.junit5.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class TimeUtilTest extends UnitTest {
@@ -24,16 +25,26 @@ class TimeUtilTest extends UnitTest {
     private static final LocalDateTime testLocalDate = LocalDateTime.of(2016, Month.DECEMBER, 25, 15, 30, 25);
     private static final Date testUtilDate = Date.from(testLocalDate.toInstant(ZoneOffset.UTC));
     private static final ZonedDateTime testZoneDate = ZonedDateTime.of(testLocalDate, GMT);
+    private static String DATE_TIME_FORMAT;
+    private static String DATE_TIME_ZONED_FORMAT;
+
+    @BeforeEach
+    void setup() {
+        DateTimeFormats.initialize();
+        DATE_TIME_FORMAT = DateTimeFormats.getFormat("DATE_TIME_1");
+        DATE_TIME_ZONED_FORMAT = DateTimeFormats.getFormat("DATE_TIME_ZONED_1");
+    }
 
     @Test
     void testGetDate() {
-        assertEquals("2016 Dec 25 15 25 30", TimeUtil.getDate(testZoneDate, "yyyy MMM dd HH ss mm", GMT), "getDate did not match");
-        assertEquals("2016-12-25T15:30:25 GMT", TimeUtil.getDate(testZoneDate, "yyyy-MM-dd'T'HH:mm:ss z", null), "getDate did not match");
+        assertEquals("2016 Dec 25 15 25 30", TimeUtil.getDate(testZoneDate, DATE_TIME_FORMAT, GMT), "getDate did not match");
+        assertEquals("2016-12-25T15:30:25 GMT", TimeUtil.getDate(testZoneDate, DATE_TIME_ZONED_FORMAT, null), "getDate did not match");
         assertEquals("2016-12-25T14:30:25 GMT",
-                TimeUtil.getDate(ZonedDateTime.of(testLocalDate, ZoneId.of("Europe/Paris")), "yyyy-MM-dd'T'HH:mm:ss z", GMT),
+
+                TimeUtil.getDate(ZonedDateTime.of(testLocalDate, ZoneId.of("Europe/Paris")), DATE_TIME_ZONED_FORMAT, GMT),
                 "getDate did not match");
         assertEquals("2016-12-25T15:30:25 CET",
-                TimeUtil.getDate(ZonedDateTime.of(testLocalDate, ZoneId.of("Europe/Paris")), "yyyy-MM-dd'T'HH:mm:ss z", PARIS),
+                TimeUtil.getDate(ZonedDateTime.of(testLocalDate, ZoneId.of("Europe/Paris")), DATE_TIME_ZONED_FORMAT, PARIS),
                 "getDate did not match");
         assertNull(TimeUtil.getDate(null, null, null));
     }
@@ -51,7 +62,7 @@ class TimeUtilTest extends UnitTest {
 
     @Test
     void testGetDateExceptionBadZone() {
-        assertThrows(ZoneRulesException.class, () -> TimeUtil.getDate("yyyy", "BAD"));
+        assertThrows(ZoneRulesException.class, () -> TimeUtil.getDate(DateTimeFormats.getFormat("DATE_YEAR"), "BAD"));
     }
 
     @Deprecated
@@ -137,11 +148,11 @@ class TimeUtilTest extends UnitTest {
 
     @Test
     void testTimeZoneAddedOnFormat() {
-        String dt = TimeUtil.getDate("yyyy-MM-dd'T'HH:mm:ss z", null);
+        String dt = TimeUtil.getDate(DATE_TIME_ZONED_FORMAT, null);
         assertTrue(dt.contains("GMT"), "GMT must be added by default - " + dt);
 
         // timezone changes due to daylight savings
-        dt = TimeUtil.getDate("yyyy-MM-dd'T'HH:mm:ss z", "Europe/Paris");
+        dt = TimeUtil.getDate(DATE_TIME_ZONED_FORMAT, "Europe/Paris");
         assertTrue(dt.contains("CET") || dt.contains("CEST"), "Specified tz must be added - " + dt);
     }
 


### PR DESCRIPTION
Initial commit as part of effort to declare date/time formats used by DateTimeFormatter or SimpleDateFormat all in one place. Going forward we can reference the config file instead of re-typing these formats in multiple places.
DateTimeFormats.cfg can be overridden to load other formats.