### PR TITLE
Add file change verify to maven builds

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,3 +38,14 @@ jobs:
 
     - name: Build with Maven
       run: mvn -B --no-transfer-progress verify --file pom.xml
+
+    - name: Verify Changed Files
+      uses: tj-actions/verify-changed-files@v12
+      id: verify-changed-files
+
+    - name: Run step only when files change
+      if: steps.verify-changed-files.outputs.files_changed == 'true'
+      uses: actions/github-script@v6.3.3
+      with:
+        script: |
+          core.setFailed('Changed files found: ${{ steps.verify-changed-files.outputs.changed_files }}')


### PR DESCRIPTION
This will make the check's fail if a file changes during a build. This is primarily caused by the auto format and changes from it not being committed.
To view an example of the check failing: https://github.com/NationalSecurityAgency/emissary/actions/runs/3260922729/jobs/5354949963