### PR TITLE
Add environment check to enable object metrics appender

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -523,7 +523,7 @@
     <dependency>
       <groupId>org.codehaus.janino</groupId>
       <artifactId>janino</artifactId>
-      <version>3.1.8</version>
+      <version>3.1.7</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -521,6 +521,11 @@
       <artifactId>xmlbeans</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.codehaus.janino</groupId>
+      <artifactId>janino</artifactId>
+      <version>3.1.8</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-plus</artifactId>
     </dependency>

--- a/src/main/config/emissary.output.DropOffPlace.cfg
+++ b/src/main/config/emissary.output.DropOffPlace.cfg
@@ -37,7 +37,7 @@ OUTPUT_FILTER = "JSON:emissary.output.filter.JsonOutputFilter"
 
 IMPORT_FILE = "emissary.output.DropOffUtil.cfg"
 
-OUTPUT_OBJECT_METRICS = "true"
+OUTPUT_OBJECT_METRICS = "@ENV{'LogObjectMetrics'}"
 OBJECT_METRICS_LATENCY = ""
 OBJECT_METRICS_LATENCY_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
 OBJECT_METRICS_FIELDS = "FILETYPE"

--- a/src/main/config/logback.xml
+++ b/src/main/config/logback.xml
@@ -20,31 +20,34 @@
     </encoder>
   </appender>
 
+  <!-- Enable output metrics logging by creating an environment variable of "LogObjectMetrics=true" -->
+  <if condition='${LogObjectMetrics} == true'>
+    <then>
+      <appender name="OBJECT-METRICS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+          <customFields>{"node":"${emissary.node.name}","port":"${emissary.node.port}","application":"server"}</customFields>
+          <includeMdc>false</includeMdc>
+          <fieldNames>
+            <version>[ignore]</version>
+            <logValue>[ignore]</logValue>
+            <logger>[ignore]</logger>
+            <thread>[ignore]</thread>
+            <levelValue>[ignore]</levelValue>
+            <level>[ignore]</level>
+            <message>[ignore]</message>
+          </fieldNames>
+        </encoder>
+        <file>logs/${emissary.node.name}-${emissary.node.port}-object-metrics.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+          <fileNamePattern>logs/${emissary.node.name}-${emissary.node.port}-object-metrics.log.%d{yyyy-MM-dd-HH}</fileNamePattern>
+        </rollingPolicy>
+      </appender>
 
-  <appender name="OBJECT-METRICS" class="ch.qos.logback.core.ConsoleAppender">
-    <!--<appender name="OBJECT-METRICS" class="ch.qos.logback.core.rolling.RollingFileAppender">-->
-    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-      <customFields>{"node":"${emissary.node.name}","port":"${emissary.node.port}","application":"server"}</customFields>
-      <includeMdc>false</includeMdc>
-      <fieldNames>
-        <version>[ignore]</version>
-        <logValue>[ignore]</logValue>
-        <logger>[ignore]</logger>
-        <thread>[ignore]</thread>
-        <levelValue>[ignore]</levelValue>
-        <level>[ignore]</level>
-        <message>[ignore]</message>
-      </fieldNames>
-    </encoder>
-    <!--<file>logs/${emissary.node.name}-${emissary.node.port}-object-metrics.log</file>
-    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>logs/${emissary.node.name}-${emissary.node.port}-object-metrics.log.%d{yyyy-MM-dd-HH}</fileNamePattern>
-    </rollingPolicy>-->
-  </appender>
-
-  <logger name="objectMetrics" level="INFO" additivity="false">
-    <appender-ref ref="OBJECT-METRICS" />
-  </logger>
+      <logger name="objectMetrics" level="INFO" additivity="false">
+        <appender-ref ref="OBJECT-METRICS" />
+      </logger>
+    </then>
+  </if>
 
   <root level="INFO">
     <!-- stop logging to a file in development man, redirect or tee to a file

--- a/src/main/resources/emissary/output/DropOffPlace.cfg
+++ b/src/main/resources/emissary/output/DropOffPlace.cfg
@@ -35,7 +35,7 @@ OUTPUT_FILTER = "emissary.output.filter.DataFilter"
 
 IMPORT_FILE = "emissary.output.DropOffUtil.cfg"
 
-OUTPUT_OBJECT_METRICS = "true"
+OUTPUT_OBJECT_METRICS = "@ENV{'LogObjectMetrics'}"
 OBJECT_METRICS_LATENCY = ""
 OBJECT_METRICS_LATENCY_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
 OBJECT_METRICS_FIELDS = "FILETYPE"


### PR DESCRIPTION
We need a way to control what logback appenders are enabled based on the environment that they are running in.
This will enable/disable the object metrics appender based on an environment variable.
I still need to test this more to see if this will work.