### PR TITLE
1944 Sorting imports, enforce import sort for checkstyle

### DIFF
--- a/contrib/checkstyle.xml
+++ b/contrib/checkstyle.xml
@@ -140,12 +140,16 @@
     </module>
     <module name="OverloadMethodsDeclarationOrder"/>
     <module name="VariableDeclarationUsageDistance"/>
-    <module name="CustomImportOrder">
-      <property name="severity" value="ignore"/>
-      <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
-      <property name="specialImportsRegExp" value="com.google"/>
-      <property name="sortImportsInGroupAlphabetically" value="true"/>
-      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    <module name="ImportOrder">
+      <!-- entering an invalid value for severity essential disables this check -->
+      <!-- valid values are ignore, info, warning, error -->
+      <property name="severity" value="error"/>
+      <property name="option" value="bottom"/> <!-- static imports at bottom-->
+      <property name="groups" value="emissary,*,/java.*/"/>
+      <property name="ordered" value="true"/>
+      <property name="separated" value="true"/>
+      <property name="separatedStaticGroups" value="false"/>
+      <property name="sortStaticImportsAlphabetically" value="true"/>
     </module>
     <module name="MethodParamPad"/>
     <module name="OperatorWrap">

--- a/pom.xml
+++ b/pom.xml
@@ -687,10 +687,11 @@
           </configuration>
           <executions>
             <execution>
-              <id>sort-imports</id>
+              <id>sort-java-imports</id>
               <goals>
                 <goal>sort</goal>
               </goals>
+              <phase>generate-sources</phase>
             </execution>
           </executions>
         </plugin>
@@ -717,14 +718,14 @@
               <goals>
                 <goal>format</goal>
               </goals>
-              <phase>process-sources</phase>
+              <phase>generate-sources</phase>
             </execution>
             <execution>
               <id>format-java-test-sources</id>
               <goals>
                 <goal>format</goal>
               </goals>
-              <phase>process-test-sources</phase>
+              <phase>generate-test-sources</phase>
             </execution>
           </executions>
         </plugin>
@@ -739,8 +740,14 @@
           <version>3.1.1</version>
           <configuration>
             <configLocation>${checkstyleFormatter}</configLocation>
-            <!-- TODO change this to warning when the build is cleaned up and stable, to catch new problems -->
-            <violationSeverity>warn</violationSeverity>
+            <!-- this combination of these two configurations
+              (failOnViolation=true and violationSeverity=error) means
+              any checks with severity=error will fail the build -->
+            <!-- TODO enforce more checkstyle categories as the build gets cleaned up -->
+            <!-- As you fix checkstyle warning categories, change the severity of that category
+              to "error" so it will fail the build if new violations of that category get introduced. -->
+            <failOnViolation>true</failOnViolation>
+            <violationSeverity>error</violationSeverity>
             <includeTestSourceDirectory>true</includeTestSourceDirectory>
             <excludes />
           </configuration>
@@ -753,10 +760,18 @@
           </dependencies>
           <executions>
             <execution>
-              <id>check-style</id>
+              <id>checkstyle-sources</id>
               <goals>
                 <goal>check</goal>
               </goals>
+              <phase>process-sources</phase>
+            </execution>
+            <execution>
+              <id>checkstyle-test-sources</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <phase>process-test-sources</phase>
             </execution>
           </executions>
         </plugin>
@@ -1260,7 +1275,8 @@
       <id>checkstyle</id>
       <activation>
         <property>
-          <name>code-quality</name>
+          <!-- skip with -DskipCheckstyle -->
+          <name>!skipCheckstyle</name>
         </property>
       </activation>
       <build>
@@ -1348,8 +1364,33 @@
             <artifactId>sortpom-maven-plugin</artifactId>
           </plugin>
           <plugin>
+            <!-- Sort java imports -->
             <groupId>net.revelc.code</groupId>
             <artifactId>impsort-maven-plugin</artifactId>
+            <version>1.6.2</version>
+            <!--TODO update to latest once we move past JDK11 -->
+            <configuration>
+              <groups>emissary,*,java</groups>
+              <staticGroups>*</staticGroups>
+              <staticAfter>true</staticAfter>
+              <removeUnused>true</removeUnused>
+            </configuration>
+            <executions>
+              <execution>
+                <id>impsort-sources</id>
+                <goals>
+                  <goal>sort</goal>
+                </goals>
+                <phase>generate-sources</phase>
+              </execution>
+              <execution>
+                <id>impsort-test-sources</id>
+                <goals>
+                  <goal>sort</goal>
+                </goals>
+                <phase>generate-test-sources</phase>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>net.revelc.code.formatter</groupId>

--- a/src/main/java/emissary/Emissary.java
+++ b/src/main/java/emissary/Emissary.java
@@ -1,23 +1,5 @@
 package emissary;
 
-import java.io.PrintStream;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeSet;
-
-import javax.annotation.Nullable;
-
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.ConsoleAppender;
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.MissingCommandException;
-import com.google.common.annotations.VisibleForTesting;
 import emissary.command.AgentsCommand;
 import emissary.command.Banner;
 import emissary.command.EmissaryCommand;
@@ -33,8 +15,26 @@ import emissary.command.TopologyCommand;
 import emissary.command.VersionCommand;
 import emissary.command.WhatCommand;
 import emissary.util.GitRepositoryState;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.ConsoleAppender;
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.MissingCommandException;
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import javax.annotation.Nullable;
 
 /**
  * Main entry point of the jar file

--- a/src/main/java/emissary/admin/PlaceStarter.java
+++ b/src/main/java/emissary/admin/PlaceStarter.java
@@ -1,12 +1,5 @@
 package emissary.admin;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.annotation.Nullable;
-
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
 import emissary.core.EmissaryException;
@@ -18,9 +11,16 @@ import emissary.directory.DirectoryPlace;
 import emissary.directory.IDirectoryPlace;
 import emissary.directory.KeyManipulator;
 import emissary.place.IServiceProviderPlace;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Static methods to start places in the system.

--- a/src/main/java/emissary/admin/Startup.java
+++ b/src/main/java/emissary/admin/Startup.java
@@ -1,5 +1,17 @@
 package emissary.admin;
 
+import emissary.config.Configurator;
+import emissary.config.ServiceConfigGuide;
+import emissary.core.EmissaryException;
+import emissary.core.Namespace;
+import emissary.directory.EmissaryNode;
+import emissary.directory.KeyManipulator;
+import emissary.pickup.PickUpPlace;
+import emissary.place.IServiceProviderPlace;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,19 +23,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
 import javax.annotation.Nullable;
-
-import emissary.config.Configurator;
-import emissary.config.ServiceConfigGuide;
-import emissary.core.EmissaryException;
-import emissary.core.Namespace;
-import emissary.directory.EmissaryNode;
-import emissary.directory.KeyManipulator;
-import emissary.pickup.PickUpPlace;
-import emissary.place.IServiceProviderPlace;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Startup {
 

--- a/src/main/java/emissary/analyze/Analyzer.java
+++ b/src/main/java/emissary/analyze/Analyzer.java
@@ -1,12 +1,12 @@
 package emissary.analyze;
 
+import emissary.core.IBaseDataObject;
+import emissary.place.ServiceProviderPlace;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Set;
-
-import emissary.core.IBaseDataObject;
-import emissary.place.ServiceProviderPlace;
 
 /**
  * Base class for analyzers

--- a/src/main/java/emissary/client/EmissaryClient.java
+++ b/src/main/java/emissary/client/EmissaryClient.java
@@ -1,16 +1,9 @@
 package emissary.client;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.Nullable;
-import javax.ws.rs.core.MediaType;
-
-import com.google.common.annotations.VisibleForTesting;
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
+
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.http.HttpEntity;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
@@ -37,6 +30,13 @@ import org.eclipse.jetty.util.security.Password;
 import org.glassfish.jersey.server.filter.CsrfProtectionFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import javax.ws.rs.core.MediaType;
 
 /**
  * Base class of all the actions that use HttpClient.

--- a/src/main/java/emissary/client/EmissaryResponse.java
+++ b/src/main/java/emissary/client/EmissaryResponse.java
@@ -1,13 +1,8 @@
 package emissary.client;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-
-import javax.ws.rs.core.MediaType;
+import emissary.client.response.BaseEntity;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import emissary.client.response.BaseEntity;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -16,6 +11,11 @@ import org.apache.http.HttpResponse;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import javax.ws.rs.core.MediaType;
 
 public class EmissaryResponse {
 

--- a/src/main/java/emissary/client/HTTPConnectionFactory.java
+++ b/src/main/java/emissary/client/HTTPConnectionFactory.java
@@ -1,20 +1,10 @@
 package emissary.client;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-import java.security.KeyStore;
-import java.security.SecureRandom;
-
-import javax.annotation.Nullable;
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManagerFactory;
-
-import com.google.common.annotations.VisibleForTesting;
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
 import emissary.util.PkiUtil;
+
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.http.ConnectionReuseStrategy;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
@@ -29,6 +19,16 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.SecureRandom;
+import javax.annotation.Nullable;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 
 /**
  * Emissary HTTP Connection Factory. This is a singleton class that allows for the central configuration of an Apache

--- a/src/main/java/emissary/client/response/Agent.java
+++ b/src/main/java/emissary/client/response/Agent.java
@@ -1,13 +1,12 @@
 package emissary.client.response;
 
-import java.io.Serializable;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.io.Serializable;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
-
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @XmlAccessorType(XmlAccessType.NONE)
 public class Agent implements Comparable<Agent>, Serializable {

--- a/src/main/java/emissary/client/response/AgentList.java
+++ b/src/main/java/emissary/client/response/AgentList.java
@@ -1,16 +1,15 @@
 package emissary.client.response;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Serializable;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @XmlAccessorType(XmlAccessType.NONE)
 public class AgentList implements Serializable {

--- a/src/main/java/emissary/client/response/AgentsFormatter.java
+++ b/src/main/java/emissary/client/response/AgentsFormatter.java
@@ -1,7 +1,8 @@
 package emissary.client.response;
 
-import com.google.gson.JsonObject;
 import emissary.util.TimeUtil;
+
+import com.google.gson.JsonObject;
 
 /**
  * Formatter for Emissary MobileAgents. Currently,supports json output, but could be expanded to support any number of

--- a/src/main/java/emissary/client/response/AgentsResponseEntity.java
+++ b/src/main/java/emissary/client/response/AgentsResponseEntity.java
@@ -5,7 +5,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;

--- a/src/main/java/emissary/client/response/BaseResponseEntity.java
+++ b/src/main/java/emissary/client/response/BaseResponseEntity.java
@@ -3,7 +3,6 @@ package emissary.client.response;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAccessOrder;
 import javax.xml.bind.annotation.XmlAccessType;

--- a/src/main/java/emissary/client/response/MapResponseEntity.java
+++ b/src/main/java/emissary/client/response/MapResponseEntity.java
@@ -1,15 +1,14 @@
 package emissary.client.response;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Map;
 import java.util.TreeMap;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @XmlRootElement(name = "mapResponseEntity")
 @XmlAccessorType(XmlAccessType.NONE)

--- a/src/main/java/emissary/client/response/PeerList.java
+++ b/src/main/java/emissary/client/response/PeerList.java
@@ -1,14 +1,13 @@
 package emissary.client.response;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Serializable;
 import java.util.Set;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @XmlAccessorType(XmlAccessType.NONE)
 public class PeerList implements Serializable {

--- a/src/main/java/emissary/client/response/PeersResponseEntity.java
+++ b/src/main/java/emissary/client/response/PeersResponseEntity.java
@@ -1,15 +1,14 @@
 package emissary.client.response;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @XmlRootElement(name = "peers")
 @XmlAccessorType(XmlAccessType.NONE)

--- a/src/main/java/emissary/client/response/PlaceList.java
+++ b/src/main/java/emissary/client/response/PlaceList.java
@@ -1,16 +1,15 @@
 package emissary.client.response;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Serializable;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @XmlAccessorType(XmlAccessType.NONE)
 public class PlaceList implements Serializable {

--- a/src/main/java/emissary/client/response/PlacesResponseEntity.java
+++ b/src/main/java/emissary/client/response/PlacesResponseEntity.java
@@ -1,16 +1,15 @@
 package emissary.client.response;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @XmlRootElement(name = "places")
 @XmlAccessorType(XmlAccessType.NONE)

--- a/src/main/java/emissary/command/AgentsCommand.java
+++ b/src/main/java/emissary/command/AgentsCommand.java
@@ -1,11 +1,12 @@
 package emissary.command;
 
-import static emissary.server.api.Agents.AGENTS_ENDPOINT;
-
-import com.beust.jcommander.Parameters;
 import emissary.client.EmissaryClient;
 import emissary.client.response.AgentsResponseEntity;
+
+import com.beust.jcommander.Parameters;
 import org.apache.http.client.methods.HttpGet;
+
+import static emissary.server.api.Agents.AGENTS_ENDPOINT;
 
 @Parameters(commandDescription = "List all the agents for a given node or all nodes in the cluster")
 public class AgentsCommand extends MonitorCommand<AgentsResponseEntity> {

--- a/src/main/java/emissary/command/BaseCommand.java
+++ b/src/main/java/emissary/command/BaseCommand.java
@@ -1,10 +1,8 @@
 package emissary.command;
 
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
+import emissary.command.converter.PathExistsConverter;
+import emissary.command.converter.ProjectBaseConverter;
+import emissary.config.ConfigUtil;
 
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.util.ContextInitializer;
@@ -12,11 +10,14 @@ import ch.qos.logback.core.joran.spi.JoranException;
 import ch.qos.logback.core.joran.util.ConfigurationWatchListUtil;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
-import emissary.command.converter.PathExistsConverter;
-import emissary.command.converter.ProjectBaseConverter;
-import emissary.config.ConfigUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 
 public abstract class BaseCommand implements EmissaryCommand {
 

--- a/src/main/java/emissary/command/EnvCommand.java
+++ b/src/main/java/emissary/command/EnvCommand.java
@@ -1,5 +1,7 @@
 package emissary.command;
 
+import emissary.client.EmissaryClient;
+
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
@@ -8,7 +10,6 @@ import ch.qos.logback.core.ConsoleAppender;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import emissary.client.EmissaryClient;
 import org.apache.http.client.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/emissary/command/FeedCommand.java
+++ b/src/main/java/emissary/command/FeedCommand.java
@@ -1,22 +1,23 @@
 package emissary.command;
 
-import java.nio.file.Paths;
-import java.util.Comparator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-
-import com.beust.jcommander.Parameter;
-import com.beust.jcommander.ParameterException;
-import com.beust.jcommander.Parameters;
 import emissary.command.converter.PriorityDirectoryConverter;
 import emissary.command.converter.WorkspaceSortModeConverter;
 import emissary.pickup.PriorityDirectory;
 import emissary.pickup.WorkBundle;
 import emissary.pickup.WorkSpace;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
 import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 @Parameters(commandDescription = "Start the feeder process given a particular WorkSpace implemetation to distribute work to peer nodes")
 public class FeedCommand extends ServiceCommand {

--- a/src/main/java/emissary/command/HelpCommand.java
+++ b/src/main/java/emissary/command/HelpCommand.java
@@ -1,15 +1,15 @@
 package emissary.command;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map.Entry;
-
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
 
 @Parameters(commandDescription = "Print commands or usage for subcommand")
 public class HelpCommand implements EmissaryCommand {

--- a/src/main/java/emissary/command/HttpCommand.java
+++ b/src/main/java/emissary/command/HttpCommand.java
@@ -1,19 +1,20 @@
 package emissary.command;
 
-import java.io.File;
-import java.util.LinkedHashSet;
-import java.util.Set;
-
-import com.beust.jcommander.Parameter;
-import com.google.common.net.HostAndPort;
 import emissary.client.EmissaryClient;
 import emissary.client.EmissaryResponse;
 import emissary.command.converter.FileExistsConverter;
 import emissary.directory.EmissaryNode;
+
+import com.beust.jcommander.Parameter;
+import com.google.common.net.HostAndPort;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /* abstract command to configure http options
  * <p>

--- a/src/main/java/emissary/command/MonitorCommand.java
+++ b/src/main/java/emissary/command/MonitorCommand.java
@@ -1,15 +1,16 @@
 package emissary.command;
 
-import java.io.IOException;
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
+import emissary.client.EmissaryClient;
+import emissary.client.response.BaseResponseEntity;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
-import emissary.client.EmissaryClient;
-import emissary.client.response.BaseResponseEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 public abstract class MonitorCommand<T extends BaseResponseEntity> extends HttpCommand {
 

--- a/src/main/java/emissary/command/PeersCommand.java
+++ b/src/main/java/emissary/command/PeersCommand.java
@@ -1,16 +1,17 @@
 package emissary.command;
 
-import java.io.IOException;
-import java.util.Set;
-import java.util.TreeSet;
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+import emissary.directory.KeyManipulator;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.common.net.HostAndPort;
-import emissary.config.ConfigUtil;
-import emissary.config.Configurator;
-import emissary.directory.KeyManipulator;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.TreeSet;
 
 // TODO Had to extend Http in order to get node host/port substitution. MAybe move up to BaseCommand?
 @Parameters(commandDescription = "Read the peers.cfg (respective flavors) and return hosts as bashable list")

--- a/src/main/java/emissary/command/PoolCommand.java
+++ b/src/main/java/emissary/command/PoolCommand.java
@@ -1,13 +1,14 @@
 package emissary.command;
 
-import static emissary.server.api.Pool.POOL_ENDPOINT;
-
-import com.beust.jcommander.Parameters;
 import emissary.client.EmissaryClient;
 import emissary.client.response.MapResponseEntity;
+
+import com.beust.jcommander.Parameters;
 import org.apache.http.client.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static emissary.server.api.Pool.POOL_ENDPOINT;
 
 @Parameters(commandDescription = "List the active/idle agents in the pool for a given node or all nodes in the cluster")
 public class PoolCommand extends MonitorCommand<MapResponseEntity> {

--- a/src/main/java/emissary/command/RunCommand.java
+++ b/src/main/java/emissary/command/RunCommand.java
@@ -1,16 +1,16 @@
 package emissary.command;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @Deprecated
 @Parameters(commandDescription = "Run arbitrary class with optional args")

--- a/src/main/java/emissary/command/ServerCommand.java
+++ b/src/main/java/emissary/command/ServerCommand.java
@@ -1,19 +1,20 @@
 package emissary.command;
 
-import java.nio.file.Path;
-import java.util.LinkedHashSet;
-import java.util.Set;
-
-import com.beust.jcommander.Parameter;
-import com.beust.jcommander.Parameters;
 import emissary.client.EmissaryResponse;
 import emissary.command.converter.ProjectBaseConverter;
 import emissary.command.validator.ServerModeValidator;
 import emissary.core.EmissaryException;
 import emissary.server.EmissaryServer;
 import emissary.server.api.Pause;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 @Parameters(commandDescription = "Start an Emissary jetty server")
 public class ServerCommand extends ServiceCommand {

--- a/src/main/java/emissary/command/ServiceCommand.java
+++ b/src/main/java/emissary/command/ServiceCommand.java
@@ -1,15 +1,16 @@
 package emissary.command;
 
-import static emissary.server.api.HealthCheckAction.HEALTH;
-import static emissary.server.api.Shutdown.SHUTDOWN;
+import emissary.client.EmissaryResponse;
+import emissary.directory.EmissaryNode;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
-import emissary.client.EmissaryResponse;
-import emissary.directory.EmissaryNode;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static emissary.server.api.HealthCheckAction.HEALTH;
+import static emissary.server.api.Shutdown.SHUTDOWN;
 
 /**
  * Abstract command to control service components (stop/pause/unpause)

--- a/src/main/java/emissary/command/StopCommand.java
+++ b/src/main/java/emissary/command/StopCommand.java
@@ -1,12 +1,13 @@
 package emissary.command;
 
-import static emissary.command.ServiceCommand.SERVICE_SHUTDOWN_ENDPOINT;
+import emissary.client.EmissaryResponse;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameters;
-import emissary.client.EmissaryResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static emissary.command.ServiceCommand.SERVICE_SHUTDOWN_ENDPOINT;
 
 /**
  * Use the {@link ServiceCommand} --stop flag to stop a running server

--- a/src/main/java/emissary/command/TopologyCommand.java
+++ b/src/main/java/emissary/command/TopologyCommand.java
@@ -1,9 +1,10 @@
 package emissary.command;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.Parameters;
 import emissary.client.EmissaryClient;
 import emissary.client.response.PeersResponseEntity;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameters;
 import org.apache.http.client.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/emissary/command/VersionCommand.java
+++ b/src/main/java/emissary/command/VersionCommand.java
@@ -1,15 +1,16 @@
 package emissary.command;
 
-import java.io.FileDescriptor;
-import java.io.FileOutputStream;
-import java.io.PrintStream;
+import emissary.util.Version;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import emissary.util.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
 
 @Parameters(commandDescription = "Dump the Emissary version")
 public class VersionCommand implements EmissaryCommand {

--- a/src/main/java/emissary/command/WhatCommand.java
+++ b/src/main/java/emissary/command/WhatCommand.java
@@ -1,19 +1,5 @@
 package emissary.command;
 
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
-import javax.annotation.Nullable;
-
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.Parameter;
-import com.beust.jcommander.Parameters;
 import emissary.command.converter.PathExistsReadableConverter;
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
@@ -32,8 +18,22 @@ import emissary.parser.SessionParser;
 import emissary.parser.SessionProducer;
 import emissary.place.IServiceProviderPlace;
 import emissary.util.shell.Executrix;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 @Deprecated
 @Parameters(commandDescription = "Run Identification places on a payload to determine the file type")

--- a/src/main/java/emissary/command/converter/FileExistsConverter.java
+++ b/src/main/java/emissary/command/converter/FileExistsConverter.java
@@ -1,13 +1,13 @@
 package emissary.command.converter;
 
+import com.beust.jcommander.converters.BaseConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import com.beust.jcommander.converters.BaseConverter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class FileExistsConverter extends BaseConverter<File> {
 

--- a/src/main/java/emissary/command/converter/PathExistsConverter.java
+++ b/src/main/java/emissary/command/converter/PathExistsConverter.java
@@ -1,12 +1,12 @@
 package emissary.command.converter;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 import com.beust.jcommander.converters.BaseConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class PathExistsConverter extends BaseConverter<Path> {
 

--- a/src/main/java/emissary/command/converter/PathExistsReadableConverter.java
+++ b/src/main/java/emissary/command/converter/PathExistsReadableConverter.java
@@ -1,10 +1,10 @@
 package emissary.command.converter;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class PathExistsReadableConverter extends PathExistsConverter {
 

--- a/src/main/java/emissary/command/converter/PriorityDirectoryConverter.java
+++ b/src/main/java/emissary/command/converter/PriorityDirectoryConverter.java
@@ -1,8 +1,9 @@
 package emissary.command.converter;
 
-import com.beust.jcommander.IStringConverter;
 import emissary.pickup.Priority;
 import emissary.pickup.PriorityDirectory;
+
+import com.beust.jcommander.IStringConverter;
 
 public class PriorityDirectoryConverter implements IStringConverter<PriorityDirectory> {
     public static final String PRIORITY_DIR_REGEX = ".*:\\d+$";

--- a/src/main/java/emissary/command/converter/ProjectBaseConverter.java
+++ b/src/main/java/emissary/command/converter/ProjectBaseConverter.java
@@ -1,10 +1,10 @@
 package emissary.command.converter;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class ProjectBaseConverter extends PathExistsConverter {
 

--- a/src/main/java/emissary/command/converter/WorkspaceSortModeConverter.java
+++ b/src/main/java/emissary/command/converter/WorkspaceSortModeConverter.java
@@ -1,11 +1,12 @@
 package emissary.command.converter;
 
-import java.util.Comparator;
+import emissary.pickup.WorkBundle;
 
 import com.beust.jcommander.IStringConverter;
-import emissary.pickup.WorkBundle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Comparator;
 
 public class WorkspaceSortModeConverter implements IStringConverter<Comparator<WorkBundle>> {
     private static final Logger LOG = LoggerFactory.getLogger(WorkspaceSortModeConverter.class);

--- a/src/main/java/emissary/config/ConfigUtil.java
+++ b/src/main/java/emissary/config/ConfigUtil.java
@@ -1,5 +1,11 @@
 package emissary.config;
 
+import emissary.core.EmissaryException;
+import emissary.util.io.ResourceReader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -12,11 +18,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-
-import emissary.core.EmissaryException;
-import emissary.util.io.ResourceReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This configuration utility collection helps to find configuration for various classes and objects. It responds to

--- a/src/main/java/emissary/config/ExtractResource.java
+++ b/src/main/java/emissary/config/ExtractResource.java
@@ -1,15 +1,16 @@
 package emissary.config;
 
+import emissary.util.io.ResourceReader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-
-import emissary.util.io.ResourceReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class assists users and integrators by extracting the named resource and putting it into the config directory

--- a/src/main/java/emissary/config/ServiceConfigGuide.java
+++ b/src/main/java/emissary/config/ServiceConfigGuide.java
@@ -1,5 +1,9 @@
 package emissary.config;
 
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileWriter;
@@ -24,12 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-
 import javax.annotation.Nullable;
-
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class implements the Configurator interface for services within the Emissary framework.

--- a/src/main/java/emissary/core/AgentPoolHealthCheck.java
+++ b/src/main/java/emissary/core/AgentPoolHealthCheck.java
@@ -1,8 +1,9 @@
 package emissary.core;
 
-import com.codahale.metrics.health.HealthCheck;
 import emissary.pool.AgentPool;
 import emissary.pool.MobileAgentFactory;
+
+import com.codahale.metrics.health.HealthCheck;
 
 public class AgentPoolHealthCheck extends HealthCheck {
 

--- a/src/main/java/emissary/core/BaseDataObject.java
+++ b/src/main/java/emissary/core/BaseDataObject.java
@@ -1,5 +1,15 @@
 package emissary.core;
 
+import emissary.directory.DirectoryEntry;
+import emissary.pickup.Priority;
+import emissary.util.ByteUtil;
+import emissary.util.PayloadUtil;
+
+import com.google.common.collect.LinkedListMultimap;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -16,17 +26,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
-
 import javax.annotation.Nullable;
-
-import com.google.common.collect.LinkedListMultimap;
-import emissary.directory.DirectoryEntry;
-import emissary.pickup.Priority;
-import emissary.util.ByteUtil;
-import emissary.util.PayloadUtil;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Class to hold byte array of data, header, footer, and attributes

--- a/src/main/java/emissary/core/DataObjectFactory.java
+++ b/src/main/java/emissary/core/DataObjectFactory.java
@@ -1,11 +1,12 @@
 package emissary.core;
 
-import java.io.IOException;
-
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 /**
  * Factory implementation to provide an instance of whichever BaseDataObject implementation is configured for the system

--- a/src/main/java/emissary/core/Factory.java
+++ b/src/main/java/emissary/core/Factory.java
@@ -6,16 +6,17 @@
 
 package emissary.core;
 
+import emissary.util.ClassLookupCache;
+import emissary.util.ConstructorLookupCache;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import emissary.util.ClassLookupCache;
-import emissary.util.ConstructorLookupCache;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Factory.create() is one of the main methods that Emissary uses. This method simply constructs objects in the server

--- a/src/main/java/emissary/core/FilePickUpPlaceHealthCheck.java
+++ b/src/main/java/emissary/core/FilePickUpPlaceHealthCheck.java
@@ -1,12 +1,13 @@
 package emissary.core;
 
+import emissary.pickup.file.FilePickUpPlace;
+
+import com.codahale.metrics.health.HealthCheck;
+import org.apache.commons.io.filefilter.HiddenFileFilter;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.lang.reflect.Field;
-
-import com.codahale.metrics.health.HealthCheck;
-import emissary.pickup.file.FilePickUpPlace;
-import org.apache.commons.io.filefilter.HiddenFileFilter;
 
 /**
  * A health check that warns if the input data queue is larger than a given threshold or if the aggregate file size is

--- a/src/main/java/emissary/core/HDMobileAgent.java
+++ b/src/main/java/emissary/core/HDMobileAgent.java
@@ -1,21 +1,21 @@
 package emissary.core;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-
-import javax.annotation.Nullable;
-
 import emissary.directory.DirectoryEntry;
 import emissary.directory.KeyManipulator;
 import emissary.log.MDCConstants;
 import emissary.place.EmptyFormPlace;
 import emissary.place.IServiceProviderPlace;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * This mobile agent carries around an ArrayList of payload that can be added onto instead of sprouting. The agent is

--- a/src/main/java/emissary/core/MetadataDictionary.java
+++ b/src/main/java/emissary/core/MetadataDictionary.java
@@ -1,5 +1,12 @@
 package emissary.core;
 
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+
+import org.apache.commons.collections4.map.LRUMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -7,14 +14,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.annotation.Nullable;
-
-import emissary.config.ConfigUtil;
-import emissary.config.Configurator;
-import org.apache.commons.collections4.map.LRUMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class provides metadata renaming and remapping based on values in its configuration file. There are a set of

--- a/src/main/java/emissary/core/MetricsFormatter.java
+++ b/src/main/java/emissary/core/MetricsFormatter.java
@@ -1,9 +1,9 @@
 package emissary.core;
 
-import java.util.concurrent.TimeUnit;
-
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Formatter for metrics data, following the existing format emissary format, established previously. Employs the

--- a/src/main/java/emissary/core/MetricsManager.java
+++ b/src/main/java/emissary/core/MetricsManager.java
@@ -1,11 +1,7 @@
 package emissary.core;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
-import java.util.concurrent.TimeUnit;
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
@@ -24,10 +20,15 @@ import com.codahale.metrics.jvm.FileDescriptorRatioGauge;
 import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
 import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
-import emissary.config.ConfigUtil;
-import emissary.config.Configurator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Manages the interactions with CodaHale's Metrics package, including configuration

--- a/src/main/java/emissary/core/MobileAgent.java
+++ b/src/main/java/emissary/core/MobileAgent.java
@@ -1,12 +1,5 @@
 package emissary.core;
 
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-
-import javax.annotation.Nullable;
-
 import emissary.directory.DirectoryEntry;
 import emissary.directory.DirectoryPlace;
 import emissary.directory.KeyManipulator;
@@ -18,9 +11,16 @@ import emissary.pool.AgentPool;
 import emissary.pool.AgentThreadGroup;
 import emissary.util.JMXUtil;
 import emissary.util.PayloadUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * An autonomous hunk of software

--- a/src/main/java/emissary/core/Namespace.java
+++ b/src/main/java/emissary/core/Namespace.java
@@ -6,15 +6,15 @@
 
 package emissary.core;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
-
 import com.google.common.collect.Sets;
 import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This class is used by Emissary core to manage named classes. Each registered place gets a name which includes the

--- a/src/main/java/emissary/core/Pausable.java
+++ b/src/main/java/emissary/core/Pausable.java
@@ -1,9 +1,9 @@
 package emissary.core;
 
-import java.util.concurrent.TimeUnit;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
 
 public abstract class Pausable extends Thread implements IPausable {
 

--- a/src/main/java/emissary/core/ResourceWatcher.java
+++ b/src/main/java/emissary/core/ResourceWatcher.java
@@ -1,5 +1,14 @@
 package emissary.core;
 
+import emissary.place.IServiceProviderPlace;
+
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.reflect.Field;
 import java.util.Iterator;
 import java.util.Map;
@@ -8,14 +17,6 @@ import java.util.SortedMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-
-import com.codahale.metrics.ExponentiallyDecayingReservoir;
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
-import emissary.place.IServiceProviderPlace;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Track mobile agents and make them obey resource limitations

--- a/src/main/java/emissary/core/TimedResource.java
+++ b/src/main/java/emissary/core/TimedResource.java
@@ -1,11 +1,12 @@
 package emissary.core;
 
-import java.util.concurrent.locks.ReentrantLock;
+import emissary.place.IServiceProviderPlace;
 
 import com.codahale.metrics.Timer;
-import emissary.place.IServiceProviderPlace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Class to help track the things we are interested in monitoring

--- a/src/main/java/emissary/core/TransformHistory.java
+++ b/src/main/java/emissary/core/TransformHistory.java
@@ -1,12 +1,12 @@
 package emissary.core;
 
+import emissary.directory.KeyManipulator;
+import emissary.place.IServiceProviderPlace;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import emissary.directory.KeyManipulator;
-import emissary.place.IServiceProviderPlace;
 
 public class TransformHistory {
 

--- a/src/main/java/emissary/directory/DirectoryAdapter.java
+++ b/src/main/java/emissary/directory/DirectoryAdapter.java
@@ -1,10 +1,11 @@
 package emissary.directory;
 
-import java.util.Set;
-
 import emissary.core.EmissaryException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Set;
 
 /**
  * This class implements all of the emissary.directory.DirectoryPlace observer interfaces with null implementations so

--- a/src/main/java/emissary/directory/DirectoryEntry.java
+++ b/src/main/java/emissary/directory/DirectoryEntry.java
@@ -1,17 +1,18 @@
 package emissary.directory;
 
-import static emissary.directory.KeyManipulator.CLASSSEPARATOR;
-import static emissary.directory.KeyManipulator.DOLLAR;
-
-import java.io.Serializable;
-
 import emissary.core.Namespace;
 import emissary.core.NamespaceException;
 import emissary.place.IServiceProviderPlace;
 import emissary.util.xml.JDOMUtil;
+
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+
+import static emissary.directory.KeyManipulator.CLASSSEPARATOR;
+import static emissary.directory.KeyManipulator.DOLLAR;
 
 /**
  * This class is container object for storing directory entry information such as the service name and type, the

--- a/src/main/java/emissary/directory/DirectoryEntryList.java
+++ b/src/main/java/emissary/directory/DirectoryEntryList.java
@@ -1,5 +1,10 @@
 package emissary.directory;
 
+import org.apache.commons.lang3.StringUtils;
+import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -7,13 +12,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-
 import javax.annotation.Nullable;
-
-import org.apache.commons.lang3.StringUtils;
-import org.jdom2.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Hold a set of Directory keys (four-tuples) in sorted order by expense, cheapest first, no duplicates

--- a/src/main/java/emissary/directory/DirectoryEntryMap.java
+++ b/src/main/java/emissary/directory/DirectoryEntryMap.java
@@ -1,15 +1,14 @@
 package emissary.directory;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
 import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Keep a map of DataID to DirectoryEntryList for the Directory Extensible to use other things for the key if desired,

--- a/src/main/java/emissary/directory/DirectoryObserverManager.java
+++ b/src/main/java/emissary/directory/DirectoryObserverManager.java
@@ -1,11 +1,11 @@
 package emissary.directory;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class is used by DirectoryPlace to manage the interaction with the different types of observers that need to be

--- a/src/main/java/emissary/directory/DirectoryPlace.java
+++ b/src/main/java/emissary/directory/DirectoryPlace.java
@@ -1,5 +1,15 @@
 package emissary.directory;
 
+import emissary.config.Configurator;
+import emissary.core.EmissaryException;
+import emissary.core.IBaseDataObject;
+import emissary.core.Namespace;
+import emissary.log.MDCConstants;
+import emissary.place.ServiceProviderPlace;
+import emissary.server.mvc.adapters.DirectoryAdapter;
+
+import org.slf4j.MDC;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -9,17 +19,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArraySet;
-
 import javax.annotation.Nullable;
-
-import emissary.config.Configurator;
-import emissary.core.EmissaryException;
-import emissary.core.IBaseDataObject;
-import emissary.core.Namespace;
-import emissary.log.MDCConstants;
-import emissary.place.ServiceProviderPlace;
-import emissary.server.mvc.adapters.DirectoryAdapter;
-import org.slf4j.MDC;
 
 /**
  * The DirectoryPlace class is used to store information relating to Places/Services in the Emissary Agent-Based

--- a/src/main/java/emissary/directory/DirectoryXmlContainer.java
+++ b/src/main/java/emissary/directory/DirectoryXmlContainer.java
@@ -1,16 +1,16 @@
 package emissary.directory;
 
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.Nullable;
-
 import emissary.util.xml.SaferJDOMUtil;
+
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * This class acts as a container and producer for turning a directory entry list into a full xml document

--- a/src/main/java/emissary/directory/EmissaryNode.java
+++ b/src/main/java/emissary/directory/EmissaryNode.java
@@ -1,12 +1,5 @@
 package emissary.directory;
 
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.List;
-
 import emissary.admin.Startup;
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
@@ -17,8 +10,16 @@ import emissary.pool.MobileAgentFactory;
 import emissary.pool.MoveSpool;
 import emissary.roll.RollManager;
 import emissary.spi.SPILoader;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Hold some details about being a P2P node in the emissary network The order of preference to find the node

--- a/src/main/java/emissary/directory/HeartbeatManager.java
+++ b/src/main/java/emissary/directory/HeartbeatManager.java
@@ -1,5 +1,18 @@
 package emissary.directory;
 
+import emissary.client.EmissaryClient;
+import emissary.client.EmissaryResponse;
+import emissary.core.Namespace;
+import emissary.core.NamespaceException;
+import emissary.server.mvc.adapters.HeartbeatAdapter;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.message.BasicNameValuePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -7,20 +20,7 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
-
 import javax.annotation.Nullable;
-
-import emissary.client.EmissaryClient;
-import emissary.client.EmissaryResponse;
-import emissary.core.Namespace;
-import emissary.core.NamespaceException;
-import emissary.server.mvc.adapters.HeartbeatAdapter;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.message.BasicNameValuePair;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Facility for directory instances to check up on each other by sending a heartbeat message

--- a/src/main/java/emissary/directory/IDirectoryPlace.java
+++ b/src/main/java/emissary/directory/IDirectoryPlace.java
@@ -1,9 +1,9 @@
 package emissary.directory;
 
+import emissary.place.IServiceProviderPlace;
+
 import java.util.List;
 import java.util.Set;
-
-import emissary.place.IServiceProviderPlace;
 
 /**
  * Interface for normal directory operations

--- a/src/main/java/emissary/directory/IRemoteDirectory.java
+++ b/src/main/java/emissary/directory/IRemoteDirectory.java
@@ -1,13 +1,13 @@
 package emissary.directory;
 
-import java.util.List;
-import java.util.Set;
-
-import javax.annotation.Nullable;
-
 import emissary.core.Namespace;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Interface for inter-directory operations over http These methods are designed to only be called by the remote

--- a/src/main/java/emissary/directory/KeyManipulator.java
+++ b/src/main/java/emissary/directory/KeyManipulator.java
@@ -1,10 +1,9 @@
 package emissary.directory;
 
-import java.io.Serializable;
-
-import javax.annotation.Nullable;
-
 import emissary.place.IServiceProviderPlace;
+
+import java.io.Serializable;
+import javax.annotation.Nullable;
 
 /**
  * A class of utility methods for manipulating dictionary keys. Keys are stored in the dictionary with the following

--- a/src/main/java/emissary/directory/WildcardEntry.java
+++ b/src/main/java/emissary/directory/WildcardEntry.java
@@ -1,13 +1,13 @@
 package emissary.directory;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Handle the details of a wildcard directory entry including iterating through the possible directory match strings A

--- a/src/main/java/emissary/id/IdPlace.java
+++ b/src/main/java/emissary/id/IdPlace.java
@@ -1,17 +1,16 @@
 package emissary.id;
 
+import emissary.config.Configurator;
+import emissary.core.Form;
+import emissary.core.IBaseDataObject;
+import emissary.place.ServiceProviderPlace;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-
 import javax.annotation.Nullable;
-
-import emissary.config.Configurator;
-import emissary.core.Form;
-import emissary.core.IBaseDataObject;
-import emissary.place.ServiceProviderPlace;
 
 /**
  * Abstract class that is the parent of all places that operate in the ID phase of the workflow.

--- a/src/main/java/emissary/id/SizeIdPlace.java
+++ b/src/main/java/emissary/id/SizeIdPlace.java
@@ -1,10 +1,10 @@
 package emissary.id;
 
+import emissary.core.IBaseDataObject;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-
-import emissary.core.IBaseDataObject;
 
 /**
  * Id place that sets the current form based on size of the data

--- a/src/main/java/emissary/id/TikaFilePlace.java
+++ b/src/main/java/emissary/id/TikaFilePlace.java
@@ -1,5 +1,15 @@
 package emissary.id;
 
+import emissary.core.IBaseDataObject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.tika.io.TikaInputStream;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.mime.MediaType;
+import org.apache.tika.mime.MimeTypeException;
+import org.apache.tika.mime.MimeTypes;
+import org.apache.tika.mime.MimeTypesFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -9,15 +19,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import emissary.core.IBaseDataObject;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.tika.io.TikaInputStream;
-import org.apache.tika.metadata.Metadata;
-import org.apache.tika.mime.MediaType;
-import org.apache.tika.mime.MimeTypeException;
-import org.apache.tika.mime.MimeTypes;
-import org.apache.tika.mime.MimeTypesFactory;
 
 /**
  * Perform file identification tests using the configured TIKA_SIGNATURE_FILE to drive the identification process

--- a/src/main/java/emissary/id/UnixFilePlace.java
+++ b/src/main/java/emissary/id/UnixFilePlace.java
@@ -1,11 +1,11 @@
 package emissary.id;
 
+import emissary.core.IBaseDataObject;
+import emissary.util.UnixFile;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
-
-import emissary.core.IBaseDataObject;
-import emissary.util.UnixFile;
 
 /**
  * Accesses emissary.util.UnixFile to perform file identification tests using emissary.util.UnixFile

--- a/src/main/java/emissary/jni/JNI.java
+++ b/src/main/java/emissary/jni/JNI.java
@@ -1,16 +1,5 @@
 package emissary.jni;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.Nullable;
-
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
 import emissary.core.EmissaryException;
@@ -20,8 +9,19 @@ import emissary.directory.DirectoryEntry;
 import emissary.directory.DirectoryPlace;
 import emissary.directory.IDirectoryPlace;
 import emissary.directory.KeyManipulator;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Provide methods for retrieving native libraries from the repository The main entry point is loadLibrary. Places

--- a/src/main/java/emissary/jni/JniRepositoryPlace.java
+++ b/src/main/java/emissary/jni/JniRepositoryPlace.java
@@ -1,5 +1,8 @@
 package emissary.jni;
 
+import emissary.core.IBaseDataObject;
+import emissary.place.ServiceProviderPlace;
+
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -8,9 +11,6 @@ import java.io.IOException;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.List;
-
-import emissary.core.IBaseDataObject;
-import emissary.place.ServiceProviderPlace;
 
 public class JniRepositoryPlace extends ServiceProviderPlace {
 

--- a/src/main/java/emissary/kff/ChecksumCalculator.java
+++ b/src/main/java/emissary/kff/ChecksumCalculator.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.zip.CRC32;
-
 import javax.annotation.Nullable;
 
 /**

--- a/src/main/java/emissary/kff/KffChain.java
+++ b/src/main/java/emissary/kff/KffChain.java
@@ -1,13 +1,12 @@
 package emissary.kff;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
 import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Keep a list of hash algorithm names and compute them and compare the results to the ordered chain of KFF filter when

--- a/src/main/java/emissary/kff/KffChainLoader.java
+++ b/src/main/java/emissary/kff/KffChainLoader.java
@@ -1,14 +1,15 @@
 package emissary.kff;
 
+import emissary.core.Factory;
+import emissary.kff.KffFilter.FilterType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
-
-import emissary.core.Factory;
-import emissary.kff.KffFilter.FilterType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Loads a chain of file filter specified by the configuration subsystem Expects to find a configuration file with a

--- a/src/main/java/emissary/kff/KffDataObjectHandler.java
+++ b/src/main/java/emissary/kff/KffDataObjectHandler.java
@@ -1,13 +1,13 @@
 package emissary.kff;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.annotation.Nullable;
-
 import emissary.core.IBaseDataObject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * A helpful class to set and evaluate the KFF details of a BaseDataObject

--- a/src/main/java/emissary/kff/KffFile.java
+++ b/src/main/java/emissary/kff/KffFile.java
@@ -1,14 +1,13 @@
 package emissary.kff;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
-
 import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * KffFile provides access to the known file filter data. The NIST/NSRL data is a CSV file with other information. It

--- a/src/main/java/emissary/kff/KffMemcached.java
+++ b/src/main/java/emissary/kff/KffMemcached.java
@@ -1,5 +1,16 @@
 package emissary.kff;
 
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+import emissary.util.Hexl;
+
+import net.spy.memcached.ConnectionFactoryBuilder;
+import net.spy.memcached.ConnectionFactoryBuilder.Protocol;
+import net.spy.memcached.FailureMode;
+import net.spy.memcached.MemcachedClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.LinkedList;
@@ -7,18 +18,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
 import javax.annotation.Nullable;
-
-import emissary.config.ConfigUtil;
-import emissary.config.Configurator;
-import emissary.util.Hexl;
-import net.spy.memcached.ConnectionFactoryBuilder;
-import net.spy.memcached.ConnectionFactoryBuilder.Protocol;
-import net.spy.memcached.FailureMode;
-import net.spy.memcached.MemcachedClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * KffMemcached checks Emissary hashes against a set of external memcached servers. If a given Emissary hash does not

--- a/src/main/java/emissary/kff/KffResult.java
+++ b/src/main/java/emissary/kff/KffResult.java
@@ -1,12 +1,12 @@
 package emissary.kff;
 
+import emissary.kff.KffFilter.FilterType;
+
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-
-import emissary.kff.KffFilter.FilterType;
 
 /**
  * Provide results of a KFF check including the details of the hash or cryptographic sum or sums that were used.

--- a/src/main/java/emissary/kff/Ssdeep.java
+++ b/src/main/java/emissary/kff/Ssdeep.java
@@ -1,15 +1,14 @@
 package emissary.kff;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.Arrays;
-
 import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A java port of the ssdeep code for "fuzzy hashing". http://ssdeep.sourceforge.net There are a number of ports out

--- a/src/main/java/emissary/output/DropOffPlace.java
+++ b/src/main/java/emissary/output/DropOffPlace.java
@@ -1,6 +1,16 @@
 package emissary.output;
 
-import static net.logstash.logback.marker.Markers.appendEntries;
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+import emissary.core.DataObjectFactory;
+import emissary.core.Form;
+import emissary.core.IBaseDataObject;
+import emissary.output.filter.IDropOffFilter;
+import emissary.place.ServiceProviderPlace;
+import emissary.util.DataUtil;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -14,16 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import emissary.config.ConfigUtil;
-import emissary.config.Configurator;
-import emissary.core.DataObjectFactory;
-import emissary.core.Form;
-import emissary.core.IBaseDataObject;
-import emissary.output.filter.IDropOffFilter;
-import emissary.place.ServiceProviderPlace;
-import emissary.util.DataUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static net.logstash.logback.marker.Markers.appendEntries;
 
 /**
  * DropOffPlace manages the output from the system It has evolved into a controller of sorts with way too many options,

--- a/src/main/java/emissary/output/DropOffUtil.java
+++ b/src/main/java/emissary/output/DropOffUtil.java
@@ -1,5 +1,14 @@
 package emissary.output;
 
+import emissary.config.Configurator;
+import emissary.core.Family;
+import emissary.core.IBaseDataObject;
+import emissary.util.shell.Executrix;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.security.SecureRandom;
@@ -17,16 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SimpleTimeZone;
 import java.util.UUID;
-
 import javax.annotation.Nullable;
-
-import emissary.config.Configurator;
-import emissary.core.Family;
-import emissary.core.IBaseDataObject;
-import emissary.util.shell.Executrix;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DropOffUtil {
     protected static final Logger logger = LoggerFactory.getLogger(DropOffUtil.class);

--- a/src/main/java/emissary/output/filter/AbstractFilter.java
+++ b/src/main/java/emissary/output/filter/AbstractFilter.java
@@ -1,5 +1,14 @@
 package emissary.output.filter;
 
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+import emissary.core.IBaseDataObject;
+import emissary.output.DropOffUtil;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
@@ -10,16 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.annotation.Nullable;
-
-import emissary.config.ConfigUtil;
-import emissary.config.Configurator;
-import emissary.core.IBaseDataObject;
-import emissary.output.DropOffUtil;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Provides the base mechanism for a drop off filter

--- a/src/main/java/emissary/output/filter/AbstractRollableFilter.java
+++ b/src/main/java/emissary/output/filter/AbstractRollableFilter.java
@@ -1,17 +1,5 @@
 package emissary.output.filter;
 
-import static emissary.roll.Roller.CFG_ROLL_INTERVAL;
-
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
 import emissary.core.IBaseDataObject;
@@ -23,7 +11,20 @@ import emissary.pool.AgentPool;
 import emissary.roll.RollManager;
 import emissary.roll.Roller;
 import emissary.util.io.FileNameGenerator;
+
 import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static emissary.roll.Roller.CFG_ROLL_INTERVAL;
 
 public abstract class AbstractRollableFilter extends AbstractFilter {
 

--- a/src/main/java/emissary/output/filter/DataFilter.java
+++ b/src/main/java/emissary/output/filter/DataFilter.java
@@ -1,18 +1,17 @@
 package emissary.output.filter;
 
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.Map;
-import java.util.Set;
-
-import javax.annotation.Nullable;
-
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
 import emissary.core.IBaseDataObject;
 import emissary.output.DropOffPlace;
 import emissary.output.DropOffUtil;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Filter that writes unadorned data as raw bytes

--- a/src/main/java/emissary/output/filter/IFilterCondition.java
+++ b/src/main/java/emissary/output/filter/IFilterCondition.java
@@ -1,9 +1,9 @@
 package emissary.output.filter;
 
-import java.util.List;
-
 import emissary.config.Configurator;
 import emissary.core.IBaseDataObject;
+
+import java.util.List;
 
 /**
  * Defines a simple interface for accepting a filter condition

--- a/src/main/java/emissary/output/filter/JsonOutputFilter.java
+++ b/src/main/java/emissary/output/filter/JsonOutputFilter.java
@@ -1,18 +1,9 @@
 package emissary.output.filter;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
-
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.UUID;
-
-import javax.annotation.Nullable;
+import emissary.config.Configurator;
+import emissary.core.IBaseDataObject;
+import emissary.directory.DirectoryEntry;
+import emissary.util.TimeUtil;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -32,11 +23,20 @@ import com.fasterxml.jackson.databind.ser.PropertyWriter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.fasterxml.jackson.databind.ser.std.MapProperty;
-import emissary.config.Configurator;
-import emissary.core.IBaseDataObject;
-import emissary.directory.DirectoryEntry;
-import emissary.util.TimeUtil;
 import org.apache.commons.collections4.CollectionUtils;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+import javax.annotation.Nullable;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 
 /**
  * JSON Output filter using Jackson

--- a/src/main/java/emissary/output/filter/XmlOutputFilter.java
+++ b/src/main/java/emissary/output/filter/XmlOutputFilter.java
@@ -1,16 +1,15 @@
 package emissary.output.filter;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.Nullable;
-
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
 import emissary.core.IBaseDataObject;
 import emissary.output.DropOffPlace;
 import emissary.util.PayloadUtil;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Filter that writes unadorned data as utf-8.

--- a/src/main/java/emissary/output/io/DateStampFilenameGenerator.java
+++ b/src/main/java/emissary/output/io/DateStampFilenameGenerator.java
@@ -1,12 +1,13 @@
 package emissary.output.io;
 
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
-
 import emissary.directory.EmissaryNode;
 import emissary.util.TimeUtil;
 import emissary.util.io.FileNameGenerator;
+
 import org.apache.commons.lang3.StringUtils;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Create a filename generator that uses a datestamp as the name

--- a/src/main/java/emissary/output/roller/IJournaler.java
+++ b/src/main/java/emissary/output/roller/IJournaler.java
@@ -1,9 +1,9 @@
 package emissary.output.roller;
 
-import java.io.IOException;
-
 import emissary.output.roller.journal.KeyedOutput;
 import emissary.roll.Rollable;
+
+import java.io.IOException;
 
 /**
  * A {@link Rollable} implementation that uses a journal to record offsets of completed writes to a pool of outputs. The

--- a/src/main/java/emissary/output/roller/JournaledCoalescer.java
+++ b/src/main/java/emissary/output/roller/JournaledCoalescer.java
@@ -1,15 +1,15 @@
 package emissary.output.roller;
 
-import static emissary.output.roller.journal.Journal.EXT;
-import static emissary.output.roller.journal.JournaledChannelPool.EXTENSION;
-import static java.nio.file.Files.exists;
-import static java.nio.file.Files.isDirectory;
-import static java.nio.file.Files.isReadable;
-import static java.nio.file.Files.isWritable;
-import static java.nio.file.StandardOpenOption.CREATE;
-import static java.nio.file.StandardOpenOption.READ;
-import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
-import static java.nio.file.StandardOpenOption.WRITE;
+import emissary.output.roller.journal.Journal;
+import emissary.output.roller.journal.JournalEntry;
+import emissary.output.roller.journal.JournalReader;
+import emissary.output.roller.journal.JournaledChannelPool;
+import emissary.output.roller.journal.KeyedOutput;
+import emissary.util.io.FileNameGenerator;
+
+import org.apache.commons.io.FilenameUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -24,15 +24,16 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
-import emissary.output.roller.journal.Journal;
-import emissary.output.roller.journal.JournalEntry;
-import emissary.output.roller.journal.JournalReader;
-import emissary.output.roller.journal.JournaledChannelPool;
-import emissary.output.roller.journal.KeyedOutput;
-import emissary.util.io.FileNameGenerator;
-import org.apache.commons.io.FilenameUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static emissary.output.roller.journal.Journal.EXT;
+import static emissary.output.roller.journal.JournaledChannelPool.EXTENSION;
+import static java.nio.file.Files.exists;
+import static java.nio.file.Files.isDirectory;
+import static java.nio.file.Files.isReadable;
+import static java.nio.file.Files.isWritable;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.READ;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.nio.file.StandardOpenOption.WRITE;
 
 /**
  * The Rollable implemenation that uses a journal to record offsets of completed writes to a pool of outputs. The

--- a/src/main/java/emissary/output/roller/journal/JournalEntry.java
+++ b/src/main/java/emissary/output/roller/journal/JournalEntry.java
@@ -2,7 +2,6 @@ package emissary.output.roller.journal;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;
-
 import javax.annotation.Nullable;
 
 /**

--- a/src/main/java/emissary/output/roller/journal/JournalReader.java
+++ b/src/main/java/emissary/output/roller/journal/JournalReader.java
@@ -1,11 +1,7 @@
 package emissary.output.roller.journal;
 
-import static emissary.output.roller.journal.Journal.CURRENT_VERSION;
-import static emissary.output.roller.journal.Journal.ENTRY_LENGTH;
-import static emissary.output.roller.journal.Journal.EXT;
-import static emissary.output.roller.journal.Journal.MAGIC;
-import static emissary.output.roller.journal.Journal.NINE;
-import static emissary.output.roller.journal.Journal.SEP;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -22,8 +18,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static emissary.output.roller.journal.Journal.CURRENT_VERSION;
+import static emissary.output.roller.journal.Journal.ENTRY_LENGTH;
+import static emissary.output.roller.journal.Journal.EXT;
+import static emissary.output.roller.journal.Journal.MAGIC;
+import static emissary.output.roller.journal.Journal.NINE;
+import static emissary.output.roller.journal.Journal.SEP;
 
 /**
  * Encapsulates logic to read/deserialize a BG Journal file.

--- a/src/main/java/emissary/output/roller/journal/JournalWriter.java
+++ b/src/main/java/emissary/output/roller/journal/JournalWriter.java
@@ -1,7 +1,5 @@
 package emissary.output.roller.journal;
 
-import static emissary.output.roller.journal.Journal.SEP;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -10,6 +8,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.locks.ReentrantLock;
+
+import static emissary.output.roller.journal.Journal.SEP;
 
 /**
  * BG Write ahead log to track progress, often files, that have been successfully flushed to disk. The file itself

--- a/src/main/java/emissary/output/roller/journal/JournaledChannel.java
+++ b/src/main/java/emissary/output/roller/journal/JournaledChannel.java
@@ -1,5 +1,8 @@
 package emissary.output.roller.journal;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
@@ -7,9 +10,6 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Wrapper class to allow for use of underlying channel in either OutputStream code or WritableChannel.

--- a/src/main/java/emissary/output/roller/journal/JournaledChannelPool.java
+++ b/src/main/java/emissary/output/roller/journal/JournaledChannelPool.java
@@ -1,5 +1,8 @@
 package emissary.output.roller.journal;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.file.Path;
@@ -9,9 +12,6 @@ import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Pool implementation that utilizes a Journal to durably track state out written data. The implementation will create

--- a/src/main/java/emissary/output/roller/journal/KeyedOutput.java
+++ b/src/main/java/emissary/output/roller/journal/KeyedOutput.java
@@ -1,13 +1,13 @@
 package emissary.output.roller.journal;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Path;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Lightweight wrapper holding reference to a pooled object and the pool, which returns the channel to the pool on

--- a/src/main/java/emissary/parser/DataByteArraySlicer.java
+++ b/src/main/java/emissary/parser/DataByteArraySlicer.java
@@ -1,13 +1,12 @@
 package emissary.parser;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
-
 import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DataByteArraySlicer {
 

--- a/src/main/java/emissary/parser/DataByteBufferSlicer.java
+++ b/src/main/java/emissary/parser/DataByteBufferSlicer.java
@@ -1,15 +1,14 @@
 package emissary.parser;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.List;
-
 import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DataByteBufferSlicer {
     private static final Logger logger = LoggerFactory.getLogger(DataByteBufferSlicer.class);

--- a/src/main/java/emissary/parser/DataIdentifier.java
+++ b/src/main/java/emissary/parser/DataIdentifier.java
@@ -1,17 +1,17 @@
 package emissary.parser;
 
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+import emissary.util.shell.Executrix;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.annotation.Nullable;
-
-import emissary.config.ConfigUtil;
-import emissary.config.Configurator;
-import emissary.util.shell.Executrix;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A simple base class for doing data type identification This simple implementation can only match constant strings

--- a/src/main/java/emissary/parser/DecomposedSession.java
+++ b/src/main/java/emissary/parser/DecomposedSession.java
@@ -1,14 +1,13 @@
 package emissary.parser;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
 import javax.annotation.Nullable;
-
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 
 /**
  * Representation of a fully built session with metadata, header, footer, classification, initial forms, and data

--- a/src/main/java/emissary/parser/FillingNIOParser.java
+++ b/src/main/java/emissary/parser/FillingNIOParser.java
@@ -1,11 +1,11 @@
 package emissary.parser;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Encapsulate the behavior necessary to slide a window through a channel and parse sessions from it. nextChunkOrDie

--- a/src/main/java/emissary/parser/InputSession.java
+++ b/src/main/java/emissary/parser/InputSession.java
@@ -1,14 +1,13 @@
 package emissary.parser;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Detailed session information as it is parsed This class just records offsets and length of various things using lists

--- a/src/main/java/emissary/parser/NIOSessionParser.java
+++ b/src/main/java/emissary/parser/NIOSessionParser.java
@@ -1,15 +1,14 @@
 package emissary.parser;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
 import java.util.Arrays;
-
 import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Provide a basic NIO-based session parser that reads data in chunks from the underlying channel. A chunk might have

--- a/src/main/java/emissary/parser/ParserFactory.java
+++ b/src/main/java/emissary/parser/ParserFactory.java
@@ -1,5 +1,14 @@
 package emissary.parser;
 
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+import emissary.core.Factory;
+import emissary.util.WindowedSeekableByteChannel;
+import emissary.util.shell.Executrix;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -7,16 +16,7 @@ import java.nio.channels.Channels;
 import java.nio.channels.SeekableByteChannel;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.annotation.Nullable;
-
-import emissary.config.ConfigUtil;
-import emissary.config.Configurator;
-import emissary.core.Factory;
-import emissary.util.WindowedSeekableByteChannel;
-import emissary.util.shell.Executrix;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Provide a factory for getting the proper type of input parser Provide the implementing classes for that match the

--- a/src/main/java/emissary/parser/SessionProducer.java
+++ b/src/main/java/emissary/parser/SessionProducer.java
@@ -1,13 +1,13 @@
 package emissary.parser;
 
+import emissary.core.DataObjectFactory;
+import emissary.core.IBaseDataObject;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
-import emissary.core.DataObjectFactory;
-import emissary.core.IBaseDataObject;
 
 /**
  * This class takes a SessionParser and produces data objects from the sessions coming out of the session parser.

--- a/src/main/java/emissary/parser/SimpleNioParser.java
+++ b/src/main/java/emissary/parser/SimpleNioParser.java
@@ -1,5 +1,8 @@
 package emissary.parser;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -7,11 +10,7 @@ import java.nio.channels.SeekableByteChannel;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A very simple minded parser implementation that assumes each input channel is one session. This parser has no idea

--- a/src/main/java/emissary/parser/SimpleParser.java
+++ b/src/main/java/emissary/parser/SimpleParser.java
@@ -1,14 +1,13 @@
 package emissary.parser;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A very simple minded parser implementation that assumes each input set of data bytes is one session This parser has

--- a/src/main/java/emissary/pickup/PickUpPlace.java
+++ b/src/main/java/emissary/pickup/PickUpPlace.java
@@ -1,16 +1,5 @@
 package emissary.pickup;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.RandomAccessFile;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import javax.annotation.Nullable;
-
 import emissary.core.DataObjectFactory;
 import emissary.core.EmissaryException;
 import emissary.core.IBaseDataObject;
@@ -25,7 +14,18 @@ import emissary.place.IServiceProviderPlace;
 import emissary.pool.AgentPool;
 import emissary.util.ClassComparator;
 import emissary.util.shell.Executrix;
+
 import org.slf4j.MDC;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.RandomAccessFile;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * This class is the base class of those places that inject data into the system. This place knows a lot about

--- a/src/main/java/emissary/pickup/PickUpSpace.java
+++ b/src/main/java/emissary/pickup/PickUpSpace.java
@@ -1,13 +1,13 @@
 package emissary.pickup;
 
+import emissary.server.mvc.adapters.WorkSpaceAdapter;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import emissary.server.mvc.adapters.WorkSpaceAdapter;
 
 /**
  * Implementation of a pick up place that talks to a one or more WorkSpace instances for obtaining distributed work.

--- a/src/main/java/emissary/pickup/PickupQueue.java
+++ b/src/main/java/emissary/pickup/PickupQueue.java
@@ -1,11 +1,10 @@
 package emissary.pickup;
 
-import java.util.LinkedList;
-
-import javax.annotation.Nullable;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.LinkedList;
+import javax.annotation.Nullable;
 
 /**
  * A size limited queue for holding data to process.

--- a/src/main/java/emissary/pickup/QueServer.java
+++ b/src/main/java/emissary/pickup/QueServer.java
@@ -1,10 +1,11 @@
 package emissary.pickup;
 
-import java.util.Iterator;
-
 import emissary.core.Pausable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
 
 /**
  * Monitor thread for a PickupQueue and return items for processing. Operates in pull mode from a PickupSpace or push

--- a/src/main/java/emissary/pickup/WorkBundle.java
+++ b/src/main/java/emissary/pickup/WorkBundle.java
@@ -1,5 +1,12 @@
 package emissary.pickup;
 
+import emissary.util.xml.SaferJDOMUtil;
+
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -7,14 +14,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
-
 import javax.annotation.Nullable;
-
-import emissary.util.xml.SaferJDOMUtil;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Used to communicate between the TreePickUpPlace and TreeSpace about a set of files to process.

--- a/src/main/java/emissary/pickup/WorkSpace.java
+++ b/src/main/java/emissary/pickup/WorkSpace.java
@@ -1,5 +1,27 @@
 package emissary.pickup;
 
+import emissary.client.EmissaryResponse;
+import emissary.command.BaseCommand;
+import emissary.command.FeedCommand;
+import emissary.command.ServerCommand;
+import emissary.core.EmissaryException;
+import emissary.core.NamespaceException;
+import emissary.directory.DirectoryAdapter;
+import emissary.directory.DirectoryEntry;
+import emissary.directory.DirectoryPlace;
+import emissary.directory.EmissaryNode;
+import emissary.directory.IDirectoryPlace;
+import emissary.directory.KeyManipulator;
+import emissary.pool.AgentPool;
+import emissary.server.EmissaryServer;
+import emissary.server.mvc.adapters.WorkSpaceAdapter;
+import emissary.util.io.FileFind;
+
+import org.apache.http.HttpStatus;
+import org.eclipse.jetty.server.Server;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
@@ -18,29 +40,7 @@ import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
-
 import javax.annotation.Nullable;
-
-import emissary.client.EmissaryResponse;
-import emissary.command.BaseCommand;
-import emissary.command.FeedCommand;
-import emissary.command.ServerCommand;
-import emissary.core.EmissaryException;
-import emissary.core.NamespaceException;
-import emissary.directory.DirectoryAdapter;
-import emissary.directory.DirectoryEntry;
-import emissary.directory.DirectoryPlace;
-import emissary.directory.EmissaryNode;
-import emissary.directory.IDirectoryPlace;
-import emissary.directory.KeyManipulator;
-import emissary.pool.AgentPool;
-import emissary.server.EmissaryServer;
-import emissary.server.mvc.adapters.WorkSpaceAdapter;
-import emissary.util.io.FileFind;
-import org.apache.http.HttpStatus;
-import org.eclipse.jetty.server.Server;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Recursively process input and distribute files to one or more remote PickUp client instances when they ask for a

--- a/src/main/java/emissary/pickup/file/FileDataServer.java
+++ b/src/main/java/emissary/pickup/file/FileDataServer.java
@@ -1,13 +1,14 @@
 package emissary.pickup.file;
 
-import java.io.File;
-import java.io.FilenameFilter;
-
 import emissary.core.Pausable;
 import emissary.log.MDCConstants;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+
+import java.io.File;
+import java.io.FilenameFilter;
 
 /**
  * Thread to monitor a directory for files

--- a/src/main/java/emissary/pickup/file/FilePickUpClient.java
+++ b/src/main/java/emissary/pickup/file/FilePickUpClient.java
@@ -1,15 +1,5 @@
 package emissary.pickup.file;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.security.MessageDigest;
-import java.util.Collection;
-import java.util.Map;
-
-import javax.annotation.Nullable;
-
 import emissary.core.IBaseDataObject;
 import emissary.pickup.IPickUp;
 import emissary.pickup.IPickUpSpace;
@@ -17,6 +7,15 @@ import emissary.pickup.PickupQueue;
 import emissary.pickup.QueServer;
 import emissary.pickup.WorkBundle;
 import emissary.pickup.WorkUnit;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.util.Collection;
+import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Pull bundles of file info from a WorkSpace and process as a normal FilePickUp. Monitors a queue rather than a

--- a/src/main/java/emissary/pickup/file/FilePickUpPlace.java
+++ b/src/main/java/emissary/pickup/file/FilePickUpPlace.java
@@ -1,11 +1,11 @@
 package emissary.pickup.file;
 
+import emissary.pickup.IPickUp;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
-import emissary.pickup.IPickUp;
 
 /**
  * Monitor one or more directories and pickup files for the system

--- a/src/main/java/emissary/place/CoordinationPlace.java
+++ b/src/main/java/emissary/place/CoordinationPlace.java
@@ -1,10 +1,5 @@
 package emissary.place;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-
 import emissary.admin.PlaceStarter;
 import emissary.core.IBaseDataObject;
 import emissary.core.Namespace;
@@ -13,6 +8,11 @@ import emissary.core.ResourceWatcher;
 import emissary.core.TimedResource;
 import emissary.directory.DirectoryEntry;
 import emissary.directory.KeyManipulator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This place will coordinate service to several lower level service places. We have a list and will execute each place

--- a/src/main/java/emissary/place/IServiceProviderPlace.java
+++ b/src/main/java/emissary/place/IServiceProviderPlace.java
@@ -1,9 +1,9 @@
 package emissary.place;
 
+import emissary.directory.DirectoryEntry;
+
 import java.util.List;
 import java.util.Set;
-
-import emissary.directory.DirectoryEntry;
 
 /**
  * IServiceProviderPlace. IServiceProviderPlaces can be created by the emissary.admin.PlaceStarter and registered with

--- a/src/main/java/emissary/place/KffHashPlace.java
+++ b/src/main/java/emissary/place/KffHashPlace.java
@@ -1,11 +1,11 @@
 package emissary.place;
 
-import java.io.IOException;
-import java.io.InputStream;
-
 import emissary.core.IBaseDataObject;
 import emissary.core.ResourceException;
 import emissary.kff.KffDataObjectHandler;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Hashing place to hash payload unless hashes are set or skip flag is set. This place is intended to execute in the

--- a/src/main/java/emissary/place/Main.java
+++ b/src/main/java/emissary/place/Main.java
@@ -1,23 +1,5 @@
 package emissary.place;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
-import java.util.regex.Pattern;
-
-import javax.annotation.Nullable;
-
 import emissary.config.ConfigUtil;
 import emissary.core.Factory;
 import emissary.core.Family;
@@ -33,6 +15,7 @@ import emissary.parser.SessionParser;
 import emissary.parser.SessionProducer;
 import emissary.parser.SimpleParser;
 import emissary.util.shell.Executrix;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -43,6 +26,23 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 
 /**
  * This class handles running a the main method from a ServiceProviderPlace instance in a well defined but extensible

--- a/src/main/java/emissary/place/MultiFileServerPlace.java
+++ b/src/main/java/emissary/place/MultiFileServerPlace.java
@@ -1,18 +1,17 @@
 package emissary.place;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Set;
-
-import javax.annotation.Nullable;
-
 import emissary.core.IBaseDataObject;
 import emissary.directory.KeyManipulator;
 import emissary.kff.KffDataObjectHandler;
 import emissary.pickup.PickUpPlace;
 import emissary.util.DataUtil;
 import emissary.util.TypeEngine;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * A hybrid of the MultiFileServerPlace and the FilePickupPlace. Knows how to sprout agents using the MoveSpool

--- a/src/main/java/emissary/place/MultiFileUnixCommandPlace.java
+++ b/src/main/java/emissary/place/MultiFileUnixCommandPlace.java
@@ -1,5 +1,13 @@
 package emissary.place;
 
+import emissary.core.DataObjectFactory;
+import emissary.core.Family;
+import emissary.core.IBaseDataObject;
+import emissary.core.ResourceException;
+import emissary.directory.KeyManipulator;
+import emissary.kff.KffDataObjectHandler;
+import emissary.util.shell.Executrix;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,16 +19,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.annotation.Nullable;
-
-import emissary.core.DataObjectFactory;
-import emissary.core.Family;
-import emissary.core.IBaseDataObject;
-import emissary.core.ResourceException;
-import emissary.directory.KeyManipulator;
-import emissary.kff.KffDataObjectHandler;
-import emissary.util.shell.Executrix;
 
 public class MultiFileUnixCommandPlace extends MultiFileServerPlace implements IMultiFileUnixCommandPlace {
     protected boolean doSynchronized;

--- a/src/main/java/emissary/place/ServiceProviderPlace.java
+++ b/src/main/java/emissary/place/ServiceProviderPlace.java
@@ -1,17 +1,5 @@
 package emissary.place;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
-
-import javax.annotation.Nullable;
-
-import com.codahale.metrics.Timer;
 import emissary.config.ConfigEntry;
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
@@ -32,10 +20,22 @@ import emissary.log.MDCConstants;
 import emissary.parser.SessionParser;
 import emissary.server.mvc.adapters.DirectoryAdapter;
 import emissary.util.JMXUtil;
+
+import com.codahale.metrics.Timer;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.annotation.Nullable;
 
 /**
  * Concrete instances of ServiceProviderPlace can be created by the emissary.admin.PlaceStarter and registered with the

--- a/src/main/java/emissary/place/UnixCommandPlace.java
+++ b/src/main/java/emissary/place/UnixCommandPlace.java
@@ -1,17 +1,16 @@
 package emissary.place;
 
+import emissary.core.IBaseDataObject;
+import emissary.core.ResourceException;
+import emissary.directory.KeyManipulator;
+import emissary.util.shell.Executrix;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
-
 import javax.annotation.Nullable;
-
-import emissary.core.IBaseDataObject;
-import emissary.core.ResourceException;
-import emissary.directory.KeyManipulator;
-import emissary.util.shell.Executrix;
 
 /**
  * Run a command external to the Emissary JVM to process data

--- a/src/main/java/emissary/place/sample/CachePlace.java
+++ b/src/main/java/emissary/place/sample/CachePlace.java
@@ -1,11 +1,11 @@
 package emissary.place.sample;
 
+import emissary.core.IBaseDataObject;
+import emissary.place.ServiceProviderPlace;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
-import emissary.core.IBaseDataObject;
-import emissary.place.ServiceProviderPlace;
 
 /**
  * This place just keeps a reference to the last 10 payload objects it has seen. The number is configurable. It allows

--- a/src/main/java/emissary/place/sample/DelayPlace.java
+++ b/src/main/java/emissary/place/sample/DelayPlace.java
@@ -1,9 +1,9 @@
 package emissary.place.sample;
 
-import java.io.IOException;
-
 import emissary.core.IBaseDataObject;
 import emissary.place.ServiceProviderPlace;
+
+import java.io.IOException;
 
 /**
  * This place is a sink hole for everything it registers for

--- a/src/main/java/emissary/place/sample/DevNullPlace.java
+++ b/src/main/java/emissary/place/sample/DevNullPlace.java
@@ -1,9 +1,9 @@
 package emissary.place.sample;
 
-import java.io.IOException;
-
 import emissary.core.IBaseDataObject;
 import emissary.place.ServiceProviderPlace;
+
+import java.io.IOException;
 
 /**
  * This place is a sink hole for everything it registers for

--- a/src/main/java/emissary/place/sample/TemplatePlace.java
+++ b/src/main/java/emissary/place/sample/TemplatePlace.java
@@ -1,12 +1,12 @@
 package emissary.place.sample;
 
+import emissary.core.IBaseDataObject;
+import emissary.place.ServiceProviderPlace;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
-
-import emissary.core.IBaseDataObject;
-import emissary.place.ServiceProviderPlace;
 
 /**
  * This is the main Xxx program. It consists of ...

--- a/src/main/java/emissary/place/sample/ToLowerPlace.java
+++ b/src/main/java/emissary/place/sample/ToLowerPlace.java
@@ -1,9 +1,9 @@
 package emissary.place.sample;
 
-import java.io.IOException;
-
 import emissary.core.IBaseDataObject;
 import emissary.place.ServiceProviderPlace;
+
+import java.io.IOException;
 
 /**
  * This is the main ToLower program.

--- a/src/main/java/emissary/place/sample/ToUpperPlace.java
+++ b/src/main/java/emissary/place/sample/ToUpperPlace.java
@@ -1,9 +1,9 @@
 package emissary.place.sample;
 
-import java.io.IOException;
-
 import emissary.core.IBaseDataObject;
 import emissary.place.ServiceProviderPlace;
+
+import java.io.IOException;
 
 /**
  * This is the ToUpper program.

--- a/src/main/java/emissary/pool/AgentPool.java
+++ b/src/main/java/emissary/pool/AgentPool.java
@@ -1,15 +1,15 @@
 package emissary.pool;
 
-import java.time.Duration;
-
-import javax.annotation.Nullable;
-
 import emissary.core.IMobileAgent;
 import emissary.core.Namespace;
 import emissary.core.NamespaceException;
+
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import javax.annotation.Nullable;
 
 /**
  * Extends the GenericObjectPool to hold MobileAgents, each on it's own thread.

--- a/src/main/java/emissary/pool/MobileAgentFactory.java
+++ b/src/main/java/emissary/pool/MobileAgentFactory.java
@@ -1,14 +1,15 @@
 package emissary.pool;
 
-import java.io.IOException;
-
 import emissary.core.Factory;
 import emissary.core.IMobileAgent;
+
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.PooledObjectFactory;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 public class MobileAgentFactory implements PooledObjectFactory<IMobileAgent> {
 

--- a/src/main/java/emissary/pool/MoveSpool.java
+++ b/src/main/java/emissary/pool/MoveSpool.java
@@ -1,11 +1,5 @@
 package emissary.pool;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-
 import emissary.core.IMobileAgent;
 import emissary.core.Namespace;
 import emissary.core.NamespaceException;
@@ -13,8 +7,15 @@ import emissary.directory.DirectoryEntry;
 import emissary.directory.IDirectoryPlace;
 import emissary.place.IServiceProviderPlace;
 import emissary.util.PayloadUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Provide a storage area for incoming "moveTo(here)" payloads so that the http transfer can become more asnychronous.

--- a/src/main/java/emissary/pool/PayloadLauncher.java
+++ b/src/main/java/emissary/pool/PayloadLauncher.java
@@ -1,16 +1,17 @@
 package emissary.pool;
 
-import java.util.List;
-
 import emissary.core.EmissaryException;
 import emissary.core.IMobileAgent;
 import emissary.core.NamespaceException;
 import emissary.directory.DirectoryEntry;
 import emissary.log.MDCConstants;
 import emissary.place.IServiceProviderPlace;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+
+import java.util.List;
 
 /**
  * Launch an incoming payload the best way possible.

--- a/src/main/java/emissary/roll/RollManager.java
+++ b/src/main/java/emissary/roll/RollManager.java
@@ -1,5 +1,11 @@
 package emissary.roll;
 
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -9,11 +15,6 @@ import java.util.Observer;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import emissary.config.ConfigUtil;
-import emissary.config.Configurator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * RollManager handles all incremental rolls for configured objects within the framework

--- a/src/main/java/emissary/roll/RollScheduledExecutor.java
+++ b/src/main/java/emissary/roll/RollScheduledExecutor.java
@@ -1,5 +1,8 @@
 package emissary.roll;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.concurrent.Delayed;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RunnableScheduledFuture;
@@ -7,9 +10,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Scheduled Executor to support unhandled execution Exceptions. The intention of Rollable tasks is that they run for

--- a/src/main/java/emissary/roll/RollUtil.java
+++ b/src/main/java/emissary/roll/RollUtil.java
@@ -1,12 +1,11 @@
 package emissary.roll;
 
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.Nullable;
-
 import emissary.config.Configurator;
 import emissary.core.Factory;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 /**
  * Util class to grab known parameters from configs to help configure Rollable objects.

--- a/src/main/java/emissary/roll/Roller.java
+++ b/src/main/java/emissary/roll/Roller.java
@@ -1,12 +1,12 @@
 package emissary.roll;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Observable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Stateful object for the RollManager to track progress of a provided Rollable.

--- a/src/main/java/emissary/server/EmissaryServer.java
+++ b/src/main/java/emissary/server/EmissaryServer.java
@@ -1,26 +1,5 @@
 package emissary.server;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.UnknownHostException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.security.GeneralSecurityException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
-import javax.naming.directory.AttributeInUseException;
-
-import ch.qos.logback.classic.ViewStatusMessagesServlet;
-import com.google.common.annotations.VisibleForTesting;
 import emissary.client.EmissaryClient;
 import emissary.client.EmissaryResponse;
 import emissary.client.HTTPConnectionFactory;
@@ -40,6 +19,9 @@ import emissary.pool.MoveSpool;
 import emissary.roll.RollManager;
 import emissary.server.mvc.ThreadDumpAction;
 import emissary.server.mvc.ThreadDumpAction.ThreadDumpInfo;
+
+import ch.qos.logback.classic.ViewStatusMessagesServlet;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.http.client.methods.HttpGet;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
@@ -68,6 +50,24 @@ import org.glassfish.jersey.server.filter.CsrfProtectionFilter;
 import org.glassfish.jersey.server.mvc.mustache.MustacheMvcFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import javax.naming.directory.AttributeInUseException;
 
 public class EmissaryServer {
 

--- a/src/main/java/emissary/server/InitializeContext.java
+++ b/src/main/java/emissary/server/InitializeContext.java
@@ -1,11 +1,12 @@
 package emissary.server;
 
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-
 import emissary.directory.EmissaryNode;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
 
 /**
  * Initialize the application from inside the webapp context This initializer performs the following actions

--- a/src/main/java/emissary/server/api/Agents.java
+++ b/src/main/java/emissary/server/api/Agents.java
@@ -1,16 +1,5 @@
 package emissary.server.api;
 
-import static emissary.server.api.ApiUtils.lookupPeers;
-import static emissary.server.api.ApiUtils.stripPeerString;
-
-import java.util.StringJoiner;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
 import emissary.client.EmissaryClient;
 import emissary.client.response.Agent;
 import emissary.client.response.AgentList;
@@ -22,9 +11,20 @@ import emissary.core.NamespaceException;
 import emissary.directory.EmissaryNode;
 import emissary.pool.MobileAgentFactory;
 import emissary.server.EmissaryServer;
+
 import org.apache.http.client.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.StringJoiner;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static emissary.server.api.ApiUtils.lookupPeers;
+import static emissary.server.api.ApiUtils.stripPeerString;
 
 /**
  * The agents Emissary API endpoint. Currently, contains the local (/api/agents) call and cluster (/api/clusterAgents)

--- a/src/main/java/emissary/server/api/ApiUtils.java
+++ b/src/main/java/emissary/server/api/ApiUtils.java
@@ -1,15 +1,16 @@
 package emissary.server.api;
 
-import java.util.Set;
-
 import emissary.core.EmissaryException;
 import emissary.core.Namespace;
 import emissary.core.NamespaceException;
 import emissary.directory.DirectoryPlace;
 import emissary.directory.EmissaryNode;
 import emissary.server.EmissaryServer;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Set;
 
 public class ApiUtils {
     private static final Logger logger = LoggerFactory.getLogger(ApiUtils.class);

--- a/src/main/java/emissary/server/api/Env.java
+++ b/src/main/java/emissary/server/api/Env.java
@@ -1,20 +1,20 @@
 package emissary.server.api;
 
-import java.util.Map;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
 import emissary.client.response.MapResponseEntity;
 import emissary.command.ServerCommand;
 import emissary.core.Namespace;
 import emissary.core.NamespaceException;
 import emissary.server.EmissaryServer;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 /**
  * The env Emissary API endpoint that returns key=value pairs of config info for the running node

--- a/src/main/java/emissary/server/api/HealthCheckAction.java
+++ b/src/main/java/emissary/server/api/HealthCheckAction.java
@@ -1,15 +1,16 @@
 package emissary.server.api;
 
+import emissary.core.MetricsManager;
+import emissary.core.NamespaceException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import emissary.core.MetricsManager;
-import emissary.core.NamespaceException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Path("")
 // context is /api, set in EmissaryServer

--- a/src/main/java/emissary/server/api/MetricsAction.java
+++ b/src/main/java/emissary/server/api/MetricsAction.java
@@ -1,15 +1,16 @@
 package emissary.server.api;
 
+import emissary.core.MetricsManager;
+import emissary.core.NamespaceException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import emissary.core.MetricsManager;
-import emissary.core.NamespaceException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Path("")
 // context is /api, set in EmissaryServer

--- a/src/main/java/emissary/server/api/Nav.java
+++ b/src/main/java/emissary/server/api/Nav.java
@@ -1,16 +1,15 @@
 package emissary.server.api;
 
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+
 import java.io.IOException;
 import java.util.Map;
-
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import emissary.config.ConfigUtil;
-import emissary.config.Configurator;
 
 @Path("")
 // context is /api

--- a/src/main/java/emissary/server/api/Pause.java
+++ b/src/main/java/emissary/server/api/Pause.java
@@ -1,5 +1,11 @@
 package emissary.server.api;
 
+import emissary.core.NamespaceException;
+import emissary.server.EmissaryServer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -7,11 +13,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import emissary.core.NamespaceException;
-import emissary.server.EmissaryServer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Path("")
 // context is api

--- a/src/main/java/emissary/server/api/Peers.java
+++ b/src/main/java/emissary/server/api/Peers.java
@@ -1,24 +1,24 @@
 package emissary.server.api;
 
-import static emissary.server.api.ApiUtils.getHostAndPort;
-import static emissary.server.api.ApiUtils.lookupPeers;
-import static emissary.server.api.ApiUtils.stripPeerString;
+import emissary.client.EmissaryClient;
+import emissary.client.response.PeerList;
+import emissary.client.response.PeersResponseEntity;
+import emissary.core.EmissaryException;
+
+import org.apache.http.client.methods.HttpGet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Set;
-
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import emissary.client.EmissaryClient;
-import emissary.client.response.PeerList;
-import emissary.client.response.PeersResponseEntity;
-import emissary.core.EmissaryException;
-import org.apache.http.client.methods.HttpGet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static emissary.server.api.ApiUtils.getHostAndPort;
+import static emissary.server.api.ApiUtils.lookupPeers;
+import static emissary.server.api.ApiUtils.stripPeerString;
 
 /**
  * The peers Emissary API endpoint.

--- a/src/main/java/emissary/server/api/Places.java
+++ b/src/main/java/emissary/server/api/Places.java
@@ -1,16 +1,5 @@
 package emissary.server.api;
 
-import static emissary.server.api.ApiUtils.lookupPeers;
-import static emissary.server.api.ApiUtils.stripPeerString;
-
-import java.util.Set;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
 import emissary.client.EmissaryClient;
 import emissary.client.response.PlaceList;
 import emissary.client.response.PlacesResponseEntity;
@@ -18,9 +7,20 @@ import emissary.core.EmissaryException;
 import emissary.core.Namespace;
 import emissary.directory.EmissaryNode;
 import emissary.server.EmissaryServer;
+
 import org.apache.http.client.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static emissary.server.api.ApiUtils.lookupPeers;
+import static emissary.server.api.ApiUtils.stripPeerString;
 
 /**
  * The agents Emissary API endpoint. Currently contains the local (/api/places) call and cluster (/api/clusterPlaces)

--- a/src/main/java/emissary/server/api/Pool.java
+++ b/src/main/java/emissary/server/api/Pool.java
@@ -1,14 +1,5 @@
 package emissary.server.api;
 
-import static emissary.server.api.ApiUtils.lookupPeers;
-import static emissary.server.api.ApiUtils.stripPeerString;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
 import emissary.client.EmissaryClient;
 import emissary.client.response.MapResponseEntity;
 import emissary.core.EmissaryException;
@@ -18,9 +9,19 @@ import emissary.directory.EmissaryNode;
 import emissary.pool.AgentPool;
 import emissary.pool.MobileAgentFactory;
 import emissary.server.EmissaryServer;
+
 import org.apache.http.client.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static emissary.server.api.ApiUtils.lookupPeers;
+import static emissary.server.api.ApiUtils.stripPeerString;
 
 /**
  * The agents Emissary API endpoint. Currently contains the local (/api/pool) call and cluster (/api/clusterPool) calls.

--- a/src/main/java/emissary/server/api/Shutdown.java
+++ b/src/main/java/emissary/server/api/Shutdown.java
@@ -1,5 +1,10 @@
 package emissary.server.api;
 
+import emissary.server.EmissaryServer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -7,10 +12,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import emissary.server.EmissaryServer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Path("")
 // context is api

--- a/src/main/java/emissary/server/api/Version.java
+++ b/src/main/java/emissary/server/api/Version.java
@@ -1,16 +1,5 @@
 package emissary.server.api;
 
-import static emissary.server.api.ApiUtils.lookupPeers;
-import static emissary.server.api.ApiUtils.stripPeerString;
-
-import java.util.Set;
-
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
 import emissary.client.EmissaryClient;
 import emissary.client.response.MapResponseEntity;
 import emissary.core.EmissaryException;
@@ -18,9 +7,20 @@ import emissary.core.Namespace;
 import emissary.core.NamespaceException;
 import emissary.directory.EmissaryNode;
 import emissary.server.EmissaryServer;
+
 import org.apache.http.client.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static emissary.server.api.ApiUtils.lookupPeers;
+import static emissary.server.api.ApiUtils.stripPeerString;
 
 /**
  * The version Emissary API endpoint. Currently contains the local (/api/version) call and cluster (/api/clusterVersion)

--- a/src/main/java/emissary/server/mvc/DumpDirectoryAction.java
+++ b/src/main/java/emissary/server/mvc/DumpDirectoryAction.java
@@ -1,20 +1,5 @@
 package emissary.server.mvc;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.Nullable;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-
 import emissary.core.EmissaryException;
 import emissary.core.Namespace;
 import emissary.core.NamespaceException;
@@ -23,9 +8,24 @@ import emissary.directory.DirectoryPlace;
 import emissary.directory.IDirectoryPlace;
 import emissary.directory.KeyManipulator;
 import emissary.server.mvc.adapters.DirectoryAdapter;
+
 import org.glassfish.jersey.server.mvc.Template;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
 
 @Path("")
 // context is emissary

--- a/src/main/java/emissary/server/mvc/EnvironmentAction.java
+++ b/src/main/java/emissary/server/mvc/EnvironmentAction.java
@@ -1,17 +1,16 @@
 package emissary.server.mvc;
 
+import org.glassfish.jersey.server.mvc.Template;
+
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import org.glassfish.jersey.server.mvc.Template;
 
 @Path("")
 // context is emissary

--- a/src/main/java/emissary/server/mvc/NamespaceAction.java
+++ b/src/main/java/emissary/server/mvc/NamespaceAction.java
@@ -1,20 +1,20 @@
 package emissary.server.mvc;
 
+import emissary.core.Namespace;
+import emissary.core.NamespaceException;
+
+import org.glassfish.jersey.server.mvc.Template;
+
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-
-import emissary.core.Namespace;
-import emissary.core.NamespaceException;
-import org.glassfish.jersey.server.mvc.Template;
 
 @Path("")
 // context is emissary

--- a/src/main/java/emissary/server/mvc/PauseAction.java
+++ b/src/main/java/emissary/server/mvc/PauseAction.java
@@ -1,16 +1,15 @@
 package emissary.server.mvc;
 
+import org.glassfish.jersey.server.mvc.Template;
+
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-
-import org.glassfish.jersey.server.mvc.Template;
 
 @Path("")
 // context is emissary

--- a/src/main/java/emissary/server/mvc/ShutdownAction.java
+++ b/src/main/java/emissary/server/mvc/ShutdownAction.java
@@ -1,16 +1,15 @@
 package emissary.server.mvc;
 
+import org.glassfish.jersey.server.mvc.Template;
+
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-
-import org.glassfish.jersey.server.mvc.Template;
 
 @Path("")
 // context is emissary

--- a/src/main/java/emissary/server/mvc/ThreadDumpAction.java
+++ b/src/main/java/emissary/server/mvc/ThreadDumpAction.java
@@ -1,5 +1,7 @@
 package emissary.server.mvc;
 
+import org.glassfish.jersey.server.mvc.Template;
+
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
@@ -7,14 +9,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
 import javax.annotation.Nullable;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import org.glassfish.jersey.server.mvc.Template;
 
 @Path("")
 // context is emissary

--- a/src/main/java/emissary/server/mvc/TransferDirectoryAction.java
+++ b/src/main/java/emissary/server/mvc/TransferDirectoryAction.java
@@ -1,5 +1,15 @@
 package emissary.server.mvc;
 
+import emissary.core.EmissaryException;
+import emissary.core.Namespace;
+import emissary.directory.DirectoryPlace;
+import emissary.directory.DirectoryXmlContainer;
+import emissary.directory.IDirectoryPlace;
+import emissary.util.web.HtmlEscaper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -7,15 +17,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import emissary.core.EmissaryException;
-import emissary.core.Namespace;
-import emissary.directory.DirectoryPlace;
-import emissary.directory.DirectoryXmlContainer;
-import emissary.directory.IDirectoryPlace;
-import emissary.util.web.HtmlEscaper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Path("")
 // context is emissary

--- a/src/main/java/emissary/server/mvc/adapters/DirectoryAdapter.java
+++ b/src/main/java/emissary/server/mvc/adapters/DirectoryAdapter.java
@@ -1,14 +1,5 @@
 package emissary.server.mvc.adapters;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.annotation.Nullable;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.MediaType;
-
 import emissary.client.EmissaryClient;
 import emissary.client.EmissaryResponse;
 import emissary.config.ConfigUtil;
@@ -20,6 +11,7 @@ import emissary.directory.DirectoryXmlContainer;
 import emissary.directory.IRemoteDirectory;
 import emissary.directory.KeyManipulator;
 import emissary.log.MDCConstants;
+
 import org.apache.http.HttpStatus;
 import org.apache.http.HttpVersion;
 import org.apache.http.NameValuePair;
@@ -31,6 +23,14 @@ import org.apache.http.message.BasicNameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.MediaType;
 
 /**
  * Stuff for adapting the Directory calls to HTTP All of the outbound methods supply the TARGET_DIRECTORY parameter that

--- a/src/main/java/emissary/server/mvc/adapters/HeartbeatAdapter.java
+++ b/src/main/java/emissary/server/mvc/adapters/HeartbeatAdapter.java
@@ -6,6 +6,7 @@ import emissary.core.NamespaceException;
 import emissary.directory.DirectoryPlace;
 import emissary.directory.KeyManipulator;
 import emissary.place.IServiceProviderPlace;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/emissary/server/mvc/adapters/RequestUtil.java
+++ b/src/main/java/emissary/server/mvc/adapters/RequestUtil.java
@@ -1,9 +1,9 @@
 package emissary.server.mvc.adapters;
 
-import javax.servlet.ServletRequest;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletRequest;
 
 /**
  * Utilities for dealing with request parameters

--- a/src/main/java/emissary/server/mvc/adapters/WorkSpaceAdapter.java
+++ b/src/main/java/emissary/server/mvc/adapters/WorkSpaceAdapter.java
@@ -1,12 +1,10 @@
 package emissary.server.mvc.adapters;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import emissary.client.EmissaryClient;
 import emissary.client.EmissaryResponse;
 import emissary.directory.KeyManipulator;
 import emissary.pickup.WorkBundle;
+
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.config.RequestConfig;
@@ -15,6 +13,9 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.message.BasicNameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Stuff for adapting the WorkSpace remote call to HTTP

--- a/src/main/java/emissary/server/mvc/internal/DeregisterPlaceAction.java
+++ b/src/main/java/emissary/server/mvc/internal/DeregisterPlaceAction.java
@@ -1,10 +1,15 @@
 package emissary.server.mvc.internal;
 
-import static emissary.server.mvc.adapters.DirectoryAdapter.ADD_KEY;
-import static emissary.server.mvc.adapters.DirectoryAdapter.TARGET_DIRECTORY;
+import emissary.directory.IRemoteDirectory;
+import emissary.directory.KeyManipulator;
+import emissary.log.MDCConstants;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.util.List;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
@@ -13,13 +18,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import emissary.directory.IRemoteDirectory;
-import emissary.directory.KeyManipulator;
-import emissary.log.MDCConstants;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
+import static emissary.server.mvc.adapters.DirectoryAdapter.ADD_KEY;
+import static emissary.server.mvc.adapters.DirectoryAdapter.TARGET_DIRECTORY;
 
 @Path("")
 // context is /emissary, set in EmissaryServer

--- a/src/main/java/emissary/server/mvc/internal/FailDirectoryAction.java
+++ b/src/main/java/emissary/server/mvc/internal/FailDirectoryAction.java
@@ -1,9 +1,13 @@
 package emissary.server.mvc.internal;
 
-import static emissary.server.mvc.adapters.DirectoryAdapter.ADD_KEY;
-import static emissary.server.mvc.adapters.DirectoryAdapter.ADD_PROPAGATION_FLAG;
-import static emissary.server.mvc.adapters.DirectoryAdapter.FAILED_DIRECTORY_NAME;
-import static emissary.server.mvc.adapters.DirectoryAdapter.TARGET_DIRECTORY;
+import emissary.directory.IRemoteDirectory;
+import emissary.directory.KeyManipulator;
+import emissary.log.MDCConstants;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
@@ -13,13 +17,10 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import emissary.directory.IRemoteDirectory;
-import emissary.directory.KeyManipulator;
-import emissary.log.MDCConstants;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
+import static emissary.server.mvc.adapters.DirectoryAdapter.ADD_KEY;
+import static emissary.server.mvc.adapters.DirectoryAdapter.ADD_PROPAGATION_FLAG;
+import static emissary.server.mvc.adapters.DirectoryAdapter.FAILED_DIRECTORY_NAME;
+import static emissary.server.mvc.adapters.DirectoryAdapter.TARGET_DIRECTORY;
 
 @Path("")
 // context is /emissary, set in EmissaryServer

--- a/src/main/java/emissary/server/mvc/internal/HeartbeatAction.java
+++ b/src/main/java/emissary/server/mvc/internal/HeartbeatAction.java
@@ -1,5 +1,13 @@
 package emissary.server.mvc.internal;
 
+import emissary.core.NamespaceException;
+import emissary.directory.IDirectoryPlace;
+import emissary.place.IServiceProviderPlace;
+import emissary.server.mvc.adapters.HeartbeatAdapter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
@@ -7,13 +15,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import emissary.core.NamespaceException;
-import emissary.directory.IDirectoryPlace;
-import emissary.place.IServiceProviderPlace;
-import emissary.server.mvc.adapters.HeartbeatAdapter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Path("")
 // context is emissary

--- a/src/main/java/emissary/server/mvc/internal/RegisterPeerAction.java
+++ b/src/main/java/emissary/server/mvc/internal/RegisterPeerAction.java
@@ -1,19 +1,5 @@
 package emissary.server.mvc.internal;
 
-import static emissary.server.mvc.adapters.DirectoryAdapter.DIRECTORY_NAME;
-import static emissary.server.mvc.adapters.DirectoryAdapter.TARGET_DIRECTORY;
-
-import java.util.HashSet;
-import java.util.Set;
-
-import javax.ws.rs.Consumes;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
 import emissary.core.Namespace;
 import emissary.core.NamespaceException;
 import emissary.directory.DirectoryPlace;
@@ -22,10 +8,24 @@ import emissary.directory.IRemoteDirectory;
 import emissary.directory.KeyManipulator;
 import emissary.log.MDCConstants;
 import emissary.util.web.HtmlEscaper;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static emissary.server.mvc.adapters.DirectoryAdapter.DIRECTORY_NAME;
+import static emissary.server.mvc.adapters.DirectoryAdapter.TARGET_DIRECTORY;
 
 @Path("")
 // context is /emissary, set in EmissaryServer

--- a/src/main/java/emissary/server/mvc/internal/RollOutputsAction.java
+++ b/src/main/java/emissary/server/mvc/internal/RollOutputsAction.java
@@ -1,9 +1,11 @@
 package emissary.server.mvc.internal;
 
-import static emissary.util.PayloadUtil.logger;
+import emissary.core.Namespace;
+import emissary.core.ResourceWatcher;
+import emissary.output.DropOffPlace;
+import emissary.output.filter.IDropOffFilter;
 
 import java.util.List;
-
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -12,10 +14,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import emissary.core.Namespace;
-import emissary.core.ResourceWatcher;
-import emissary.output.DropOffPlace;
-import emissary.output.filter.IDropOffFilter;
+import static emissary.util.PayloadUtil.logger;
 
 @Path("")
 // context is /emissary, set in EmissaryServer

--- a/src/main/java/emissary/server/mvc/internal/WorkBundleCompletedAction.java
+++ b/src/main/java/emissary/server/mvc/internal/WorkBundleCompletedAction.java
@@ -1,9 +1,12 @@
 package emissary.server.mvc.internal;
 
-import static emissary.server.mvc.adapters.WorkSpaceAdapter.CLIENT_NAME;
-import static emissary.server.mvc.adapters.WorkSpaceAdapter.SPACE_NAME;
-import static emissary.server.mvc.adapters.WorkSpaceAdapter.WORK_BUNDLE_ID;
-import static emissary.server.mvc.adapters.WorkSpaceAdapter.WORK_BUNDLE_STATUS;
+import emissary.core.Namespace;
+import emissary.core.NamespaceException;
+import emissary.pickup.WorkSpace;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
@@ -13,12 +16,10 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import emissary.core.Namespace;
-import emissary.core.NamespaceException;
-import emissary.pickup.WorkSpace;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static emissary.server.mvc.adapters.WorkSpaceAdapter.CLIENT_NAME;
+import static emissary.server.mvc.adapters.WorkSpaceAdapter.SPACE_NAME;
+import static emissary.server.mvc.adapters.WorkSpaceAdapter.WORK_BUNDLE_ID;
+import static emissary.server.mvc.adapters.WorkSpaceAdapter.WORK_BUNDLE_STATUS;
 
 /**
  * Web-tier worker to call into the TreeSpace with notification that a work bundle was completed

--- a/src/main/java/emissary/server/mvc/internal/WorkSpaceClientOpenWorkSpaceAction.java
+++ b/src/main/java/emissary/server/mvc/internal/WorkSpaceClientOpenWorkSpaceAction.java
@@ -1,7 +1,11 @@
 package emissary.server.mvc.internal;
 
-import static emissary.server.mvc.adapters.WorkSpaceAdapter.CLIENT_NAME;
-import static emissary.server.mvc.adapters.WorkSpaceAdapter.SPACE_NAME;
+import emissary.core.Namespace;
+import emissary.core.NamespaceException;
+import emissary.pickup.IPickUpSpace;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
@@ -11,11 +15,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import emissary.core.Namespace;
-import emissary.core.NamespaceException;
-import emissary.pickup.IPickUpSpace;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static emissary.server.mvc.adapters.WorkSpaceAdapter.CLIENT_NAME;
+import static emissary.server.mvc.adapters.WorkSpaceAdapter.SPACE_NAME;
 
 /**
  * Web-tier worker to call the WorkSpaceClientPlace.openSpace coming in on a remote request

--- a/src/main/java/emissary/server/mvc/internal/WorkSpaceClientSpaceTakeAction.java
+++ b/src/main/java/emissary/server/mvc/internal/WorkSpaceClientSpaceTakeAction.java
@@ -1,5 +1,15 @@
 package emissary.server.mvc.internal;
 
+import emissary.core.EmissaryException;
+import emissary.core.Namespace;
+import emissary.pickup.WorkBundle;
+import emissary.pickup.WorkSpace;
+import emissary.util.web.HtmlEscaper;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
@@ -7,15 +17,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import emissary.core.EmissaryException;
-import emissary.core.Namespace;
-import emissary.pickup.WorkBundle;
-import emissary.pickup.WorkSpace;
-import emissary.util.web.HtmlEscaper;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Path("")
 // context is /emissary, set in EmissaryServer

--- a/src/main/java/emissary/spi/JavaCharSetInitializationProvider.java
+++ b/src/main/java/emissary/spi/JavaCharSetInitializationProvider.java
@@ -1,11 +1,12 @@
 package emissary.spi;
 
-import java.io.IOException;
-import java.util.HashMap;
-
 import emissary.util.JavaCharSet;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
 
 public class JavaCharSetInitializationProvider implements InitializationProvider {
     protected static Logger logger = LoggerFactory.getLogger(JavaCharSetInitializationProvider.class);

--- a/src/main/java/emissary/spi/SPILoader.java
+++ b/src/main/java/emissary/spi/SPILoader.java
@@ -1,9 +1,9 @@
 package emissary.spi;
 
-import java.util.ServiceLoader;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ServiceLoader;
 
 /**
  * Load SPI implementations to support initialization of the Emissary server.

--- a/src/main/java/emissary/transform/HtmlEscapePlace.java
+++ b/src/main/java/emissary/transform/HtmlEscapePlace.java
@@ -5,16 +5,17 @@
 
 package emissary.transform;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
 import emissary.core.IBaseDataObject;
 import emissary.place.ServiceProviderPlace;
 import emissary.transform.decode.HtmlEscape;
 import emissary.util.CharacterCounterSet;
 import emissary.util.DataUtil;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class HtmlEscapePlace extends ServiceProviderPlace {
 

--- a/src/main/java/emissary/transform/JavascriptEscapePlace.java
+++ b/src/main/java/emissary/transform/JavascriptEscapePlace.java
@@ -5,13 +5,14 @@
 
 package emissary.transform;
 
-import java.io.IOException;
-
 import emissary.core.IBaseDataObject;
 import emissary.place.ServiceProviderPlace;
 import emissary.transform.decode.JavascriptEscape;
 import emissary.util.DataUtil;
+
 import org.apache.commons.lang3.ArrayUtils;
+
+import java.io.IOException;
 
 public class JavascriptEscapePlace extends ServiceProviderPlace {
 

--- a/src/main/java/emissary/transform/JsonEscapePlace.java
+++ b/src/main/java/emissary/transform/JsonEscapePlace.java
@@ -5,13 +5,14 @@
 
 package emissary.transform;
 
-import java.io.IOException;
-
 import emissary.core.IBaseDataObject;
 import emissary.place.ServiceProviderPlace;
 import emissary.transform.decode.JsonEscape;
 import emissary.util.DataUtil;
+
 import org.apache.commons.lang3.ArrayUtils;
+
+import java.io.IOException;
 
 public class JsonEscapePlace extends ServiceProviderPlace {
 

--- a/src/main/java/emissary/transform/decode/HtmlEscape.java
+++ b/src/main/java/emissary/transform/decode/HtmlEscape.java
@@ -1,17 +1,17 @@
 package emissary.transform.decode;
 
+import emissary.util.CharacterCounterSet;
+import emissary.util.HtmlEntityMap;
+import emissary.util.shell.Executrix;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.annotation.Nullable;
-
-import emissary.util.CharacterCounterSet;
-import emissary.util.HtmlEntityMap;
-import emissary.util.shell.Executrix;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class HtmlEscape {
 

--- a/src/main/java/emissary/transform/decode/JavascriptEscape.java
+++ b/src/main/java/emissary/transform/decode/JavascriptEscape.java
@@ -1,11 +1,12 @@
 package emissary.transform.decode;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-
 import emissary.util.shell.Executrix;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 public class JavascriptEscape {
 

--- a/src/main/java/emissary/transform/decode/JsonEscape.java
+++ b/src/main/java/emissary/transform/decode/JsonEscape.java
@@ -1,11 +1,12 @@
 package emissary.transform.decode;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-
 import emissary.util.shell.Executrix;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 public class JsonEscape {
     /* our logger */

--- a/src/main/java/emissary/util/ByteUtil.java
+++ b/src/main/java/emissary/util/ByteUtil.java
@@ -2,7 +2,6 @@ package emissary.util;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.annotation.Nullable;
 
 /**

--- a/src/main/java/emissary/util/CharsetUtil.java
+++ b/src/main/java/emissary/util/CharsetUtil.java
@@ -1,11 +1,10 @@
 package emissary.util;
 
-import java.io.UnsupportedEncodingException;
-
-import javax.annotation.Nullable;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+import javax.annotation.Nullable;
 
 /**
  * A collection of utilities for dealing with different character sets in Java. Mainly with the aim of getting to UTF-8.

--- a/src/main/java/emissary/util/ConstructorLookupCache.java
+++ b/src/main/java/emissary/util/ConstructorLookupCache.java
@@ -1,13 +1,13 @@
 package emissary.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.ref.SoftReference;
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This implements a simple caching mechanism for {@link Constructor} lookups. For example if the same class constructor

--- a/src/main/java/emissary/util/DataUtil.java
+++ b/src/main/java/emissary/util/DataUtil.java
@@ -1,5 +1,11 @@
 package emissary.util;
 
+import emissary.core.Form;
+import emissary.core.IBaseDataObject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -11,13 +17,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
-
 import javax.annotation.Nullable;
-
-import emissary.core.Form;
-import emissary.core.IBaseDataObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DataUtil {
     private static final Logger logger = LoggerFactory.getLogger(DataUtil.class);

--- a/src/main/java/emissary/util/DependencyCheck.java
+++ b/src/main/java/emissary/util/DependencyCheck.java
@@ -1,12 +1,12 @@
 package emissary.util;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Set;
-
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
 import emissary.util.shell.Executrix;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
 
 /**
  * Class that performs simple checks to determine if an executable, directory, and/or file exists on the host machine.

--- a/src/main/java/emissary/util/FlexibleDateTimeParser.java
+++ b/src/main/java/emissary/util/FlexibleDateTimeParser.java
@@ -1,6 +1,13 @@
 package emissary.util;
 
-import static java.util.stream.Collectors.toList;
+import emissary.config.ConfigEntry;
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.DateTimeException;
@@ -17,13 +24,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
-import emissary.config.ConfigEntry;
-import emissary.config.ConfigUtil;
-import emissary.config.Configurator;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Attempt to parse a date in an unknown format. This will loop through a set of configured formats and convert it into

--- a/src/main/java/emissary/util/GitRepositoryState.java
+++ b/src/main/java/emissary/util/GitRepositoryState.java
@@ -1,10 +1,10 @@
 package emissary.util;
 
-import java.io.IOException;
-import java.util.Properties;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Properties;
 
 /**
  * POJO for parsing and returning values from a git properties file. The properties file is created during the maven

--- a/src/main/java/emissary/util/Hexl.java
+++ b/src/main/java/emissary/util/Hexl.java
@@ -4,11 +4,11 @@
 
 package emissary.util;
 
+import org.apache.commons.codec.binary.Hex;
+
 import java.io.DataInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
-
-import org.apache.commons.codec.binary.Hex;
 
 public class Hexl {
 

--- a/src/main/java/emissary/util/HtmlEntityMap.java
+++ b/src/main/java/emissary/util/HtmlEntityMap.java
@@ -1,14 +1,15 @@
 package emissary.util;
 
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Map;
 import java.util.TreeMap;
-
-import emissary.config.ConfigUtil;
-import emissary.config.Configurator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Map HTML entities

--- a/src/main/java/emissary/util/JMXUtil.java
+++ b/src/main/java/emissary/util/JMXUtil.java
@@ -1,13 +1,12 @@
 package emissary.util;
 
-import java.lang.management.ManagementFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.management.ManagementFactory;
 import javax.annotation.Nullable;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Utility class for JMX operations.

--- a/src/main/java/emissary/util/JavaCharSet.java
+++ b/src/main/java/emissary/util/JavaCharSet.java
@@ -2,7 +2,6 @@ package emissary.util;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.annotation.Nullable;
 
 /**

--- a/src/main/java/emissary/util/LineTokenizer.java
+++ b/src/main/java/emissary/util/LineTokenizer.java
@@ -1,7 +1,6 @@
 package emissary.util;
 
 import java.nio.charset.Charset;
-
 import javax.annotation.Nullable;
 
 /**

--- a/src/main/java/emissary/util/MagicNumberUtil.java
+++ b/src/main/java/emissary/util/MagicNumberUtil.java
@@ -1,17 +1,18 @@
 package emissary.util;
 
+import emissary.util.magic.MagicNumber;
+import emissary.util.magic.MagicNumberFactory;
+import emissary.util.shell.Executrix;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-
-import emissary.util.magic.MagicNumber;
-import emissary.util.magic.MagicNumberFactory;
-import emissary.util.shell.Executrix;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Magic entry rules when using the Java utility, MagicNumberUtil

--- a/src/main/java/emissary/util/MetadataDictionaryUtil.java
+++ b/src/main/java/emissary/util/MetadataDictionaryUtil.java
@@ -1,17 +1,18 @@
 package emissary.util;
 
+import emissary.core.MetadataDictionary;
+import emissary.core.NamespaceException;
+
+import com.google.common.collect.TreeMultimap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
-
-import com.google.common.collect.TreeMultimap;
-import emissary.core.MetadataDictionary;
-import emissary.core.NamespaceException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class takes an alternate view byte stream and changes the metadata labels to be consistent with the

--- a/src/main/java/emissary/util/PayloadUtil.java
+++ b/src/main/java/emissary/util/PayloadUtil.java
@@ -1,19 +1,20 @@
 package emissary.util;
 
+import emissary.core.IBaseDataObject;
+import emissary.core.TransformHistory;
+import emissary.util.xml.JDOMUtil;
+
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-
-import emissary.core.IBaseDataObject;
-import emissary.core.TransformHistory;
-import emissary.util.xml.JDOMUtil;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Utilities for dealing with IBaseDataObject and Lists thereof

--- a/src/main/java/emissary/util/PkiUtil.java
+++ b/src/main/java/emissary/util/PkiUtil.java
@@ -1,6 +1,8 @@
 package emissary.util;
 
-import static java.nio.charset.StandardCharsets.US_ASCII;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -19,13 +21,10 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.annotation.Nullable;
 import javax.xml.bind.DatatypeConverter;
 
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 public class PkiUtil {
 

--- a/src/main/java/emissary/util/ShortNameComparator.java
+++ b/src/main/java/emissary/util/ShortNameComparator.java
@@ -1,10 +1,10 @@
 package emissary.util;
 
-import java.io.Serializable;
-import java.util.Comparator;
-
 import emissary.core.Family;
 import emissary.core.IBaseDataObject;
+
+import java.io.Serializable;
+import java.util.Comparator;
 
 /**
  * Allow a Collection or Array of IBaseDataObject to be sorted by shortName such that all attachments come in order and

--- a/src/main/java/emissary/util/SizeUtil.java
+++ b/src/main/java/emissary/util/SizeUtil.java
@@ -1,12 +1,11 @@
 package emissary.util;
 
+import emissary.core.IBaseDataObject;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
 import javax.annotation.Nullable;
-
-import emissary.core.IBaseDataObject;
 
 /**
  * This class provides routines for approximating the RAM size of Emissary objects - primarily the

--- a/src/main/java/emissary/util/TimeUtil.java
+++ b/src/main/java/emissary/util/TimeUtil.java
@@ -1,5 +1,7 @@
 package emissary.util;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -9,10 +11,7 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.zone.ZoneRulesException;
 import java.util.Date;
-
 import javax.annotation.Nullable;
-
-import org.apache.commons.lang3.StringUtils;
 
 public class TimeUtil {
 

--- a/src/main/java/emissary/util/TypeEngine.java
+++ b/src/main/java/emissary/util/TypeEngine.java
@@ -1,16 +1,16 @@
 package emissary.util;
 
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.annotation.Nullable;
-
-import emissary.config.ConfigUtil;
-import emissary.config.Configurator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Help determine type of data from various data file mappings The name of the file gives some context to the mappings

--- a/src/main/java/emissary/util/UnixFile.java
+++ b/src/main/java/emissary/util/UnixFile.java
@@ -1,15 +1,15 @@
 package emissary.util;
 
+import emissary.util.shell.Executrix;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.annotation.Nullable;
-
-import emissary.util.shell.Executrix;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class UnixFile {
 

--- a/src/main/java/emissary/util/Version.java
+++ b/src/main/java/emissary/util/Version.java
@@ -1,10 +1,10 @@
 package emissary.util;
 
-import java.io.IOException;
-import java.io.InputStream;
-
 import emissary.config.ConfigUtil;
 import emissary.util.io.ResourceReader;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 public final class Version {
     private String version = "missing version";

--- a/src/main/java/emissary/util/WatcherThread.java
+++ b/src/main/java/emissary/util/WatcherThread.java
@@ -1,11 +1,11 @@
 /* $Id$ */
 package emissary.util;
 
+import emissary.util.io.ReadOutput;
+
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Date;
-
-import emissary.util.io.ReadOutput;
 
 public class WatcherThread extends Thread {
     private Process proc = null;

--- a/src/main/java/emissary/util/WindowedSeekableByteChannel.java
+++ b/src/main/java/emissary/util/WindowedSeekableByteChannel.java
@@ -1,14 +1,14 @@
 package emissary.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SeekableByteChannel;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class provides a seekable channel for a portion, or window, within the provided ReadableByteChannel. The

--- a/src/main/java/emissary/util/io/FastStringBuffer.java
+++ b/src/main/java/emissary/util/io/FastStringBuffer.java
@@ -1,16 +1,16 @@
 package emissary.util.io;
 
+import emissary.util.web.HtmlEscaper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.annotation.Nullable;
-
-import emissary.util.web.HtmlEscaper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This buffer implementation attempts to improve file creation performance by preventing conversion from byte array to

--- a/src/main/java/emissary/util/io/ListOpenFiles.java
+++ b/src/main/java/emissary/util/io/ListOpenFiles.java
@@ -1,10 +1,10 @@
 package emissary.util.io;
 
+import emissary.util.shell.Executrix;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import emissary.util.shell.Executrix;
 
 public class ListOpenFiles {
 

--- a/src/main/java/emissary/util/io/ResourceReader.java
+++ b/src/main/java/emissary/util/io/ResourceReader.java
@@ -1,5 +1,8 @@
 package emissary.util.io;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,11 +14,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-
 import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class reads a resource with utilities to read those with common names

--- a/src/main/java/emissary/util/magic/MagicMath.java
+++ b/src/main/java/emissary/util/magic/MagicMath.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Stack;
-
 import javax.annotation.Nullable;
 
 public class MagicMath {

--- a/src/main/java/emissary/util/magic/MagicNumber.java
+++ b/src/main/java/emissary/util/magic/MagicNumber.java
@@ -1,14 +1,13 @@
 package emissary.util.magic;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
-
 import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class MagicNumber {
 

--- a/src/main/java/emissary/util/magic/MagicNumberFactory.java
+++ b/src/main/java/emissary/util/magic/MagicNumberFactory.java
@@ -1,5 +1,8 @@
 package emissary.util.magic;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -9,11 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-
 import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class MagicNumberFactory {
 

--- a/src/main/java/emissary/util/roll/RollableFileOutputStream.java
+++ b/src/main/java/emissary/util/roll/RollableFileOutputStream.java
@@ -1,5 +1,11 @@
 package emissary.util.roll;
 
+import emissary.roll.Rollable;
+import emissary.util.io.FileNameGenerator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -9,13 +15,7 @@ import java.io.OutputStream;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
-
 import javax.annotation.Nullable;
-
-import emissary.roll.Rollable;
-import emissary.util.io.FileNameGenerator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Allows for use within the Emissary Rolling framework. Keeps track of bytes written and is thread safe.

--- a/src/main/java/emissary/util/search/ByteMatcher.java
+++ b/src/main/java/emissary/util/search/ByteMatcher.java
@@ -1,7 +1,6 @@
 package emissary.util.search;
 
 import java.nio.charset.Charset;
-
 import javax.annotation.Nullable;
 
 /**

--- a/src/main/java/emissary/util/search/ByteTokenizer.java
+++ b/src/main/java/emissary/util/search/ByteTokenizer.java
@@ -5,13 +5,13 @@
 
 package emissary.util.search;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.Enumeration;
 import java.util.NoSuchElementException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The byte tokenizer class allows an application to break a byte buffer into tokens. This was modified from the

--- a/src/main/java/emissary/util/search/FastBoyerMoore.java
+++ b/src/main/java/emissary/util/search/FastBoyerMoore.java
@@ -1,12 +1,12 @@
 package emissary.util.search;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class FastBoyerMoore {
     private static Logger logger = LoggerFactory.getLogger(FastBoyerMoore.class);

--- a/src/main/java/emissary/util/search/KeywordScanner.java
+++ b/src/main/java/emissary/util/search/KeywordScanner.java
@@ -1,7 +1,6 @@
 package emissary.util.search;
 
 import java.nio.charset.Charset;
-
 import javax.annotation.Nullable;
 
 /**

--- a/src/main/java/emissary/util/search/MultiKeywordScanner.java
+++ b/src/main/java/emissary/util/search/MultiKeywordScanner.java
@@ -1,9 +1,9 @@
 package emissary.util.search;
 
-import javax.annotation.Nullable;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 public class MultiKeywordScanner implements IMultiKeywordScanner {
 

--- a/src/main/java/emissary/util/shell/Executrix.java
+++ b/src/main/java/emissary/util/shell/Executrix.java
@@ -1,5 +1,15 @@
 package emissary.util.shell;
 
+import emissary.config.Configurator;
+import emissary.config.ServiceConfigGuide;
+import emissary.directory.KeyManipulator;
+import emissary.util.io.FileManipulator;
+
+import org.apache.commons.exec.ExecuteWatchdog;
+import org.apache.commons.lang3.ArrayUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedOutputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
@@ -15,17 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
 import java.util.Arrays;
 import java.util.Map;
-
 import javax.annotation.Nullable;
-
-import emissary.config.Configurator;
-import emissary.config.ServiceConfigGuide;
-import emissary.directory.KeyManipulator;
-import emissary.util.io.FileManipulator;
-import org.apache.commons.exec.ExecuteWatchdog;
-import org.apache.commons.lang3.ArrayUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class wraps up things related to exec-ing of external processes and reading and writing disk files.

--- a/src/main/java/emissary/util/shell/ReadOutputBuffer.java
+++ b/src/main/java/emissary/util/shell/ReadOutputBuffer.java
@@ -6,14 +6,14 @@
 
 package emissary.util.shell;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *

--- a/src/main/java/emissary/util/shell/ReadOutputLogger.java
+++ b/src/main/java/emissary/util/shell/ReadOutputLogger.java
@@ -6,13 +6,13 @@
 
 package emissary.util.shell;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *

--- a/src/main/java/emissary/util/web/HttpPostParameters.java
+++ b/src/main/java/emissary/util/web/HttpPostParameters.java
@@ -1,5 +1,8 @@
 package emissary.util.web;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /*
  $Id$
  */
@@ -13,11 +16,7 @@ package emissary.util.web;
  */
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-
 import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class HttpPostParameters {
 

--- a/src/main/java/emissary/util/web/Url.java
+++ b/src/main/java/emissary/util/web/Url.java
@@ -4,6 +4,9 @@
 
 package emissary.util.web;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -13,11 +16,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Url {
 

--- a/src/main/java/emissary/util/xml/AbstractJDOMUtil.java
+++ b/src/main/java/emissary/util/xml/AbstractJDOMUtil.java
@@ -1,15 +1,5 @@
 package emissary.util.xml;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.StringReader;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-
-import javax.annotation.Nullable;
-
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.net.QuotedPrintableCodec;
 import org.jdom2.CDATA;
@@ -23,6 +13,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLFilter;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import javax.annotation.Nullable;
 
 /**
  * Utilities for dealing with JDOM documents

--- a/src/test/java/emissary/EmissaryTest.java
+++ b/src/test/java/emissary/EmissaryTest.java
@@ -1,9 +1,13 @@
 package emissary;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.command.BaseCommand;
+import emissary.command.EmissaryCommand;
+import emissary.test.core.junit5.UnitTest;
+
+import com.beust.jcommander.JCommander;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -12,13 +16,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.beust.jcommander.JCommander;
-import emissary.command.BaseCommand;
-import emissary.command.EmissaryCommand;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EmissaryTest extends UnitTest {
 

--- a/src/test/java/emissary/admin/StartupTest.java
+++ b/src/test/java/emissary/admin/StartupTest.java
@@ -1,12 +1,5 @@
 package emissary.admin;
 
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import emissary.directory.EmissaryNode;
 import emissary.pickup.file.FilePickUpClient;
 import emissary.pickup.file.FilePickUpPlace;
@@ -14,7 +7,15 @@ import emissary.place.CoordinationPlace;
 import emissary.place.sample.DelayPlace;
 import emissary.place.sample.DevNullPlace;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 class StartupTest extends UnitTest {
 

--- a/src/test/java/emissary/client/EmissaryClientTest.java
+++ b/src/test/java/emissary/client/EmissaryClientTest.java
@@ -1,6 +1,12 @@
 package emissary.client;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import emissary.config.ConfigUtil;
+import emissary.test.core.junit5.UnitTest;
+
+import org.apache.http.client.config.RequestConfig;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -11,12 +17,7 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.TimeUnit;
 
-import emissary.config.ConfigUtil;
-import emissary.test.core.junit5.UnitTest;
-import org.apache.http.client.config.RequestConfig;
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class EmissaryClientTest extends UnitTest {
 

--- a/src/test/java/emissary/client/HTTPConnectionFactoryTest.java
+++ b/src/test/java/emissary/client/HTTPConnectionFactoryTest.java
@@ -1,5 +1,17 @@
 package emissary.client;
 
+import emissary.config.Configurator;
+import emissary.config.ServiceConfigGuide;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.PkiUtil;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.net.ssl.SSLContext;
+
 import static emissary.client.HTTPConnectionFactory.CFG_KEY_STORE;
 import static emissary.client.HTTPConnectionFactory.CFG_KEY_STORE_PW;
 import static emissary.client.HTTPConnectionFactory.CFG_KEY_STORE_TYPE;
@@ -10,17 +22,6 @@ import static emissary.client.HTTPConnectionFactory.DFLT_STORE_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
-
-import javax.net.ssl.SSLContext;
-
-import emissary.config.Configurator;
-import emissary.config.ServiceConfigGuide;
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.PkiUtil;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class HTTPConnectionFactoryTest extends UnitTest {
 

--- a/src/test/java/emissary/client/response/AgentsFormatterTest.java
+++ b/src/test/java/emissary/client/response/AgentsFormatterTest.java
@@ -1,8 +1,8 @@
 package emissary.client.response;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AgentsFormatterTest {
 

--- a/src/test/java/emissary/command/BaseCommandTest.java
+++ b/src/test/java/emissary/command/BaseCommandTest.java
@@ -1,14 +1,15 @@
 package emissary.command;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import emissary.config.ConfigUtil;
+import emissary.test.core.junit5.UnitTest;
+
+import com.beust.jcommander.JCommander;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import com.beust.jcommander.JCommander;
-import emissary.config.ConfigUtil;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class BaseCommandTest extends UnitTest {
 

--- a/src/test/java/emissary/command/FeedCommandIT.java
+++ b/src/test/java/emissary/command/FeedCommandIT.java
@@ -1,11 +1,20 @@
 package emissary.command;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.config.ConfigUtil;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.io.UnitTestFileUtils;
+
+import com.beust.jcommander.ParameterException;
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -17,20 +26,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
-import com.beust.jcommander.ParameterException;
-import com.google.common.collect.Lists;
-import emissary.config.ConfigUtil;
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.io.UnitTestFileUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FeedCommandIT extends UnitTest {
 

--- a/src/test/java/emissary/command/PeersCommandIT.java
+++ b/src/test/java/emissary/command/PeersCommandIT.java
@@ -1,9 +1,13 @@
 package emissary.command;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.config.ConfigUtil;
+import emissary.test.core.junit5.UnitTest;
+
+import com.beust.jcommander.JCommander;
+import com.google.common.net.HostAndPort;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -13,13 +17,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import com.beust.jcommander.JCommander;
-import com.google.common.net.HostAndPort;
-import emissary.config.ConfigUtil;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PeersCommandIT extends UnitTest {
 

--- a/src/test/java/emissary/command/RunCommandIT.java
+++ b/src/test/java/emissary/command/RunCommandIT.java
@@ -1,17 +1,18 @@
 package emissary.command;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+
+import com.beust.jcommander.JCommander;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
 
-import com.beust.jcommander.JCommander;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RunCommandIT extends UnitTest {
 

--- a/src/test/java/emissary/command/ServerCommandIT.java
+++ b/src/test/java/emissary/command/ServerCommandIT.java
@@ -1,13 +1,14 @@
 package emissary.command;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import emissary.config.ConfigUtil;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Paths;
 
-import emissary.config.ConfigUtil;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ServerCommandIT extends UnitTest {
     private static final String PROJECT_BASE = System.getenv(ConfigUtil.PROJECT_BASE_ENV);

--- a/src/test/java/emissary/command/WhatCommandIT.java
+++ b/src/test/java/emissary/command/WhatCommandIT.java
@@ -1,8 +1,19 @@
 package emissary.command;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.config.ConfigUtil;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.io.UnitTestFileUtils;
+
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -15,19 +26,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import com.google.common.collect.Lists;
-import emissary.config.ConfigUtil;
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.io.UnitTestFileUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WhatCommandIT extends UnitTest {
 

--- a/src/test/java/emissary/command/converter/FileExistsConverterTest.java
+++ b/src/test/java/emissary/command/converter/FileExistsConverterTest.java
@@ -1,18 +1,19 @@
 package emissary.command.converter;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.io.UnitTestFileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.io.UnitTestFileUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class FileExistsConverterTest extends UnitTest {
 

--- a/src/test/java/emissary/command/converter/PathExistsConverterTest.java
+++ b/src/test/java/emissary/command/converter/PathExistsConverterTest.java
@@ -1,17 +1,18 @@
 package emissary.command.converter;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.io.UnitTestFileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.io.UnitTestFileUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PathExistsConverterTest extends UnitTest {
 

--- a/src/test/java/emissary/command/converter/PathExistsReadableConverterTest.java
+++ b/src/test/java/emissary/command/converter/PathExistsReadableConverterTest.java
@@ -1,8 +1,10 @@
 package emissary.command.converter;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -11,10 +13,9 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashSet;
 import java.util.Set;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PathExistsReadableConverterTest extends UnitTest {
 

--- a/src/test/java/emissary/command/converter/PriorityDirectoryConverterTest.java
+++ b/src/test/java/emissary/command/converter/PriorityDirectoryConverterTest.java
@@ -1,13 +1,14 @@
 package emissary.command.converter;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import emissary.pickup.Priority;
 import emissary.pickup.PriorityDirectory;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PriorityDirectoryConverterTest extends UnitTest {
     private PriorityDirectoryConverter converter;

--- a/src/test/java/emissary/command/converter/ProjectBaseConverterTest.java
+++ b/src/test/java/emissary/command/converter/ProjectBaseConverterTest.java
@@ -1,17 +1,18 @@
 package emissary.command.converter;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.io.UnitTestFileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.io.UnitTestFileUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ProjectBaseConverterTest extends UnitTest {
 

--- a/src/test/java/emissary/command/converter/WorkspaceSortModeConverterTest.java
+++ b/src/test/java/emissary/command/converter/WorkspaceSortModeConverterTest.java
@@ -1,15 +1,16 @@
 package emissary.command.converter;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.pickup.WorkBundle;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
 
-import emissary.pickup.WorkBundle;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WorkspaceSortModeConverterTest extends UnitTest {
     private Comparator<WorkBundle> comparator;

--- a/src/test/java/emissary/config/ConfigUtilTest.java
+++ b/src/test/java/emissary/config/ConfigUtilTest.java
@@ -1,12 +1,19 @@
 package emissary.config;
 
-import static emissary.config.ConfigUtil.CONFIG_DIR_PROPERTY;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import emissary.core.EmissaryException;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.shell.Executrix;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -18,19 +25,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
-import emissary.core.EmissaryException;
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.shell.Executrix;
-import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.LoggerFactory;
+import static emissary.config.ConfigUtil.CONFIG_DIR_PROPERTY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class ConfigUtilTest extends UnitTest {
 

--- a/src/test/java/emissary/config/FTestServiceConfigGuide.java
+++ b/src/test/java/emissary/config/FTestServiceConfigGuide.java
@@ -1,7 +1,13 @@
 package emissary.config;
 
-import static emissary.util.io.UnitTestFileUtils.findFilesByExtension;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import emissary.core.EmissaryException;
+import emissary.test.core.junit5.FunctionalTest;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -10,13 +16,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.stream.Stream;
 
-import emissary.core.EmissaryException;
-import emissary.test.core.junit5.FunctionalTest;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static emissary.util.io.UnitTestFileUtils.findFilesByExtension;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class FTestServiceConfigGuide extends FunctionalTest {
 

--- a/src/test/java/emissary/config/ServiceConfigGuideTest.java
+++ b/src/test/java/emissary/config/ServiceConfigGuideTest.java
@@ -1,12 +1,14 @@
 package emissary.config;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.shell.Executrix;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -22,14 +24,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.shell.Executrix;
-import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class ServiceConfigGuideTest extends UnitTest {
 

--- a/src/test/java/emissary/core/BaseDataObjectTest.java
+++ b/src/test/java/emissary/core/BaseDataObjectTest.java
@@ -1,13 +1,19 @@
 package emissary.core;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+import emissary.directory.DirectoryEntry;
+import emissary.pickup.Priority;
+import emissary.test.core.junit5.UnitTest;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
@@ -23,19 +29,14 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Stream;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-import emissary.config.ConfigUtil;
-import emissary.config.Configurator;
-import emissary.directory.DirectoryEntry;
-import emissary.pickup.Priority;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class BaseDataObjectTest extends UnitTest {
 

--- a/src/test/java/emissary/core/BaseDataWithRemappingTest.java
+++ b/src/test/java/emissary/core/BaseDataWithRemappingTest.java
@@ -1,20 +1,21 @@
 package emissary.core;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BaseDataWithRemappingTest extends UnitTest {
     private BaseDataObject b = null;

--- a/src/test/java/emissary/core/DataObjectFactoryTest.java
+++ b/src/test/java/emissary/core/DataObjectFactoryTest.java
@@ -1,14 +1,15 @@
 package emissary.core;
 
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 class DataObjectFactoryTest extends UnitTest {
     private String defaultPayloadClass;

--- a/src/test/java/emissary/core/EmissaryExceptionTest.java
+++ b/src/test/java/emissary/core/EmissaryExceptionTest.java
@@ -1,9 +1,10 @@
 package emissary.core;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class EmissaryExceptionTest extends UnitTest {
     @Test

--- a/src/test/java/emissary/core/ExtendedDataObject.java
+++ b/src/test/java/emissary/core/ExtendedDataObject.java
@@ -1,12 +1,11 @@
 package emissary.core;
 
-import java.io.Serializable;
-import java.util.Map;
-
-import javax.annotation.Nullable;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * This class exists to make sure the BaseDataObject can be extended properly and used from JNIPlace and JNIMultiPlace

--- a/src/test/java/emissary/core/FTestMobileAgent.java
+++ b/src/test/java/emissary/core/FTestMobileAgent.java
@@ -1,16 +1,17 @@
 package emissary.core;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.io.IOException;
-
 import emissary.place.IServiceProviderPlace;
 import emissary.test.core.junit5.FunctionalTest;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class FTestMobileAgent extends FunctionalTest {
 

--- a/src/test/java/emissary/core/FTestMovingAgent.java
+++ b/src/test/java/emissary/core/FTestMovingAgent.java
@@ -1,14 +1,5 @@
 package emissary.core;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
-import java.util.List;
-
-import javax.annotation.Nullable;
-
 import emissary.client.EmissaryClient;
 import emissary.client.EmissaryResponse;
 import emissary.directory.IDirectoryPlace;
@@ -19,11 +10,20 @@ import emissary.pool.AgentPool;
 import emissary.pool.MobileAgentFactory;
 import emissary.test.core.junit5.FunctionalTest;
 import emissary.util.Version;
+
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import javax.annotation.Nullable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class FTestMovingAgent extends FunctionalTest {
     private IDirectoryPlace dir1 = null;

--- a/src/test/java/emissary/core/FactoryTest.java
+++ b/src/test/java/emissary/core/FactoryTest.java
@@ -1,16 +1,17 @@
 package emissary.core;
 
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 class FactoryTest extends UnitTest {
     @Override

--- a/src/test/java/emissary/core/FamilyTest.java
+++ b/src/test/java/emissary/core/FamilyTest.java
@@ -1,9 +1,10 @@
 package emissary.core;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 // Family doesn't do much now, but it might later
 class FamilyTest extends UnitTest {

--- a/src/test/java/emissary/core/FilePickUpPlaceHealthCheckTest.java
+++ b/src/test/java/emissary/core/FilePickUpPlaceHealthCheckTest.java
@@ -1,11 +1,12 @@
 package emissary.core;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import emissary.pickup.file.FilePickUpPlace;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FilePickUpPlaceHealthCheckTest extends UnitTest {
 

--- a/src/test/java/emissary/core/HDMobileAgentTest.java
+++ b/src/test/java/emissary/core/HDMobileAgentTest.java
@@ -1,15 +1,16 @@
 package emissary.core;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import emissary.place.ServiceProviderPlace;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import emissary.place.ServiceProviderPlace;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *

--- a/src/test/java/emissary/core/MetadataDictionaryTest.java
+++ b/src/test/java/emissary/core/MetadataDictionaryTest.java
@@ -1,13 +1,14 @@
 package emissary.core;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class MetadataDictionaryTest extends UnitTest {
     private static final String TEST_NAMESPACE = "test_namespace";

--- a/src/test/java/emissary/core/MetricsFormatterTest.java
+++ b/src/test/java/emissary/core/MetricsFormatterTest.java
@@ -1,12 +1,13 @@
 package emissary.core;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+
+import com.codahale.metrics.Timer;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import com.codahale.metrics.Timer;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MetricsFormatterTest extends UnitTest {
     @Test

--- a/src/test/java/emissary/core/MetricsManagerTest.java
+++ b/src/test/java/emissary/core/MetricsManagerTest.java
@@ -1,15 +1,16 @@
 package emissary.core;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import emissary.config.Configurator;
+import emissary.config.ServiceConfigGuide;
+import emissary.test.core.junit5.UnitTest;
+
+import com.codahale.metrics.Timer;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import com.codahale.metrics.Timer;
-import emissary.config.Configurator;
-import emissary.config.ServiceConfigGuide;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class MetricsManagerTest extends UnitTest {
     @Test

--- a/src/test/java/emissary/core/MobileAgentTest.java
+++ b/src/test/java/emissary/core/MobileAgentTest.java
@@ -1,17 +1,18 @@
 package emissary.core;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Arrays;
-
 import emissary.admin.PlaceStarter;
 import emissary.directory.DirectoryEntry;
 import emissary.place.IServiceProviderPlace;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MobileAgentTest extends UnitTest {
     private MobAg agent;

--- a/src/test/java/emissary/core/NamespaceTest.java
+++ b/src/test/java/emissary/core/NamespaceTest.java
@@ -1,14 +1,15 @@
 package emissary.core;
 
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
 
 class NamespaceTest extends UnitTest {
 

--- a/src/test/java/emissary/core/ResourceExceptionTest.java
+++ b/src/test/java/emissary/core/ResourceExceptionTest.java
@@ -1,9 +1,10 @@
 package emissary.core;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ResourceExceptionTest extends UnitTest {
     @Test

--- a/src/test/java/emissary/core/ResourceWatcherTest.java
+++ b/src/test/java/emissary/core/ResourceWatcherTest.java
@@ -1,22 +1,23 @@
 package emissary.core;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.directory.DirectoryEntry;
+import emissary.place.IServiceProviderPlace;
+import emissary.place.sample.DevNullPlace;
+import emissary.test.core.junit5.UnitTest;
+
+import com.codahale.metrics.Timer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 
-import com.codahale.metrics.Timer;
-import emissary.directory.DirectoryEntry;
-import emissary.place.IServiceProviderPlace;
-import emissary.place.sample.DevNullPlace;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ResourceWatcherTest extends UnitTest {
 

--- a/src/test/java/emissary/core/StageTest.java
+++ b/src/test/java/emissary/core/StageTest.java
@@ -1,16 +1,17 @@
 package emissary.core;
 
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.List;
-
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 class StageTest extends UnitTest {
     Stage stages;

--- a/src/test/java/emissary/core/TimedResourceTest.java
+++ b/src/test/java/emissary/core/TimedResourceTest.java
@@ -1,17 +1,18 @@
 package emissary.core;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import com.codahale.metrics.Timer;
 import emissary.place.IServiceProviderPlace;
 import emissary.place.sample.DevNullPlace;
 import emissary.test.core.junit5.UnitTest;
 import emissary.test.core.junit5.extensions.TestAttempts;
+
+import com.codahale.metrics.Timer;
 import org.junit.jupiter.api.BeforeEach;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TimedResourceTest extends UnitTest {
     private IServiceProviderPlace tp;

--- a/src/test/java/emissary/directory/DirectoryEntryListTest.java
+++ b/src/test/java/emissary/directory/DirectoryEntryListTest.java
@@ -1,20 +1,21 @@
 package emissary.directory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import emissary.test.core.junit5.UnitTest;
 import emissary.util.xml.JDOMUtil;
+
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DirectoryEntryListTest extends UnitTest {
 

--- a/src/test/java/emissary/directory/DirectoryEntryMapTest.java
+++ b/src/test/java/emissary/directory/DirectoryEntryMapTest.java
@@ -1,17 +1,18 @@
 package emissary.directory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.List;
-
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DirectoryEntryMapTest extends UnitTest {
 

--- a/src/test/java/emissary/directory/DirectoryEntryTest.java
+++ b/src/test/java/emissary/directory/DirectoryEntryTest.java
@@ -1,18 +1,19 @@
 package emissary.directory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import emissary.test.core.junit5.UnitTest;
 import emissary.util.xml.JDOMUtil;
+
 import org.jdom2.Document;
 import org.jdom2.JDOMException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DirectoryEntryTest extends UnitTest {
 

--- a/src/test/java/emissary/directory/DirectoryPlaceTest.java
+++ b/src/test/java/emissary/directory/DirectoryPlaceTest.java
@@ -1,11 +1,15 @@
 package emissary.directory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.spy;
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+import emissary.core.EmissaryException;
+import emissary.core.Namespace;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.io.ResourceReader;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,15 +18,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import emissary.config.ConfigUtil;
-import emissary.config.Configurator;
-import emissary.core.EmissaryException;
-import emissary.core.Namespace;
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.io.ResourceReader;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
 
 class DirectoryPlaceTest extends UnitTest {
 

--- a/src/test/java/emissary/directory/FTestPeerDirectoryPlace.java
+++ b/src/test/java/emissary/directory/FTestPeerDirectoryPlace.java
@@ -1,23 +1,24 @@
 package emissary.directory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Set;
-
 import emissary.core.BaseDataObject;
 import emissary.core.IBaseDataObject;
 import emissary.place.IServiceProviderPlace;
 import emissary.test.core.junit5.FunctionalTest;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FTestPeerDirectoryPlace extends FunctionalTest {
 

--- a/src/test/java/emissary/directory/HeartbeatManagerTest.java
+++ b/src/test/java/emissary/directory/HeartbeatManagerTest.java
@@ -1,19 +1,9 @@
 package emissary.directory;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
-import javax.ws.rs.core.MediaType;
-
 import emissary.client.EmissaryClient;
 import emissary.client.EmissaryResponse;
 import emissary.test.core.junit5.UnitTest;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -25,6 +15,16 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.HttpContext;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import javax.ws.rs.core.MediaType;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class HeartbeatManagerTest extends UnitTest {
 

--- a/src/test/java/emissary/directory/KeyManipulatorTest.java
+++ b/src/test/java/emissary/directory/KeyManipulatorTest.java
@@ -1,11 +1,12 @@
 package emissary.directory;
 
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
 
 class KeyManipulatorTest extends UnitTest {
 

--- a/src/test/java/emissary/directory/RoutingAlgorithmTest.java
+++ b/src/test/java/emissary/directory/RoutingAlgorithmTest.java
@@ -1,22 +1,23 @@
 package emissary.directory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import emissary.core.DataObjectFactory;
 import emissary.core.HDMobileAgent;
 import emissary.core.IBaseDataObject;
 import emissary.place.IServiceProviderPlace;
 import emissary.test.core.junit5.UnitTest;
 import emissary.util.io.ResourceReader;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class RoutingAlgorithmTest extends UnitTest {
     private MyDirectoryPlace dir;

--- a/src/test/java/emissary/directory/WildcardEntryTest.java
+++ b/src/test/java/emissary/directory/WildcardEntryTest.java
@@ -1,14 +1,15 @@
 package emissary.directory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 import java.util.Set;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WildcardEntryTest extends UnitTest {
 

--- a/src/test/java/emissary/id/IdPlaceTest.java
+++ b/src/test/java/emissary/id/IdPlaceTest.java
@@ -1,16 +1,17 @@
 package emissary.id;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.io.IOException;
-
 import emissary.core.DataObjectFactory;
 import emissary.core.IBaseDataObject;
 import emissary.core.ResourceException;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class IdPlaceTest extends UnitTest {
 

--- a/src/test/java/emissary/id/SizeIdPlaceTest.java
+++ b/src/test/java/emissary/id/SizeIdPlaceTest.java
@@ -1,15 +1,16 @@
 package emissary.id;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.io.IOException;
-
 import emissary.core.DataObjectFactory;
 import emissary.core.IBaseDataObject;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SizeIdPlaceTest extends UnitTest {
 

--- a/src/test/java/emissary/id/TikaFilePlaceTest.java
+++ b/src/test/java/emissary/id/TikaFilePlaceTest.java
@@ -1,11 +1,12 @@
 package emissary.id;
 
-import java.io.IOException;
-import java.util.stream.Stream;
-
 import emissary.place.IServiceProviderPlace;
 import emissary.test.core.junit5.IdentificationTest;
+
 import org.junit.jupiter.params.provider.Arguments;
+
+import java.io.IOException;
+import java.util.stream.Stream;
 
 class TikaFilePlaceTest extends IdentificationTest {
 

--- a/src/test/java/emissary/id/UnixFilePlaceTest.java
+++ b/src/test/java/emissary/id/UnixFilePlaceTest.java
@@ -1,11 +1,12 @@
 package emissary.id;
 
-import java.io.IOException;
-import java.util.stream.Stream;
-
 import emissary.place.IServiceProviderPlace;
 import emissary.test.core.junit5.IdentificationTest;
+
 import org.junit.jupiter.params.provider.Arguments;
+
+import java.io.IOException;
+import java.util.stream.Stream;
 
 class UnixFilePlaceTest extends IdentificationTest {
 

--- a/src/test/java/emissary/kff/ChecksumCalculatorTest.java
+++ b/src/test/java/emissary/kff/ChecksumCalculatorTest.java
@@ -1,18 +1,19 @@
 package emissary.kff;
 
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
+
+import java.security.NoSuchAlgorithmException;
+import java.util.Iterator;
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-
-import java.security.NoSuchAlgorithmException;
-import java.util.Iterator;
-import java.util.Set;
-
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
 
 class ChecksumCalculatorTest extends UnitTest {
 

--- a/src/test/java/emissary/kff/ChecksumResultsTest.java
+++ b/src/test/java/emissary/kff/ChecksumResultsTest.java
@@ -1,15 +1,16 @@
 package emissary.kff;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.security.NoSuchAlgorithmException;
 import java.util.Iterator;
 import java.util.Set;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class ChecksumResultsTest extends UnitTest {
 

--- a/src/test/java/emissary/kff/KffChainTest.java
+++ b/src/test/java/emissary/kff/KffChainTest.java
@@ -1,17 +1,18 @@
 package emissary.kff;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class KffChainTest extends UnitTest {
 

--- a/src/test/java/emissary/kff/KffDataObjectHandlerTest.java
+++ b/src/test/java/emissary/kff/KffDataObjectHandlerTest.java
@@ -1,23 +1,24 @@
 package emissary.kff;
 
+import emissary.core.DataObjectFactory;
+import emissary.core.IBaseDataObject;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.io.ResourceReader;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Map;
-
-import emissary.core.DataObjectFactory;
-import emissary.core.IBaseDataObject;
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.io.ResourceReader;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 class KffDataObjectHandlerTest extends UnitTest {
     static final byte[] DATA = "This is a test".getBytes();

--- a/src/test/java/emissary/kff/KffFileTest.java
+++ b/src/test/java/emissary/kff/KffFileTest.java
@@ -1,15 +1,16 @@
 package emissary.kff;
 
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.io.ResourceReader;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.io.ResourceReader;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 class KffFileTest extends UnitTest {
 

--- a/src/test/java/emissary/kff/KffMemcachedTest.java
+++ b/src/test/java/emissary/kff/KffMemcachedTest.java
@@ -1,12 +1,19 @@
 package emissary.kff;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.validateMockitoUsage;
-import static org.mockito.Mockito.when;
+import emissary.kff.KffFilter.FilterType;
+import emissary.test.core.junit5.UnitTest;
+
+import net.spy.memcached.MemcachedClient;
+import net.spy.memcached.internal.GetFuture;
+import net.spy.memcached.internal.OperationFuture;
+import net.spy.memcached.ops.Operation;
+import net.spy.memcached.ops.OperationStatus;
+import org.apache.commons.lang3.NotImplementedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -19,22 +26,15 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
 import javax.annotation.Nullable;
 
-import emissary.kff.KffFilter.FilterType;
-import emissary.test.core.junit5.UnitTest;
-import net.spy.memcached.MemcachedClient;
-import net.spy.memcached.internal.GetFuture;
-import net.spy.memcached.internal.OperationFuture;
-import net.spy.memcached.ops.Operation;
-import net.spy.memcached.ops.OperationStatus;
-import org.apache.commons.lang3.NotImplementedException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
-import org.mockito.stubbing.Answer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.validateMockitoUsage;
+import static org.mockito.Mockito.when;
 
 class KffMemcachedTest extends UnitTest {
 

--- a/src/test/java/emissary/kff/KffQuincyFileTest.java
+++ b/src/test/java/emissary/kff/KffQuincyFileTest.java
@@ -1,12 +1,13 @@
 package emissary.kff;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import emissary.test.core.junit5.UnitTest;
 import emissary.util.io.ResourceReader;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class KffQuincyFileTest extends UnitTest {
 

--- a/src/test/java/emissary/kff/SsdeepTest.java
+++ b/src/test/java/emissary/kff/SsdeepTest.java
@@ -1,7 +1,9 @@
 package emissary.kff;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.Hexl;
+
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -9,9 +11,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Random;
 
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.Hexl;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit tests for {@link Ssdeep}.

--- a/src/test/java/emissary/output/DropOffPlaceTest.java
+++ b/src/test/java/emissary/output/DropOffPlaceTest.java
@@ -1,8 +1,17 @@
 package emissary.output;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.config.Configurator;
+import emissary.config.ServiceConfigGuide;
+import emissary.core.DataObjectFactory;
+import emissary.core.IBaseDataObject;
+import emissary.output.filter.IDropOffFilter;
+import emissary.test.core.junit5.UnitTest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -18,17 +27,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import emissary.config.Configurator;
-import emissary.config.ServiceConfigGuide;
-import emissary.core.DataObjectFactory;
-import emissary.core.IBaseDataObject;
-import emissary.output.filter.IDropOffFilter;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DropOffPlaceTest extends UnitTest {
 

--- a/src/test/java/emissary/output/DropOffUtilTest.java
+++ b/src/test/java/emissary/output/DropOffUtilTest.java
@@ -1,11 +1,16 @@
 package emissary.output;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.config.Configurator;
+import emissary.config.ServiceConfigGuide;
+import emissary.core.BaseDataObject;
+import emissary.core.DataObjectFactory;
+import emissary.core.IBaseDataObject;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.TimeUtil;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -15,16 +20,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import emissary.config.Configurator;
-import emissary.config.ServiceConfigGuide;
-import emissary.core.BaseDataObject;
-import emissary.core.DataObjectFactory;
-import emissary.core.IBaseDataObject;
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.TimeUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for DropOffUtil

--- a/src/test/java/emissary/output/filter/DataFilterTest.java
+++ b/src/test/java/emissary/output/filter/DataFilterTest.java
@@ -1,7 +1,13 @@
 package emissary.output.filter;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.config.Configurator;
+import emissary.config.ServiceConfigGuide;
+import emissary.core.DataObjectFactory;
+import emissary.core.IBaseDataObject;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.shell.Executrix;
+
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -9,13 +15,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import emissary.config.Configurator;
-import emissary.config.ServiceConfigGuide;
-import emissary.core.DataObjectFactory;
-import emissary.core.IBaseDataObject;
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.shell.Executrix;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DataFilterTest extends UnitTest {
 

--- a/src/test/java/emissary/output/filter/JsonOutputFilterTest.java
+++ b/src/test/java/emissary/output/filter/JsonOutputFilterTest.java
@@ -1,8 +1,15 @@
 package emissary.output.filter;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.config.ServiceConfigGuide;
+import emissary.core.DataObjectFactory;
+import emissary.core.IBaseDataObject;
+import emissary.test.core.junit5.UnitTest;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -15,15 +22,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import emissary.config.ServiceConfigGuide;
-import emissary.core.DataObjectFactory;
-import emissary.core.IBaseDataObject;
-import emissary.test.core.junit5.UnitTest;
-import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JsonOutputFilterTest extends UnitTest {
 

--- a/src/test/java/emissary/output/filter/XmlOutputFilterTest.java
+++ b/src/test/java/emissary/output/filter/XmlOutputFilterTest.java
@@ -1,7 +1,15 @@
 package emissary.output.filter;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.config.ServiceConfigGuide;
+import emissary.core.DataObjectFactory;
+import emissary.core.IBaseDataObject;
+import emissary.test.core.junit5.UnitTest;
+
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -11,15 +19,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.Lists;
-import emissary.config.ServiceConfigGuide;
-import emissary.core.DataObjectFactory;
-import emissary.core.IBaseDataObject;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class XmlOutputFilterTest extends UnitTest {
 

--- a/src/test/java/emissary/output/roller/JournaledCoalescerTest.java
+++ b/src/test/java/emissary/output/roller/JournaledCoalescerTest.java
@@ -1,12 +1,20 @@
 package emissary.output.roller;
 
-import static emissary.output.roller.JournaledCoalescer.ROLLING_EXT;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.output.io.SimpleFileNameGenerator;
+import emissary.output.roller.journal.Journal;
+import emissary.output.roller.journal.JournalEntry;
+import emissary.output.roller.journal.JournalReader;
+import emissary.output.roller.journal.JournalWriter;
+import emissary.output.roller.journal.JournaledChannelPool;
+import emissary.output.roller.journal.KeyedOutput;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.io.FileNameGenerator;
+import emissary.util.io.UnitTestFileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -26,20 +34,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import emissary.output.io.SimpleFileNameGenerator;
-import emissary.output.roller.journal.Journal;
-import emissary.output.roller.journal.JournalEntry;
-import emissary.output.roller.journal.JournalReader;
-import emissary.output.roller.journal.JournalWriter;
-import emissary.output.roller.journal.JournaledChannelPool;
-import emissary.output.roller.journal.KeyedOutput;
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.io.FileNameGenerator;
-import emissary.util.io.UnitTestFileUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static emissary.output.roller.JournaledCoalescer.ROLLING_EXT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JournaledCoalescerTest extends UnitTest {
 

--- a/src/test/java/emissary/output/roller/journal/JournalTest.java
+++ b/src/test/java/emissary/output/roller/journal/JournalTest.java
@@ -1,16 +1,17 @@
 package emissary.output.roller.journal;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.UUID;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class JournalTest extends UnitTest {
     private Path tmpDir;

--- a/src/test/java/emissary/output/roller/journal/JournaledChannelPoolTest.java
+++ b/src/test/java/emissary/output/roller/journal/JournaledChannelPoolTest.java
@@ -1,7 +1,12 @@
 package emissary.output.roller.journal;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.io.UnitTestFileUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -11,12 +16,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.UUID;
 
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.io.UnitTestFileUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JournaledChannelPoolTest extends UnitTest {
 

--- a/src/test/java/emissary/output/roller/journal/JournaledChannelTest.java
+++ b/src/test/java/emissary/output/roller/journal/JournaledChannelTest.java
@@ -1,8 +1,12 @@
 package emissary.output.roller.journal;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -11,12 +15,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
 
-import emissary.test.core.junit5.UnitTest;
-import org.apache.commons.io.IOUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JournaledChannelTest extends UnitTest {
 

--- a/src/test/java/emissary/parser/DataByteArraySlicerTest.java
+++ b/src/test/java/emissary/parser/DataByteArraySlicerTest.java
@@ -1,13 +1,14 @@
 package emissary.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class DataByteArraySlicerTest extends UnitTest {
     @Test

--- a/src/test/java/emissary/parser/DataByteBufferSlicerTest.java
+++ b/src/test/java/emissary/parser/DataByteBufferSlicerTest.java
@@ -1,14 +1,15 @@
 package emissary.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class DataByteBufferSlicerTest extends UnitTest {
     @Test

--- a/src/test/java/emissary/parser/DataIdentifierTest.java
+++ b/src/test/java/emissary/parser/DataIdentifierTest.java
@@ -1,19 +1,20 @@
 package emissary.parser;
 
-import static emissary.parser.DataIdentifier.UNKNOWN_TYPE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Arrays;
-import java.util.stream.Stream;
-
 import emissary.config.ServiceConfigGuide;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static emissary.parser.DataIdentifier.UNKNOWN_TYPE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DataIdentifierTest extends UnitTest {
 

--- a/src/test/java/emissary/parser/DecomposedSessionTest.java
+++ b/src/test/java/emissary/parser/DecomposedSessionTest.java
@@ -1,12 +1,10 @@
 package emissary.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+
+import com.google.common.collect.Multimap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,10 +12,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.Multimap;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DecomposedSessionTest extends UnitTest {
 

--- a/src/test/java/emissary/parser/InputSessionTest.java
+++ b/src/test/java/emissary/parser/InputSessionTest.java
@@ -1,14 +1,15 @@
 package emissary.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class InputSessionTest extends UnitTest {
 

--- a/src/test/java/emissary/parser/ParserFactoryTest.java
+++ b/src/test/java/emissary/parser/ParserFactoryTest.java
@@ -1,17 +1,18 @@
 package emissary.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import emissary.config.Configurator;
+import emissary.config.ServiceConfigGuide;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.WindowedSeekableByteChannel;
+
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 
-import emissary.config.Configurator;
-import emissary.config.ServiceConfigGuide;
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.WindowedSeekableByteChannel;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ParserFactoryTest extends UnitTest {
 

--- a/src/test/java/emissary/parser/PositionRecordTest.java
+++ b/src/test/java/emissary/parser/PositionRecordTest.java
@@ -1,9 +1,10 @@
 package emissary.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * PositionRecord is pretty stupid so this shouldn't take much effort to test...

--- a/src/test/java/emissary/parser/SessionProducerTest.java
+++ b/src/test/java/emissary/parser/SessionProducerTest.java
@@ -1,12 +1,13 @@
 package emissary.parser;
 
+import emissary.core.IBaseDataObject;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-
-import emissary.core.IBaseDataObject;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation")
 // TODO: either remove these tests or test the new Parser

--- a/src/test/java/emissary/parser/SimpleNioParserTest.java
+++ b/src/test/java/emissary/parser/SimpleNioParserTest.java
@@ -1,10 +1,10 @@
 package emissary.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -14,10 +14,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class SimpleNioParserTest extends UnitTest {
 

--- a/src/test/java/emissary/parser/SimpleParserTest.java
+++ b/src/test/java/emissary/parser/SimpleParserTest.java
@@ -1,10 +1,9 @@
 package emissary.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,9 +13,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("deprecation")
 // duh, this is testing deprecated class

--- a/src/test/java/emissary/pickup/BreakableFilePickUpClient.java
+++ b/src/test/java/emissary/pickup/BreakableFilePickUpClient.java
@@ -1,13 +1,13 @@
 package emissary.pickup;
 
+import emissary.pickup.file.FilePickUpClient;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Date;
 import java.util.Timer;
 import java.util.TimerTask;
-
-import emissary.pickup.file.FilePickUpClient;
 
 public class BreakableFilePickUpClient extends FilePickUpClient {
 

--- a/src/test/java/emissary/pickup/FTestFailedPickupClient.java
+++ b/src/test/java/emissary/pickup/FTestFailedPickupClient.java
@@ -1,21 +1,22 @@
 package emissary.pickup;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.core.Namespace;
+import emissary.directory.EmissaryNode;
+import emissary.directory.IDirectoryPlace;
+import emissary.test.core.junit5.FunctionalTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import emissary.core.Namespace;
-import emissary.directory.EmissaryNode;
-import emissary.directory.IDirectoryPlace;
-import emissary.test.core.junit5.FunctionalTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FTestFailedPickupClient extends FunctionalTest {
     private BreakableFilePickUpClient goodplace = null;

--- a/src/test/java/emissary/pickup/FTestMultipleWorkSpaces.java
+++ b/src/test/java/emissary/pickup/FTestMultipleWorkSpaces.java
@@ -1,23 +1,24 @@
 package emissary.pickup;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.util.ArrayList;
-import java.util.List;
-
 import emissary.command.FeedCommand;
 import emissary.core.Namespace;
 import emissary.directory.EmissaryNode;
 import emissary.directory.IDirectoryPlace;
 import emissary.pickup.file.FilePickUpClient;
 import emissary.test.core.junit5.FunctionalTest;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FTestMultipleWorkSpaces extends FunctionalTest {
     private FilePickUpClient place = null;

--- a/src/test/java/emissary/pickup/FTestWorkSpaceMaxBundleSize.java
+++ b/src/test/java/emissary/pickup/FTestWorkSpaceMaxBundleSize.java
@@ -1,22 +1,23 @@
 package emissary.pickup;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.command.FeedCommand;
+import emissary.core.Namespace;
+import emissary.directory.EmissaryNode;
+import emissary.directory.IDirectoryPlace;
+import emissary.test.core.junit5.FunctionalTest;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import emissary.command.FeedCommand;
-import emissary.core.Namespace;
-import emissary.directory.EmissaryNode;
-import emissary.directory.IDirectoryPlace;
-import emissary.test.core.junit5.FunctionalTest;
-import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FTestWorkSpaceMaxBundleSize extends FunctionalTest {
     private MyWorkSpace space = null;

--- a/src/test/java/emissary/pickup/PickUpPlaceTest.java
+++ b/src/test/java/emissary/pickup/PickUpPlaceTest.java
@@ -1,14 +1,15 @@
 package emissary.pickup;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import emissary.core.IMobileAgent;
 import emissary.pickup.file.FilePickUpClient;
 import emissary.pickup.file.FilePickUpPlace;
 import emissary.server.EmissaryServer;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PickUpPlaceTest extends UnitTest {
 

--- a/src/test/java/emissary/pickup/PickupQueueTest.java
+++ b/src/test/java/emissary/pickup/PickupQueueTest.java
@@ -1,13 +1,14 @@
 package emissary.pickup;
 
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 class PickupQueueTest extends UnitTest {
     @Override

--- a/src/test/java/emissary/pickup/QueServerTest.java
+++ b/src/test/java/emissary/pickup/QueServerTest.java
@@ -1,15 +1,16 @@
 package emissary.pickup;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class QueServerTest extends UnitTest {
 

--- a/src/test/java/emissary/pickup/WorkBundleTest.java
+++ b/src/test/java/emissary/pickup/WorkBundleTest.java
@@ -1,11 +1,8 @@
 package emissary.pickup;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -18,8 +15,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class WorkBundleTest extends UnitTest {
 

--- a/src/test/java/emissary/pickup/WorkSpaceTest.java
+++ b/src/test/java/emissary/pickup/WorkSpaceTest.java
@@ -1,17 +1,18 @@
 package emissary.pickup;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import emissary.command.FeedCommand;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import emissary.command.FeedCommand;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class WorkSpaceTest extends UnitTest {
     MyWorkSpace mws;

--- a/src/test/java/emissary/pickup/WorkUnitTest.java
+++ b/src/test/java/emissary/pickup/WorkUnitTest.java
@@ -1,13 +1,13 @@
 package emissary.pickup;
 
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.UUID;
-
-import org.junit.jupiter.api.Test;
 
 class WorkUnitTest {
     @Test

--- a/src/test/java/emissary/pickup/file/FTestSpacePlaceInteraction.java
+++ b/src/test/java/emissary/pickup/file/FTestSpacePlaceInteraction.java
@@ -1,15 +1,5 @@
 package emissary.pickup.file;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-
 import emissary.core.IBaseDataObject;
 import emissary.core.Namespace;
 import emissary.pickup.Priority;
@@ -18,10 +8,21 @@ import emissary.pickup.WorkBundle;
 import emissary.pickup.WorkSpace;
 import emissary.test.core.junit5.FunctionalTest;
 import emissary.util.io.ResourceReader;
+
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class FTestSpacePlaceInteraction extends FunctionalTest {
     private FilePickUpClient place = null;

--- a/src/test/java/emissary/pickup/file/FilePickUpClientTest.java
+++ b/src/test/java/emissary/pickup/file/FilePickUpClientTest.java
@@ -1,7 +1,15 @@
 package emissary.pickup.file;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.admin.PlaceStarter;
+import emissary.core.DataObjectFactory;
+import emissary.core.IBaseDataObject;
+import emissary.pickup.WorkBundle;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.io.ResourceReader;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,15 +18,8 @@ import java.security.MessageDigest;
 import java.util.Collection;
 import java.util.Map;
 
-import emissary.admin.PlaceStarter;
-import emissary.core.DataObjectFactory;
-import emissary.core.IBaseDataObject;
-import emissary.pickup.WorkBundle;
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.io.ResourceReader;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FilePickUpClientTest extends UnitTest {
     private static final String CLIENT_KEY = "http://localhost:8005/FilePickUpClient";

--- a/src/test/java/emissary/place/CoordinationPlaceTest.java
+++ b/src/test/java/emissary/place/CoordinationPlaceTest.java
@@ -1,15 +1,5 @@
 package emissary.place;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.io.InputStream;
-import java.util.Collections;
-import java.util.List;
-
 import emissary.core.DataObjectFactory;
 import emissary.core.IBaseDataObject;
 import emissary.core.MobileAgent;
@@ -17,11 +7,22 @@ import emissary.core.Namespace;
 import emissary.core.ResourceWatcher;
 import emissary.test.core.junit5.UnitTest;
 import emissary.util.io.ResourceReader;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class CoordinationPlaceTest extends UnitTest {
 

--- a/src/test/java/emissary/place/FTestCoordinatePlace.java
+++ b/src/test/java/emissary/place/FTestCoordinatePlace.java
@@ -1,13 +1,5 @@
 package emissary.place;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.InputStream;
-import java.util.Map;
-
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
 import emissary.core.DataObjectFactory;
@@ -16,9 +8,18 @@ import emissary.core.Namespace;
 import emissary.core.ResourceWatcher;
 import emissary.test.core.junit5.FunctionalTest;
 import emissary.util.io.ResourceReader;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FTestCoordinatePlace extends FunctionalTest {
 

--- a/src/test/java/emissary/place/FTestSkippingCoordinationPlace.java
+++ b/src/test/java/emissary/place/FTestSkippingCoordinationPlace.java
@@ -1,14 +1,5 @@
 package emissary.place;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Map;
-
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
 import emissary.core.DataObjectFactory;
@@ -18,9 +9,19 @@ import emissary.core.ResourceWatcher;
 import emissary.place.sample.ToLowerPlace;
 import emissary.test.core.junit5.FunctionalTest;
 import emissary.util.io.ResourceReader;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FTestSkippingCoordinationPlace extends FunctionalTest {
     private CoordinationPlace place;

--- a/src/test/java/emissary/place/KffHashPlaceTest.java
+++ b/src/test/java/emissary/place/KffHashPlaceTest.java
@@ -1,13 +1,14 @@
 package emissary.place;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import emissary.core.BaseDataObject;
 import emissary.core.IBaseDataObject;
 import emissary.kff.KffDataObjectHandler;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests the KffHashPlace

--- a/src/test/java/emissary/place/MainTest.java
+++ b/src/test/java/emissary/place/MainTest.java
@@ -1,13 +1,17 @@
 package emissary.place;
 
-import static emissary.place.Main.filePathIsWithinBaseDirectory;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import emissary.core.DataObjectFactory;
+import emissary.core.Form;
+import emissary.core.IBaseDataObject;
+import emissary.core.Namespace;
+import emissary.test.core.junit5.UnitTest;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -19,17 +23,14 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-import emissary.core.DataObjectFactory;
-import emissary.core.Form;
-import emissary.core.IBaseDataObject;
-import emissary.core.Namespace;
-import emissary.test.core.junit5.UnitTest;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Options;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static emissary.place.Main.filePathIsWithinBaseDirectory;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 final class MainTest extends UnitTest {
     private final String className = "emissary.place.sample.DevNullPlace";

--- a/src/test/java/emissary/place/MultiFileServerPlaceTest.java
+++ b/src/test/java/emissary/place/MultiFileServerPlaceTest.java
@@ -1,24 +1,25 @@
 package emissary.place;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import emissary.core.DataObjectFactory;
+import emissary.core.Family;
+import emissary.core.IBaseDataObject;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.io.ResourceReader;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import emissary.core.DataObjectFactory;
-import emissary.core.Family;
-import emissary.core.IBaseDataObject;
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.io.ResourceReader;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class MultiFileServerPlaceTest extends UnitTest {
     MFSPlace mfsp = null;

--- a/src/test/java/emissary/place/MultiFileUnixCommandPlaceTest.java
+++ b/src/test/java/emissary/place/MultiFileUnixCommandPlaceTest.java
@@ -1,13 +1,18 @@
 package emissary.place;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.validateMockitoUsage;
-import static org.mockito.Mockito.verify;
+import emissary.core.DataObjectFactory;
+import emissary.core.IBaseDataObject;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.io.ResourceReader;
+import emissary.util.io.UnitTestFileUtils;
+import emissary.util.shell.Executrix;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -17,18 +22,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import emissary.core.DataObjectFactory;
-import emissary.core.IBaseDataObject;
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.io.ResourceReader;
-import emissary.util.io.UnitTestFileUtils;
-import emissary.util.shell.Executrix;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.validateMockitoUsage;
+import static org.mockito.Mockito.verify;
 
 class MultiFileUnixCommandPlaceTest extends UnitTest {
     private MultiFileUnixCommandPlace place;

--- a/src/test/java/emissary/place/MyFileConfigedTestPlace.java
+++ b/src/test/java/emissary/place/MyFileConfigedTestPlace.java
@@ -1,9 +1,9 @@
 package emissary.place;
 
+import emissary.core.IBaseDataObject;
+
 import java.io.IOException;
 import java.io.InputStream;
-
-import emissary.core.IBaseDataObject;
 
 public class MyFileConfigedTestPlace extends ServiceProviderPlace {
 

--- a/src/test/java/emissary/place/MyStreamConfigedTestPlace.java
+++ b/src/test/java/emissary/place/MyStreamConfigedTestPlace.java
@@ -1,9 +1,9 @@
 package emissary.place;
 
+import emissary.core.IBaseDataObject;
+
 import java.io.IOException;
 import java.io.InputStream;
-
-import emissary.core.IBaseDataObject;
 
 public class MyStreamConfigedTestPlace extends ServiceProviderPlace {
 

--- a/src/test/java/emissary/place/OOMPlace.java
+++ b/src/test/java/emissary/place/OOMPlace.java
@@ -1,9 +1,9 @@
 package emissary.place;
 
+import emissary.core.IBaseDataObject;
+
 import java.io.IOException;
 import java.io.InputStream;
-
-import emissary.core.IBaseDataObject;
 
 public class OOMPlace extends ServiceProviderPlace {
     public OOMPlace(String configInfo, String dir, String placeLoc) throws IOException {

--- a/src/test/java/emissary/place/RehashingPlaceTest.java
+++ b/src/test/java/emissary/place/RehashingPlaceTest.java
@@ -1,19 +1,20 @@
 package emissary.place;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-
 import emissary.core.BaseDataObject;
 import emissary.core.IBaseDataObject;
 import emissary.kff.KffDataObjectHandler;
 import emissary.parser.SessionParser;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class RehashingPlaceTest extends UnitTest {
 

--- a/src/test/java/emissary/place/ServiceProviderPlaceGetTLDTest.java
+++ b/src/test/java/emissary/place/ServiceProviderPlaceGetTLDTest.java
@@ -1,11 +1,5 @@
 package emissary.place;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import emissary.core.DataObjectFactory;
 import emissary.core.Family;
 import emissary.core.IBaseDataObject;
@@ -13,8 +7,15 @@ import emissary.core.IMobileAgent;
 import emissary.pool.AgentPool;
 import emissary.pool.MobileAgentFactory;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ServiceProviderPlaceGetTLDTest extends UnitTest {
 

--- a/src/test/java/emissary/place/ServiceProviderPlaceTest.java
+++ b/src/test/java/emissary/place/ServiceProviderPlaceTest.java
@@ -1,11 +1,17 @@
 package emissary.place;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import emissary.config.ConfigUtil;
+import emissary.core.BaseDataObject;
+import emissary.core.EmissaryException;
+import emissary.core.IBaseDataObject;
+import emissary.core.Namespace;
+import emissary.directory.DirectoryEntry;
+import emissary.directory.KeyManipulator;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -17,17 +23,12 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 
-import emissary.config.ConfigUtil;
-import emissary.core.BaseDataObject;
-import emissary.core.EmissaryException;
-import emissary.core.IBaseDataObject;
-import emissary.core.Namespace;
-import emissary.directory.DirectoryEntry;
-import emissary.directory.KeyManipulator;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class ServiceProviderPlaceTest extends UnitTest {
     private IServiceProviderPlace place = null;

--- a/src/test/java/emissary/place/UnixCommandPlaceTest.java
+++ b/src/test/java/emissary/place/UnixCommandPlaceTest.java
@@ -1,5 +1,26 @@
 package emissary.place;
 
+import emissary.core.DataObjectFactory;
+import emissary.core.IBaseDataObject;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.io.ResourceReader;
+import emissary.util.shell.Executrix;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -12,26 +33,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.validateMockitoUsage;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
-import emissary.core.DataObjectFactory;
-import emissary.core.IBaseDataObject;
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.io.ResourceReader;
-import emissary.util.shell.Executrix;
-import org.apache.commons.io.IOUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class UnixCommandPlaceTest extends UnitTest {
     private UnixCommandPlace place;

--- a/src/test/java/emissary/pool/AgentPoolTest.java
+++ b/src/test/java/emissary/pool/AgentPoolTest.java
@@ -1,16 +1,16 @@
 package emissary.pool;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.util.stream.Stream;
-
-import javax.annotation.Nullable;
-
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AgentPoolTest extends UnitTest {
 

--- a/src/test/java/emissary/roll/RollManagerTest.java
+++ b/src/test/java/emissary/roll/RollManagerTest.java
@@ -1,19 +1,20 @@
 package emissary.roll;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.EmissaryIsolatedClassLoaderExtension;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Observable;
 import java.util.Observer;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.EmissaryIsolatedClassLoaderExtension;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RollManagerTest extends UnitTest {
 

--- a/src/test/java/emissary/roll/RollableTest.java
+++ b/src/test/java/emissary/roll/RollableTest.java
@@ -1,12 +1,12 @@
 package emissary.roll;
 
+import emissary.test.core.junit5.UnitTest;
+
 import java.io.IOException;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
-
-import emissary.test.core.junit5.UnitTest;
 
 public class RollableTest extends UnitTest implements Rollable, Observer {
     boolean wasRolled;

--- a/src/test/java/emissary/roll/RollerTest.java
+++ b/src/test/java/emissary/roll/RollerTest.java
@@ -1,13 +1,14 @@
 package emissary.roll;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RollerTest extends UnitTest {
     @Test

--- a/src/test/java/emissary/server/EmissaryServerIT.java
+++ b/src/test/java/emissary/server/EmissaryServerIT.java
@@ -1,19 +1,20 @@
 package emissary.server;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
 import emissary.client.EmissaryClient;
 import emissary.client.response.MapResponseEntity;
 import emissary.command.ServerCommand;
 import emissary.test.core.junit5.UnitTest;
 import emissary.util.Version;
+
 import org.apache.http.client.methods.HttpGet;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class EmissaryServerIT extends UnitTest {
 

--- a/src/test/java/emissary/server/InitializeContextTest.java
+++ b/src/test/java/emissary/server/InitializeContextTest.java
@@ -1,16 +1,17 @@
 package emissary.server;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-import javax.servlet.ServletContextEvent;
-
 import emissary.core.EmissaryException;
 import emissary.directory.EmissaryNode;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import javax.servlet.ServletContextEvent;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 class InitializeContextTest extends UnitTest {
 

--- a/src/test/java/emissary/server/api/EmissaryApiTest.java
+++ b/src/test/java/emissary/server/api/EmissaryApiTest.java
@@ -1,31 +1,5 @@
 package emissary.server.api;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
-
-import javax.ws.rs.core.Response;
-
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.health.HealthCheck;
-import com.codahale.metrics.health.HealthCheckRegistry;
-import com.google.common.collect.Sets;
 import emissary.client.response.Agent;
 import emissary.client.response.AgentsResponseEntity;
 import emissary.client.response.MapResponseEntity;
@@ -40,11 +14,37 @@ import emissary.pool.AgentPool;
 import emissary.pool.MobileAgentFactory;
 import emissary.server.EmissaryServer;
 import emissary.server.mvc.EndpointTestBase;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.google.common.collect.Sets;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import javax.ws.rs.core.Response;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 class EmissaryApiTest extends EndpointTestBase {
 

--- a/src/test/java/emissary/server/api/PeersIT.java
+++ b/src/test/java/emissary/server/api/PeersIT.java
@@ -1,18 +1,5 @@
 package emissary.server.api;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
-import javax.ws.rs.core.Response;
-
-import com.google.common.collect.Sets;
 import emissary.client.response.PeersResponseEntity;
 import emissary.command.ServerCommand;
 import emissary.config.ConfigUtil;
@@ -23,10 +10,23 @@ import emissary.directory.DirectoryPlace;
 import emissary.directory.EmissaryNode;
 import emissary.server.EmissaryServer;
 import emissary.server.mvc.EndpointTestBase;
+
+import com.google.common.collect.Sets;
 import org.apache.commons.collections4.CollectionUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.ws.rs.core.Response;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PeersIT extends EndpointTestBase {
 

--- a/src/test/java/emissary/server/mvc/EmissaryMvcTest.java
+++ b/src/test/java/emissary/server/mvc/EmissaryMvcTest.java
@@ -1,26 +1,26 @@
 package emissary.server.mvc;
 
+import emissary.core.Namespace;
+import emissary.directory.DirectoryEntry;
+import emissary.directory.DirectoryEntryList;
+import emissary.directory.IDirectoryPlace;
+import emissary.util.Version;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Response;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.Response;
-
-import emissary.core.Namespace;
-import emissary.directory.DirectoryEntry;
-import emissary.directory.DirectoryEntryList;
-import emissary.directory.IDirectoryPlace;
-import emissary.util.Version;
-import org.junit.jupiter.api.Test;
 
 class EmissaryMvcTest extends EndpointTestBase {
 

--- a/src/test/java/emissary/server/mvc/EndpointTestBase.java
+++ b/src/test/java/emissary/server/mvc/EndpointTestBase.java
@@ -1,15 +1,16 @@
 package emissary.server.mvc;
 
-import javax.ws.rs.core.Application;
-
 import emissary.core.Namespace;
 import emissary.test.core.junit5.UnitTest;
+
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.mvc.mustache.MustacheMvcFeature;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
 import org.junit.jupiter.api.AfterAll;
+
+import javax.ws.rs.core.Application;
 
 public abstract class EndpointTestBase extends JerseyTest {
 

--- a/src/test/java/emissary/server/mvc/internal/DeregisterPlaceActionTest.java
+++ b/src/test/java/emissary/server/mvc/internal/DeregisterPlaceActionTest.java
@@ -1,28 +1,28 @@
 package emissary.server.mvc.internal;
 
-import static emissary.server.mvc.adapters.DirectoryAdapter.ADD_KEY;
-import static emissary.server.mvc.adapters.DirectoryAdapter.TARGET_DIRECTORY;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Arrays;
-import java.util.Collections;
-
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.Response;
-
 import emissary.core.Namespace;
 import emissary.directory.DirectoryPlace;
 import emissary.directory.EmissaryNode;
 import emissary.server.mvc.EndpointTestBase;
 import emissary.util.io.ResourceReader;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.Response;
+
+import static emissary.server.mvc.adapters.DirectoryAdapter.ADD_KEY;
+import static emissary.server.mvc.adapters.DirectoryAdapter.TARGET_DIRECTORY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DeregisterPlaceActionTest extends EndpointTestBase {
 

--- a/src/test/java/emissary/server/mvc/internal/FailDirectoryActionTest.java
+++ b/src/test/java/emissary/server/mvc/internal/FailDirectoryActionTest.java
@@ -1,5 +1,24 @@
 package emissary.server.mvc.internal;
 
+import emissary.core.Namespace;
+import emissary.directory.DirectoryPlace;
+import emissary.directory.EmissaryNode;
+import emissary.server.mvc.EndpointTestBase;
+import emissary.util.io.ResourceReader;
+
+import com.google.common.collect.Sets;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collections;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.Response;
+
 import static emissary.server.mvc.adapters.DirectoryAdapter.ADD_KEY;
 import static emissary.server.mvc.adapters.DirectoryAdapter.ADD_PROPAGATION_FLAG;
 import static emissary.server.mvc.adapters.DirectoryAdapter.FAILED_DIRECTORY_NAME;
@@ -8,25 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
-
-import java.util.Collections;
-
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.Response;
-
-import com.google.common.collect.Sets;
-import emissary.core.Namespace;
-import emissary.directory.DirectoryPlace;
-import emissary.directory.EmissaryNode;
-import emissary.server.mvc.EndpointTestBase;
-import emissary.util.io.ResourceReader;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class FailDirectoryActionTest extends EndpointTestBase {
 

--- a/src/test/java/emissary/server/mvc/internal/HeartbeatActionTest.java
+++ b/src/test/java/emissary/server/mvc/internal/HeartbeatActionTest.java
@@ -1,28 +1,28 @@
 package emissary.server.mvc.internal;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.util.Collections;
-
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.Response;
-
 import emissary.config.ConfigUtil;
 import emissary.core.Namespace;
 import emissary.directory.DirectoryPlace;
 import emissary.directory.EmissaryNode;
 import emissary.server.mvc.EndpointTestBase;
 import emissary.server.mvc.adapters.HeartbeatAdapter;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collections;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.Response;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class HeartbeatActionTest extends EndpointTestBase {
 

--- a/src/test/java/emissary/server/mvc/internal/RegisterPeerActionTest.java
+++ b/src/test/java/emissary/server/mvc/internal/RegisterPeerActionTest.java
@@ -1,30 +1,30 @@
 package emissary.server.mvc.internal;
 
-import static emissary.server.mvc.adapters.DirectoryAdapter.DIRECTORY_NAME;
-import static emissary.server.mvc.adapters.DirectoryAdapter.TARGET_DIRECTORY;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.util.Collections;
-
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.Response;
-
 import emissary.config.ConfigUtil;
 import emissary.core.Namespace;
 import emissary.directory.DirectoryPlace;
 import emissary.directory.EmissaryNode;
 import emissary.server.mvc.EndpointTestBase;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.util.Collections;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.Response;
+
+import static emissary.server.mvc.adapters.DirectoryAdapter.DIRECTORY_NAME;
+import static emissary.server.mvc.adapters.DirectoryAdapter.TARGET_DIRECTORY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class RegisterPeerActionTest extends EndpointTestBase {
 

--- a/src/test/java/emissary/server/mvc/internal/WorkBundleCompletedActionTest.java
+++ b/src/test/java/emissary/server/mvc/internal/WorkBundleCompletedActionTest.java
@@ -1,5 +1,21 @@
 package emissary.server.mvc.internal;
 
+import emissary.core.Namespace;
+import emissary.pickup.WorkSpace;
+import emissary.server.mvc.EndpointTestBase;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collections;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.Response;
+
 import static emissary.server.mvc.adapters.WorkSpaceAdapter.WORK_BUNDLE_ID;
 import static emissary.server.mvc.adapters.WorkSpaceAdapter.WORK_BUNDLE_STATUS;
 import static emissary.server.mvc.internal.WorkSpaceClientSpaceTakeAction.CLIENT_NAME;
@@ -8,22 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
-
-import java.util.Collections;
-
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.Response;
-
-import emissary.core.Namespace;
-import emissary.pickup.WorkSpace;
-import emissary.server.mvc.EndpointTestBase;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class WorkBundleCompletedActionTest extends EndpointTestBase {
 

--- a/src/test/java/emissary/server/mvc/internal/WorkSpaceClientSpaceTakeActionTest.java
+++ b/src/test/java/emissary/server/mvc/internal/WorkSpaceClientSpaceTakeActionTest.java
@@ -1,5 +1,22 @@
 package emissary.server.mvc.internal;
 
+import emissary.core.Namespace;
+import emissary.pickup.WorkBundle;
+import emissary.pickup.WorkSpace;
+import emissary.server.mvc.EndpointTestBase;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collections;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.Response;
+
 import static emissary.server.mvc.internal.WorkSpaceClientSpaceTakeAction.CLIENT_NAME;
 import static emissary.server.mvc.internal.WorkSpaceClientSpaceTakeAction.SPACE_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -7,23 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
-
-import java.util.Collections;
-
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.Response;
-
-import emissary.core.Namespace;
-import emissary.pickup.WorkBundle;
-import emissary.pickup.WorkSpace;
-import emissary.server.mvc.EndpointTestBase;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class WorkSpaceClientSpaceTakeActionTest extends EndpointTestBase {
 

--- a/src/test/java/emissary/test/core/ExtractionTest.java
+++ b/src/test/java/emissary/test/core/ExtractionTest.java
@@ -1,19 +1,5 @@
 package emissary.test.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
-import javax.xml.bind.DatatypeConverter;
-
 import emissary.core.DataObjectFactory;
 import emissary.core.Family;
 import emissary.core.IBaseDataObject;
@@ -21,6 +7,7 @@ import emissary.kff.KffDataObjectHandler;
 import emissary.place.IServiceProviderPlace;
 import emissary.util.io.ResourceReader;
 import emissary.util.xml.JDOMUtil;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jdom2.Attribute;
@@ -34,6 +21,19 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import javax.xml.bind.DatatypeConverter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
 public abstract class ExtractionTest extends UnitTest {

--- a/src/test/java/emissary/test/core/FunctionalTest.java
+++ b/src/test/java/emissary/test/core/FunctionalTest.java
@@ -1,11 +1,5 @@
 package emissary.test.core;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-
 import emissary.admin.PlaceStarter;
 import emissary.command.ServerCommand;
 import emissary.config.ConfigUtil;
@@ -16,7 +10,14 @@ import emissary.place.IServiceProviderPlace;
 import emissary.pool.AgentPool;
 import emissary.pool.MoveSpool;
 import emissary.server.EmissaryServer;
+
 import org.eclipse.jetty.server.Server;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Base class of all the functional tests

--- a/src/test/java/emissary/test/core/IdentificationTest.java
+++ b/src/test/java/emissary/test/core/IdentificationTest.java
@@ -1,17 +1,11 @@
 package emissary.test.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Collection;
-
 import emissary.core.DataObjectFactory;
 import emissary.core.Form;
 import emissary.core.IBaseDataObject;
 import emissary.place.IServiceProviderPlace;
 import emissary.util.io.ResourceReader;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,6 +13,13 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
 public abstract class IdentificationTest extends UnitTest {

--- a/src/test/java/emissary/test/core/TestExtractionTest.java
+++ b/src/test/java/emissary/test/core/TestExtractionTest.java
@@ -1,17 +1,18 @@
 package emissary.test.core;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.io.IOException;
-import java.io.InputStream;
-
 import emissary.place.IServiceProviderPlace;
+
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TestExtractionTest extends UnitTest {
 

--- a/src/test/java/emissary/test/core/UnitTest.java
+++ b/src/test/java/emissary/test/core/UnitTest.java
@@ -1,19 +1,10 @@
 package emissary.test.core;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.management.ThreadInfo;
-import java.util.ArrayList;
-import java.util.List;
-
 import emissary.command.ServerCommand;
 import emissary.config.ConfigUtil;
 import emissary.core.EmissaryException;
 import emissary.util.io.ResourceReader;
+
 import org.jdom2.Document;
 import org.jdom2.input.SAXBuilder;
 import org.junit.After;
@@ -31,6 +22,16 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.management.ThreadInfo;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Base class of all the unit tests

--- a/src/test/java/emissary/test/core/junit5/ExtractionTest.java
+++ b/src/test/java/emissary/test/core/junit5/ExtractionTest.java
@@ -1,23 +1,5 @@
 package emissary.test.core.junit5;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Stream;
-
-import javax.xml.bind.DatatypeConverter;
-
 import emissary.core.DataObjectFactory;
 import emissary.core.Family;
 import emissary.core.IBaseDataObject;
@@ -25,6 +7,7 @@ import emissary.kff.KffDataObjectHandler;
 import emissary.place.IServiceProviderPlace;
 import emissary.util.io.ResourceReader;
 import emissary.util.xml.JDOMUtil;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jdom2.Attribute;
@@ -38,6 +21,23 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.xml.bind.DatatypeConverter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class ExtractionTest extends UnitTest {
 

--- a/src/test/java/emissary/test/core/junit5/FunctionalTest.java
+++ b/src/test/java/emissary/test/core/junit5/FunctionalTest.java
@@ -1,13 +1,5 @@
 package emissary.test.core.junit5;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-
 import emissary.admin.PlaceStarter;
 import emissary.command.ServerCommand;
 import emissary.config.ConfigUtil;
@@ -18,7 +10,16 @@ import emissary.place.IServiceProviderPlace;
 import emissary.pool.AgentPool;
 import emissary.pool.MoveSpool;
 import emissary.server.EmissaryServer;
+
 import org.eclipse.jetty.server.Server;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Base class of all the functional tests

--- a/src/test/java/emissary/test/core/junit5/IdentificationTest.java
+++ b/src/test/java/emissary/test/core/junit5/IdentificationTest.java
@@ -1,17 +1,11 @@
 package emissary.test.core.junit5;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.stream.Stream;
-
 import emissary.core.DataObjectFactory;
 import emissary.core.Form;
 import emissary.core.IBaseDataObject;
 import emissary.place.IServiceProviderPlace;
 import emissary.util.io.ResourceReader;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -19,6 +13,13 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class IdentificationTest extends UnitTest {
 

--- a/src/test/java/emissary/test/core/junit5/UnitTest.java
+++ b/src/test/java/emissary/test/core/junit5/UnitTest.java
@@ -1,18 +1,10 @@
 package emissary.test.core.junit5;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
-import java.io.File;
-import java.io.InputStream;
-import java.lang.management.ThreadInfo;
-import java.util.List;
-import java.util.stream.Stream;
-
 import emissary.command.ServerCommand;
 import emissary.config.ConfigUtil;
 import emissary.core.EmissaryException;
 import emissary.util.io.ResourceReader;
+
 import org.jdom2.Document;
 import org.jdom2.input.SAXBuilder;
 import org.junit.jupiter.api.AfterEach;
@@ -25,6 +17,15 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.provider.Arguments;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.InputStream;
+import java.lang.management.ThreadInfo;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Base class of all the unit tests

--- a/src/test/java/emissary/test/core/junit5/extensions/TestAttempts.java
+++ b/src/test/java/emissary/test/core/junit5/extensions/TestAttempts.java
@@ -1,8 +1,15 @@
 package emissary.test.core.junit5.extensions;
 
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.ElementType.METHOD;
-import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.platform.commons.util.AnnotationUtils;
+import org.junit.platform.commons.util.Preconditions;
+import org.opentest4j.TestAbortedException;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,16 +21,9 @@ import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
-import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
-import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.platform.commons.util.AnnotationUtils;
-import org.junit.platform.commons.util.Preconditions;
-import org.opentest4j.TestAbortedException;
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.METHOD;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 /**
  * Attempts a test multiple times until it passes or the max amount of attempts is reached (default is 3).

--- a/src/test/java/emissary/transform/HtmlEscapePlaceTest.java
+++ b/src/test/java/emissary/transform/HtmlEscapePlaceTest.java
@@ -1,23 +1,24 @@
 package emissary.transform;
 
-import static emissary.transform.HtmlEscapePlace.DOCUMENT_TITLE;
-import static emissary.transform.HtmlEscapePlace.HTMLESC;
-import static emissary.transform.HtmlEscapePlace.SUMMARY;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.stream.Stream;
-
 import emissary.core.DataObjectFactory;
 import emissary.core.IBaseDataObject;
 import emissary.place.IServiceProviderPlace;
 import emissary.test.core.junit5.ExtractionTest;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.Arguments;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+import static emissary.transform.HtmlEscapePlace.DOCUMENT_TITLE;
+import static emissary.transform.HtmlEscapePlace.HTMLESC;
+import static emissary.transform.HtmlEscapePlace.SUMMARY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HtmlEscapePlaceTest extends ExtractionTest {
 

--- a/src/test/java/emissary/transform/JavascriptEscapePlaceTest.java
+++ b/src/test/java/emissary/transform/JavascriptEscapePlaceTest.java
@@ -1,11 +1,12 @@
 package emissary.transform;
 
-import java.io.IOException;
-import java.util.stream.Stream;
-
 import emissary.place.IServiceProviderPlace;
 import emissary.test.core.junit5.ExtractionTest;
+
 import org.junit.jupiter.params.provider.Arguments;
+
+import java.io.IOException;
+import java.util.stream.Stream;
 
 public class JavascriptEscapePlaceTest extends ExtractionTest {
 

--- a/src/test/java/emissary/transform/JsonEscapePlaceTest.java
+++ b/src/test/java/emissary/transform/JsonEscapePlaceTest.java
@@ -1,11 +1,12 @@
 package emissary.transform;
 
-import java.io.IOException;
-import java.util.stream.Stream;
-
 import emissary.place.IServiceProviderPlace;
 import emissary.test.core.junit5.ExtractionTest;
+
 import org.junit.jupiter.params.provider.Arguments;
+
+import java.io.IOException;
+import java.util.stream.Stream;
 
 public class JsonEscapePlaceTest extends ExtractionTest {
 

--- a/src/test/java/emissary/transform/decode/HtmlEscapeTest.java
+++ b/src/test/java/emissary/transform/decode/HtmlEscapeTest.java
@@ -1,12 +1,13 @@
 package emissary.transform.decode;
 
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.CharacterCounterSet;
+
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.CharacterCounterSet;
-import org.junit.jupiter.api.Test;
 
 class HtmlEscapeTest extends UnitTest {
 

--- a/src/test/java/emissary/transform/decode/JsonEscapeTest.java
+++ b/src/test/java/emissary/transform/decode/JsonEscapeTest.java
@@ -1,9 +1,10 @@
 package emissary.transform.decode;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class JsonEscapeTest extends UnitTest {
     @Test

--- a/src/test/java/emissary/util/ByteUtilTest.java
+++ b/src/test/java/emissary/util/ByteUtilTest.java
@@ -1,14 +1,15 @@
 package emissary.util;
 
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.List;
-
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
 
 class ByteUtilTest extends UnitTest {
 

--- a/src/test/java/emissary/util/CaseInsensitiveMapTest.java
+++ b/src/test/java/emissary/util/CaseInsensitiveMapTest.java
@@ -1,14 +1,15 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CaseInsensitiveMapTest extends UnitTest {
 

--- a/src/test/java/emissary/util/CharacterCounterSetTest.java
+++ b/src/test/java/emissary/util/CharacterCounterSetTest.java
@@ -1,13 +1,14 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.stream.Stream;
-
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CharacterCounterSetTest extends UnitTest {
 

--- a/src/test/java/emissary/util/CharsetUtilTest.java
+++ b/src/test/java/emissary/util/CharsetUtilTest.java
@@ -1,10 +1,11 @@
 package emissary.util;
 
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
 
 class CharsetUtilTest extends UnitTest {
     // Strings from wikipedia, 2017-07-18

--- a/src/test/java/emissary/util/ClassComparatorTest.java
+++ b/src/test/java/emissary/util/ClassComparatorTest.java
@@ -1,12 +1,13 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ClassComparatorTest extends UnitTest {
     @Test

--- a/src/test/java/emissary/util/ClassLookupCacheTest.java
+++ b/src/test/java/emissary/util/ClassLookupCacheTest.java
@@ -1,10 +1,11 @@
 package emissary.util;
 
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
-
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link ClassLookupCache}.

--- a/src/test/java/emissary/util/ConstructorLookupCacheTest.java
+++ b/src/test/java/emissary/util/ConstructorLookupCacheTest.java
@@ -1,12 +1,13 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.util.List;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for {@link ConstructorLookupCache}.

--- a/src/test/java/emissary/util/CounterSetTest.java
+++ b/src/test/java/emissary/util/CounterSetTest.java
@@ -1,12 +1,13 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class CounterSetTest extends UnitTest {
 

--- a/src/test/java/emissary/util/DataUtilTest.java
+++ b/src/test/java/emissary/util/DataUtilTest.java
@@ -1,20 +1,21 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.core.DataObjectFactory;
+import emissary.core.Form;
+import emissary.core.IBaseDataObject;
+import emissary.id.WorkUnit;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 
-import emissary.core.DataObjectFactory;
-import emissary.core.Form;
-import emissary.core.IBaseDataObject;
-import emissary.id.WorkUnit;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DataUtilTest extends UnitTest {
 

--- a/src/test/java/emissary/util/DependencyCheckTest.java
+++ b/src/test/java/emissary/util/DependencyCheckTest.java
@@ -1,16 +1,17 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
 import emissary.config.ServiceConfigGuide;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DependencyCheckTest extends UnitTest {
 

--- a/src/test/java/emissary/util/EmissaryIsolatedClassLoaderExtension.java
+++ b/src/test/java/emissary/util/EmissaryIsolatedClassLoaderExtension.java
@@ -1,16 +1,16 @@
 package emissary.util;
 
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+import org.junit.platform.commons.util.ReflectionUtils;
+
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Paths;
 import java.util.Arrays;
-
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.InvocationInterceptor;
-import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
-import org.junit.platform.commons.util.ReflectionUtils;
 
 public class EmissaryIsolatedClassLoaderExtension implements InvocationInterceptor {
 

--- a/src/test/java/emissary/util/EntropyTest.java
+++ b/src/test/java/emissary/util/EntropyTest.java
@@ -1,10 +1,11 @@
 package emissary.util;
 
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
 
 class EntropyTest extends UnitTest {
 

--- a/src/test/java/emissary/util/FlexibleDateTimeParserTest.java
+++ b/src/test/java/emissary/util/FlexibleDateTimeParserTest.java
@@ -1,16 +1,17 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class FlexibleDateTimeParserTest extends UnitTest {
 

--- a/src/test/java/emissary/util/HtmlEntityMapTest.java
+++ b/src/test/java/emissary/util/HtmlEntityMapTest.java
@@ -1,12 +1,13 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HtmlEntityMapTest extends UnitTest {
     @Test

--- a/src/test/java/emissary/util/LineTokenizerTest.java
+++ b/src/test/java/emissary/util/LineTokenizerTest.java
@@ -1,13 +1,14 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LineTokenizerTest extends UnitTest {
 

--- a/src/test/java/emissary/util/MagicNumberUtilTest.java
+++ b/src/test/java/emissary/util/MagicNumberUtilTest.java
@@ -1,14 +1,15 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MagicNumberUtilTest extends UnitTest {
     @Test

--- a/src/test/java/emissary/util/MetadataDictionaryUtilTest.java
+++ b/src/test/java/emissary/util/MetadataDictionaryUtilTest.java
@@ -1,22 +1,23 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+import emissary.core.MetadataDictionary;
+import emissary.core.MetadataDictionaryTest;
+import emissary.test.core.junit5.UnitTest;
+
+import com.google.common.collect.TreeMultimap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 
-import com.google.common.collect.TreeMultimap;
-import emissary.config.ConfigUtil;
-import emissary.config.Configurator;
-import emissary.core.MetadataDictionary;
-import emissary.core.MetadataDictionaryTest;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class MetadataDictionaryUtilTest extends UnitTest {
 

--- a/src/test/java/emissary/util/PayloadUtilTest.java
+++ b/src/test/java/emissary/util/PayloadUtilTest.java
@@ -1,8 +1,14 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.core.DataObjectFactory;
+import emissary.core.Family;
+import emissary.core.Form;
+import emissary.core.IBaseDataObject;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -11,14 +17,9 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
-import emissary.core.DataObjectFactory;
-import emissary.core.Family;
-import emissary.core.Form;
-import emissary.core.IBaseDataObject;
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PayloadUtilTest extends UnitTest {
 

--- a/src/test/java/emissary/util/PkiUtilTest.java
+++ b/src/test/java/emissary/util/PkiUtilTest.java
@@ -1,5 +1,11 @@
 package emissary.util;
 
+import emissary.test.core.junit5.UnitTest;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -10,11 +16,6 @@ import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-
-import emissary.test.core.junit5.UnitTest;
-import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 class PkiUtilTest extends UnitTest {
     private static final String projectBase = System.getenv("PROJECT_BASE"); // set in surefire config

--- a/src/test/java/emissary/util/ShortNameComparatorTest.java
+++ b/src/test/java/emissary/util/ShortNameComparatorTest.java
@@ -1,17 +1,18 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import emissary.core.BaseDataObject;
 import emissary.core.DataObjectFactory;
 import emissary.core.Family;
 import emissary.core.IBaseDataObject;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class ShortNameComparatorTest extends UnitTest {
     private final byte[] nobytes = new byte[0];

--- a/src/test/java/emissary/util/TimeUtilTest.java
+++ b/src/test/java/emissary/util/TimeUtilTest.java
@@ -1,9 +1,8 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.Month;
@@ -14,8 +13,10 @@ import java.time.format.DateTimeParseException;
 import java.time.zone.ZoneRulesException;
 import java.util.Date;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TimeUtilTest extends UnitTest {
 

--- a/src/test/java/emissary/util/TypeEngineTest.java
+++ b/src/test/java/emissary/util/TypeEngineTest.java
@@ -1,14 +1,15 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
 import emissary.config.Configurator;
 import emissary.config.ServiceConfigGuide;
 import emissary.core.EmissaryException;
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class TypeEngineTest extends UnitTest {
     @BeforeEach

--- a/src/test/java/emissary/util/WindowedSeekableByteChannelTest.java
+++ b/src/test/java/emissary/util/WindowedSeekableByteChannelTest.java
@@ -1,10 +1,8 @@
 package emissary.util;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
@@ -13,8 +11,11 @@ import java.nio.channels.Channels;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ReadableByteChannel;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *

--- a/src/test/java/emissary/util/io/ListOpenFilesTest.java
+++ b/src/test/java/emissary/util/io/ListOpenFilesTest.java
@@ -1,9 +1,12 @@
 package emissary.util.io;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.shell.Executrix;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,12 +14,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.shell.Executrix;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class ListOpenFilesTest extends UnitTest {
 

--- a/src/test/java/emissary/util/io/ResourceReaderTest.java
+++ b/src/test/java/emissary/util/io/ResourceReaderTest.java
@@ -1,14 +1,15 @@
 package emissary.util.io;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * This is a little complicated to test. If these tests fail it might be because your build system doesn't copy *.dat or

--- a/src/test/java/emissary/util/magic/MagicNumberTest.java
+++ b/src/test/java/emissary/util/magic/MagicNumberTest.java
@@ -1,12 +1,13 @@
 package emissary.util.magic;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import javax.xml.bind.DatatypeConverter;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MagicNumberTest extends UnitTest {
 

--- a/src/test/java/emissary/util/roll/RollableFileOutputStreamTest.java
+++ b/src/test/java/emissary/util/roll/RollableFileOutputStreamTest.java
@@ -1,8 +1,11 @@
 package emissary.util.roll;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import emissary.test.core.junit5.UnitTest;
+import emissary.util.io.FileNameGenerator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -10,11 +13,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
 
-import emissary.test.core.junit5.UnitTest;
-import emissary.util.io.FileNameGenerator;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests Rollable Output Stream.

--- a/src/test/java/emissary/util/search/BackwardsTreeScannerTest.java
+++ b/src/test/java/emissary/util/search/BackwardsTreeScannerTest.java
@@ -1,9 +1,9 @@
 package emissary.util.search;
 
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import org.junit.jupiter.api.Test;
 
 class BackwardsTreeScannerTest {
 

--- a/src/test/java/emissary/util/search/ByteMatcherTest.java
+++ b/src/test/java/emissary/util/search/ByteMatcherTest.java
@@ -1,18 +1,19 @@
 package emissary.util.search;
 
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.UnsupportedCharsetException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.nio.charset.UnsupportedCharsetException;
-
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 class ByteMatcherTest extends UnitTest {
 

--- a/src/test/java/emissary/util/search/FastBoyerMooreTest.java
+++ b/src/test/java/emissary/util/search/FastBoyerMooreTest.java
@@ -1,13 +1,14 @@
 package emissary.util.search;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class FastBoyerMooreTest extends UnitTest {
     private final String[][] keywords = {{"one", "two", "three", "four", "five"}, {"uno", "dos", "tres", "quatro", "cinco"},

--- a/src/test/java/emissary/util/search/KeywordScannerTest.java
+++ b/src/test/java/emissary/util/search/KeywordScannerTest.java
@@ -1,15 +1,16 @@
 package emissary.util.search;
 
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.UnsupportedCharsetException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.nio.charset.UnsupportedCharsetException;
-
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 class KeywordScannerTest extends UnitTest {
     private final byte[] DATA = "THIS is a test of the Emergency broadcasting system.".getBytes();

--- a/src/test/java/emissary/util/search/MultiKeywordScannerTest.java
+++ b/src/test/java/emissary/util/search/MultiKeywordScannerTest.java
@@ -1,9 +1,9 @@
 package emissary.util.search;
 
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.Test;
 
 class MultiKeywordScannerTest {
 

--- a/src/test/java/emissary/util/shell/ExecutrixTest.java
+++ b/src/test/java/emissary/util/shell/ExecutrixTest.java
@@ -1,13 +1,11 @@
 package emissary.util.shell;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.validateMockitoUsage;
-import static org.mockito.Mockito.when;
+import emissary.test.core.junit5.UnitTest;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -24,11 +22,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
 
-import emissary.test.core.junit5.UnitTest;
-import org.apache.commons.lang3.SystemUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.validateMockitoUsage;
+import static org.mockito.Mockito.when;
 
 class ExecutrixTest extends UnitTest {
     private Executrix e;

--- a/src/test/java/emissary/util/web/HtmlEscaperTest.java
+++ b/src/test/java/emissary/util/web/HtmlEscaperTest.java
@@ -1,10 +1,11 @@
 package emissary.util.web;
 
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
 
 class HtmlEscaperTest extends UnitTest {
 

--- a/src/test/java/emissary/util/web/HttpPostParametersTest.java
+++ b/src/test/java/emissary/util/web/HttpPostParametersTest.java
@@ -1,9 +1,10 @@
 package emissary.util.web;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class HttpPostParametersTest extends UnitTest {
 

--- a/src/test/java/emissary/util/web/UrlDataTest.java
+++ b/src/test/java/emissary/util/web/UrlDataTest.java
@@ -1,10 +1,11 @@
 package emissary.util.web;
 
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-
-import emissary.test.core.junit5.UnitTest;
-import org.junit.jupiter.api.Test;
 
 class UrlDataTest extends UnitTest {
 

--- a/src/test/java/emissary/util/web/UrlTest.java
+++ b/src/test/java/emissary/util/web/UrlTest.java
@@ -1,11 +1,12 @@
 package emissary.util.web;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import emissary.test.core.junit5.UnitTest;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UrlTest extends UnitTest {
 

--- a/src/test/java/emissary/util/xml/JDOMUtilTest.java
+++ b/src/test/java/emissary/util/xml/JDOMUtilTest.java
@@ -1,13 +1,14 @@
 package emissary.util.xml;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import emissary.test.core.junit5.UnitTest;
+
 import org.jdom2.Document;
 import org.jdom2.input.JDOMParseException;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class JDOMUtilTest extends UnitTest {
 

--- a/src/test/java/emissary/util/xml/SaferJDOMUtilTest.java
+++ b/src/test/java/emissary/util/xml/SaferJDOMUtilTest.java
@@ -1,13 +1,14 @@
 package emissary.util.xml;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import emissary.test.core.junit5.UnitTest;
+
 import org.jdom2.Document;
 import org.jdom2.JDOMException;
 import org.jdom2.input.JDOMParseException;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SaferJDOMUtilTest extends UnitTest {
 


### PR DESCRIPTION
This PR does nothing but the following

add the maven import sorter plugin
sort all the imports
Update the checkstyle config and enforce it on builds for import sorting
Added a maven plugin that automatically sorts the imports during the build, regardless of IDE settings. (thanks Tubbs)

Runs the checkstyle verification during the build by default (without an additional flag like before) to make sure that the impsort is as expected.

Right now the only "failing" violation for checkstyle is import ordering. As you fix other categories that are being flagged by checkstyle, increase their severity to error so that new instances of those violations will fail the build.

Several of my pull requests are being dinged for import sorting issues - but every file in our code base is inconsistent on import sorting so lets get ourselves together here.