### PR TITLE
change rejected parallel entry message from debug to error

### DIFF
--- a/src/main/java/emissary/core/MobileAgent.java
+++ b/src/main/java/emissary/core/MobileAgent.java
@@ -539,8 +539,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
                                 lastEntry.setDataType(cform);
                                 formID = lastEntry.getDataID();
                                 parallelEntryRejected = true;
-                                logger.debug("rejecting curEntry due to parallel check in {}, new formID={}, new lastEntry={}", this.visitedPlaces,
-                                        formID, lastEntry.getFullKey());
+                                logger.error("Rejecting parallel entry found for {}: visitedPlaces={}", lastEntry.getFullKey(), this.visitedPlaces);
                                 curEntry = nextKeyFromDirectory(formID, place, lastEntry, payloadArg);
                             } else {
                                 addParallelTrackingInfo(curEntry.getServiceName());


### PR DESCRIPTION
In order to show this, I had to re-work the place configs to force a collision where both DevNullPlace and CachePlace had the same SERVICE_NAME to show the error message and the behavior where we visited CachePlace first, tried to go to DevNullPlace but realized there was a parallel entry, rejected it and moved on ultimately to the next phase.

```
2022-11-18 20:43:13,801 localhost-8001 DEBUG emissary.core.MobileAgent - sample.dat - nextKeyFromDirectory found CASE.CACHE.ANALYZE.http://localhost:8001/DevNullPlace$5050
2022-11-18 20:43:13,801 localhost-8001 ERROR emissary.core.MobileAgent - sample.dat - Rejecting parallel entry found for CASE.CACHE.ANALYZE.http://localhost:8001/DevNullPlace$5050: visitedPlaces=[CACHE]
2022-11-18 20:43:13,801 localhost-8001 DEBUG emissary.core.MobileAgent - sample.dat  - nextKeyFromDirectory found null
2022-11-18 20:43:13,801 localhost-8001 DEBUG emissary.core.MobileAgent - sample.dat  - Trying nextKey for CASE::VERIFY with last=CASE.CACHE.ANALYZE.http://localhost:8001/DevNullPlace$5050, atPlace=CASE.CACHE.ANALYZE.http://localhost:8001/CachePlace$1010[1]
```
And the transform history looks like:
```
     CASE.TO_UPPER.TRANSFORM.http://localhost:8001/ToLowerPlace$6010
     CASE.CACHE.ANALYZE.http://localhost:8001/CachePlace$1010
     CASE.DROP_OFF.IO.http://localhost:8001/DropOffPlace$9990
```
to illustrate we never got to DevNullPlace