### PR TITLE
Added default CTOR to support Kryo deserialization

### DIFF
--- a/src/main/java/emissary/core/TransformHistory.java
+++ b/src/main/java/emissary/core/TransformHistory.java
@@ -175,6 +175,11 @@ public class TransformHistory {
         String key;
         boolean coordinated;
 
+        /**
+         * Needed to support Kryo deserialization
+         */
+        private History() {}
+
         public History(String key) {
             this(key, false);
         }


### PR DESCRIPTION
Kryo deserialization requires a default constructor, but it's fine if it's visibility is `private`