### PR TITLE
attempting to consolidate constants into classes

### DIFF
--- a/src/main/java/emissary/command/WhatCommand.java
+++ b/src/main/java/emissary/command/WhatCommand.java
@@ -37,6 +37,9 @@ import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
 
+import static emissary.core.Form.HTML;
+import static emissary.core.Form.TEXT;
+
 @Deprecated
 @Parameters(commandDescription = "Run Identification places on a payload to determine the file type")
 public class WhatCommand extends BaseCommand {
@@ -304,6 +307,6 @@ public class WhatCommand extends BaseCommand {
         }
 
         final String t = i.getFirstType();
-        return "HTML".equals(t) || t.endsWith("TEXT");
+        return HTML.equals(t) || t.endsWith(TEXT);
     }
 }

--- a/src/main/java/emissary/core/Form.java
+++ b/src/main/java/emissary/core/Form.java
@@ -10,6 +10,15 @@ public class Form {
     public static final String DONE = "DONE";
     public static final String EMPTY = "EMPTY_SESSION";
 
+    public static final String TEXT = "TEXT";
+    public static final String HTML = "HTML";
+
+    // Form prefixes
+    public static final String PREFIXES_LANG = "LANG-";
+
+    // Form suffixes
+    public static final String SUFFIXES_HTMLESC = "-HTMLESC";
+
     /** This class is not meant to be instantiated. */
     private Form() {}
 }

--- a/src/main/java/emissary/core/constants/Configurations.java
+++ b/src/main/java/emissary/core/constants/Configurations.java
@@ -1,0 +1,38 @@
+package emissary.core.constants;
+
+import com.google.common.collect.Lists;
+
+import java.util.Collections;
+import java.util.List;
+
+public class Configurations {
+
+    // common configs
+    public static final String END_FORM = "END_FORM";
+    public static final String NEW_FORM = "NEW_FORM";
+    public static final String OUTPUT_FORM = "OUTPUT_FORM";
+    public static final String PLACE_RESOURCE_LIMIT_MILLIS = "PLACE_RESOURCE_LIMIT_MILLIS";
+
+    // reserved configs for service/place creation
+    public static final String PLACE_NAME = "PLACE_NAME";
+    public static final String SERVICE_NAME = "SERVICE_NAME";
+    public static final String SERVICE_TYPE = "SERVICE_TYPE";
+    public static final String SERVICE_DESCRIPTION = "SERVICE_DESCRIPTION";
+    public static final String SERVICE_COST = "SERVICE_COST";
+    public static final String SERVICE_QUALITY = "SERVICE_QUALITY";
+    public static final String SERVICE_PROXY = "SERVICE_PROXY";
+    public static final String SERVICE_KEY = "SERVICE_KEY";
+
+    public static final List<String> RESERVED_CONFIGS_SERVICE = Collections.unmodifiableList(
+            Lists.newArrayList(
+                    PLACE_NAME,
+                    SERVICE_COST,
+                    SERVICE_DESCRIPTION,
+                    SERVICE_KEY,
+                    SERVICE_NAME,
+                    SERVICE_PROXY,
+                    SERVICE_QUALITY,
+                    SERVICE_TYPE));
+
+    private Configurations() {}
+}

--- a/src/main/java/emissary/core/constants/Configurations.java
+++ b/src/main/java/emissary/core/constants/Configurations.java
@@ -7,13 +7,13 @@ import java.util.List;
 
 public class Configurations {
 
-    // common configs
+    // common config keys
     public static final String END_FORM = "END_FORM";
     public static final String NEW_FORM = "NEW_FORM";
     public static final String OUTPUT_FORM = "OUTPUT_FORM";
     public static final String PLACE_RESOURCE_LIMIT_MILLIS = "PLACE_RESOURCE_LIMIT_MILLIS";
 
-    // reserved configs for service/place creation
+    // reserved config keys for service/place creation
     public static final String PLACE_NAME = "PLACE_NAME";
     public static final String SERVICE_NAME = "SERVICE_NAME";
     public static final String SERVICE_TYPE = "SERVICE_TYPE";
@@ -23,7 +23,10 @@ public class Configurations {
     public static final String SERVICE_PROXY = "SERVICE_PROXY";
     public static final String SERVICE_KEY = "SERVICE_KEY";
 
-    public static final List<String> RESERVED_CONFIGS_SERVICE = Collections.unmodifiableList(
+    /**
+     * The list of reserved service config keys for service/place creation
+     */
+    public static final List<String> RESERVED_SERVICE_CONFIG_KEYS = Collections.unmodifiableList(
             Lists.newArrayList(
                     PLACE_NAME,
                     SERVICE_COST,

--- a/src/main/java/emissary/core/constants/Parameters.java
+++ b/src/main/java/emissary/core/constants/Parameters.java
@@ -1,0 +1,21 @@
+package emissary.core.constants;
+
+public class Parameters {
+
+    // Common parameters
+    public static final String DOCUMENT_TITLE = "DocumentTitle";
+    public static final String EVENT_DATE = "EventDate";
+    public static final String FILE_DATE = "FILE_DATE";
+    public static final String FILE_NAME = "FILE_NAME";
+    public static final String INPUT_FILEDATE = "INPUT_FILEDATE";
+    public static final String INPUT_FILENAME = "INPUT_FILENAME";
+    public static final String ORIGINAL_FILENAME = "Original-Filename";
+    public static final String SUMMARY = "SUMMARY";
+
+    // Common parameter prefixes
+
+    // Common parameter suffixes
+    public static final String SUFFIXES_HTML_ESCAPE = "_HTML_ESCAPE";
+
+    private Parameters() {}
+}

--- a/src/main/java/emissary/output/DropOffUtil.java
+++ b/src/main/java/emissary/output/DropOffUtil.java
@@ -31,6 +31,11 @@ import java.util.SimpleTimeZone;
 import java.util.UUID;
 import javax.annotation.Nullable;
 
+import static emissary.core.Form.PREFIXES_LANG;
+import static emissary.core.Form.TEXT;
+import static emissary.core.Form.UNKNOWN;
+import static emissary.core.constants.Parameters.ORIGINAL_FILENAME;
+
 public class DropOffUtil {
     protected static final Logger logger = LoggerFactory.getLogger(DropOffUtil.class);
 
@@ -725,21 +730,21 @@ public class DropOffUtil {
             }
             if (StringUtils.isEmpty(fileType)) {
                 if (metaData.containsKey(FileTypeCheckParameter.FONT_ENCODING.getFieldName())) {
-                    fileType = "TEXT";
+                    fileType = TEXT;
                 } else {
-                    fileType = "UNKNOWN";
+                    fileType = UNKNOWN;
                 }
             }
 
             metaData.put(FileTypeCheckParameter.FILETYPE.getFieldName(), fileType);
         }
 
-        if ("UNKNOWN".equals(fileType) && forms.contains("MSWORD")) {
+        if (UNKNOWN.equals(fileType) && forms.contains("MSWORD")) {
             fileType = "MSWORD_FRAGMENT";
         }
 
-        if ("QUOTED-PRINTABLE".equals(fileType) || fileType.startsWith("LANG-") || fileType.startsWith("ENCODING(")) {
-            fileType = "TEXT";
+        if ("QUOTED-PRINTABLE".equals(fileType) || fileType.startsWith(PREFIXES_LANG) || fileType.startsWith("ENCODING(")) {
+            fileType = TEXT;
         }
 
         return fileType;
@@ -792,9 +797,9 @@ public class DropOffUtil {
             }
             if (StringUtils.isEmpty(fileType)) {
                 if (bdo.hasParameter(FileTypeCheckParameter.FONT_ENCODING.getFieldName())) {
-                    fileType = "TEXT";
+                    fileType = TEXT;
                 } else {
-                    fileType = "UNKNOWN";
+                    fileType = UNKNOWN;
                 }
             }
 
@@ -803,12 +808,12 @@ public class DropOffUtil {
             }
         }
 
-        if ("UNKNOWN".equals(fileType) && forms.contains("MSWORD")) {
+        if (UNKNOWN.equals(fileType) && forms.contains("MSWORD")) {
             fileType = "MSWORD_FRAGMENT";
         }
 
-        if ("QUOTED-PRINTABLE".equals(fileType) || fileType.startsWith("LANG-") || fileType.startsWith("ENCODING(")) {
-            fileType = "TEXT";
+        if ("QUOTED-PRINTABLE".equals(fileType) || fileType.startsWith(PREFIXES_LANG) || fileType.startsWith("ENCODING(")) {
+            fileType = TEXT;
         }
 
         return fileType;
@@ -1046,9 +1051,9 @@ public class DropOffUtil {
      *
      */
     void extractUniqueFileExtensions(IBaseDataObject p) {
-        if (p.hasParameter("Original-Filename")) {
+        if (p.hasParameter(ORIGINAL_FILENAME)) {
             final Set<String> extensions = new HashSet<>();
-            for (Object filename : p.getParameter("Original-Filename")) {
+            for (Object filename : p.getParameter(ORIGINAL_FILENAME)) {
                 final String fn = (String) filename;
                 if (StringUtils.isNotEmpty(fn) && fn.lastIndexOf('.') > -1) {
                     final int pos = fn.lastIndexOf('.') + 1;

--- a/src/main/java/emissary/output/filter/DataFilter.java
+++ b/src/main/java/emissary/output/filter/DataFilter.java
@@ -9,6 +9,7 @@ import emissary.output.DropOffUtil;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -53,7 +54,7 @@ public class DataFilter extends AbstractFilter {
         final String baseFileName = dropOffUtil.getPathFromSpec(outputSpec, d, tld);
         final String fileType = DropOffUtil.getFileType(d);
         final String currentForm = d.currentForm();
-        getCharset(d, "UTF-8");
+        getCharset(d, StandardCharsets.UTF_8.name());
         final String lang = dropOffUtil.getLanguage(d);
 
         int writeCount = 0;

--- a/src/main/java/emissary/pickup/PickUpPlace.java
+++ b/src/main/java/emissary/pickup/PickUpPlace.java
@@ -32,6 +32,9 @@ import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
 
+import static emissary.core.constants.Parameters.FILE_DATE;
+import static emissary.core.constants.Parameters.FILE_NAME;
+
 /**
  * This class is the base class of those places that inject data into the system. This place knows a lot about
  * processing files of input, including files of sessions that must be identified and parsed using a ParserFactory. It
@@ -247,8 +250,8 @@ public abstract class PickUpPlace extends ServiceProviderPlace implements IPickU
      * @param f the file it came from
      */
     protected void dataObjectCreated(IBaseDataObject d, File f) {
-        d.putParameter("FILE_DATE", TimeUtil.getDateAsISO8601(f.lastModified()));
-        d.putParameter("FILE_NAME", f.getName());
+        d.putParameter(FILE_DATE, TimeUtil.getDateAsISO8601(f.lastModified()));
+        d.putParameter(FILE_NAME, f.getName());
     }
 
     /**

--- a/src/main/java/emissary/pickup/file/FilePickUpClient.java
+++ b/src/main/java/emissary/pickup/file/FilePickUpClient.java
@@ -21,6 +21,10 @@ import java.util.Collection;
 import java.util.Map;
 import javax.annotation.Nullable;
 
+import static emissary.core.constants.Parameters.INPUT_FILEDATE;
+import static emissary.core.constants.Parameters.INPUT_FILENAME;
+import static emissary.core.constants.Parameters.ORIGINAL_FILENAME;
+
 /**
  * Pull bundles of file info from a WorkSpace and process as a normal FilePickUp. Monitors a queue rather than a
  * directory, but reads files from disk as specified in the received WorkBundle objects. Whether workBundles are
@@ -410,11 +414,11 @@ public class FilePickUpClient extends PickUpSpace implements IPickUp {
         }
 
         if (simpleParam) {
-            d.putParameter("Original-Filename", fn);
+            d.putParameter(ORIGINAL_FILENAME, fn);
         }
 
-        d.putParameter("INPUT_FILEDATE", TimeUtil.getDateAsISO8601(f.lastModified()));
-        d.putParameter("INPUT_FILENAME", f.getName());
+        d.putParameter(INPUT_FILEDATE, TimeUtil.getDateAsISO8601(f.lastModified()));
+        d.putParameter(INPUT_FILENAME, f.getName());
 
         // Fix up the case/project metadata, e.g. PROJECT:GERONIMO22
         String cid = currentBundle.getCaseId();

--- a/src/main/java/emissary/place/CoordinationPlace.java
+++ b/src/main/java/emissary/place/CoordinationPlace.java
@@ -18,6 +18,8 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import static emissary.core.constants.Configurations.OUTPUT_FORM;
+
 /**
  * This place will coordinate service to several lower level service places. We have a list and will execute each place
  * in turn. This is good for service orchestration and there is an override point for derived classed to determine
@@ -93,7 +95,7 @@ public class CoordinationPlace extends ServiceProviderPlace {
      * </ul>
      */
     protected void configurePlace() {
-        outputForm = configG.findStringEntry("OUTPUT_FORM", null);
+        outputForm = configG.findStringEntry(OUTPUT_FORM, null);
         pushForm = configG.findBooleanEntry("PUSH_OUTPUT_FORM", true);
         updateTransformHistory = configG.findBooleanEntry("UPDATE_TRANSFORM_HISTORY", false);
 

--- a/src/main/java/emissary/place/MultiFileUnixCommandPlace.java
+++ b/src/main/java/emissary/place/MultiFileUnixCommandPlace.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -21,6 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+
+import static emissary.core.constants.Parameters.DOCUMENT_TITLE;
 
 public class MultiFileUnixCommandPlace extends MultiFileServerPlace implements IMultiFileUnixCommandPlace {
     protected boolean doSynchronized;
@@ -45,7 +48,7 @@ public class MultiFileUnixCommandPlace extends MultiFileServerPlace implements I
     protected String contentFile = null;
     protected Executrix executrix;
     protected String logfilename;
-    protected String charset = "UTF-8";
+    protected String charset = StandardCharsets.UTF_8.name();
     protected boolean singleOutputAsChild = false;
     protected boolean preserveParentData = false;
 
@@ -344,7 +347,7 @@ public class MultiFileUnixCommandPlace extends MultiFileServerPlace implements I
 
             Map<String, Object> metaData = new HashMap<>();
             if (setTitleToFile) {
-                metaData.put("DocumentTitle", f.getName());
+                metaData.put(DOCUMENT_TITLE, f.getName());
             }
 
             List<String> tmpForms = getFormsFromFile(f);
@@ -485,7 +488,7 @@ public class MultiFileUnixCommandPlace extends MultiFileServerPlace implements I
         String filename = f.getName();
         d.setData(theData);
         if (setTitleToFile) {
-            d.putParameter("DocumentTitle", filename);
+            d.putParameter(DOCUMENT_TITLE, filename);
         }
         List<String> tmpForms = getFormsFromFile(f);
         for (String tmpForm : tmpForms) {

--- a/src/main/java/emissary/place/ServiceProviderPlace.java
+++ b/src/main/java/emissary/place/ServiceProviderPlace.java
@@ -43,6 +43,16 @@ import java.util.Set;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
 
+import static emissary.core.constants.Configurations.PLACE_NAME;
+import static emissary.core.constants.Configurations.PLACE_RESOURCE_LIMIT_MILLIS;
+import static emissary.core.constants.Configurations.SERVICE_COST;
+import static emissary.core.constants.Configurations.SERVICE_DESCRIPTION;
+import static emissary.core.constants.Configurations.SERVICE_KEY;
+import static emissary.core.constants.Configurations.SERVICE_NAME;
+import static emissary.core.constants.Configurations.SERVICE_PROXY;
+import static emissary.core.constants.Configurations.SERVICE_QUALITY;
+import static emissary.core.constants.Configurations.SERVICE_TYPE;
+
 /**
  * Concrete instances of ServiceProviderPlace can be created by the emissary.admin.PlaceStarter and registered with the
  * emissary.directory.IDirectoryPlace to make their respective services available and a specified cost and quality
@@ -384,7 +394,7 @@ public abstract class ServiceProviderPlace implements emissary.place.IServicePro
      * @param placeLocation the specified placeLocation or a full four part key to register with
      */
     protected void configureServicePlace(@Nullable String placeLocation) throws IOException {
-        serviceDescription = configG.findStringEntry("SERVICE_DESCRIPTION");
+        serviceDescription = configG.findStringEntry(SERVICE_DESCRIPTION);
         if (serviceDescription == null || serviceDescription.length() == 0) {
             serviceDescription = "Description not available";
         }
@@ -404,11 +414,11 @@ public abstract class ServiceProviderPlace implements emissary.place.IServicePro
 
 
         // Build keys the old fashioned way from parts specified in the config
-        String placeName = configG.findStringEntry("PLACE_NAME");
-        String serviceName = configG.findStringEntry("SERVICE_NAME");
-        String serviceType = configG.findStringEntry("SERVICE_TYPE");
-        int serviceCost = configG.findIntEntry("SERVICE_COST", -1);
-        int serviceQuality = configG.findIntEntry("SERVICE_QUALITY", -1);
+        String placeName = configG.findStringEntry(PLACE_NAME);
+        String serviceName = configG.findStringEntry(SERVICE_NAME);
+        String serviceType = configG.findStringEntry(SERVICE_TYPE);
+        int serviceCost = configG.findIntEntry(SERVICE_COST, -1);
+        int serviceQuality = configG.findIntEntry(SERVICE_QUALITY, -1);
 
         // Bah.
         if (placeName != null && placeName.length() == 0) {
@@ -423,7 +433,7 @@ public abstract class ServiceProviderPlace implements emissary.place.IServicePro
 
         if (placeName != null && serviceName != null && serviceType != null && serviceCost > -1 && serviceQuality > -1) {
             // pick up the proxies(save full 4-tuple keys!)
-            for (String sp : configG.findEntries("SERVICE_PROXY")) {
+            for (String sp : configG.findEntries(SERVICE_PROXY)) {
                 DirectoryEntry de = new DirectoryEntry(sp, serviceName, serviceType, locationPart, serviceDescription, serviceCost, serviceQuality);
                 keys.add(de.getFullKey());
             }
@@ -456,7 +466,7 @@ public abstract class ServiceProviderPlace implements emissary.place.IServicePro
         }
 
         // Now build any keys the new way
-        for (String k : configG.findEntries("SERVICE_KEY")) {
+        for (String k : configG.findEntries(SERVICE_KEY)) {
             if (KeyManipulator.isKeyComplete(k)) {
                 keys.add(k);
             } else {
@@ -998,7 +1008,7 @@ public abstract class ServiceProviderPlace implements emissary.place.IServicePro
      */
     @Override
     public long getResourceLimitMillis() {
-        return configG.findLongEntry("PLACE_RESOURCE_LIMIT_MILLIS", -2L);
+        return configG.findLongEntry(PLACE_RESOURCE_LIMIT_MILLIS, -2L);
     }
 
     /**

--- a/src/main/java/emissary/place/UnixCommandPlace.java
+++ b/src/main/java/emissary/place/UnixCommandPlace.java
@@ -13,6 +13,8 @@ import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import javax.annotation.Nullable;
 
+import static emissary.core.constants.Configurations.NEW_FORM;
+
 /**
  * Run a command external to the Emissary JVM to process data
  */
@@ -93,7 +95,7 @@ public class UnixCommandPlace extends ServiceProviderPlace {
      */
     protected void configurePlace() {
         doSynchronized = configG.findBooleanEntry("SYNCHRONIZED_PROCESS", false);
-        newForm = configG.findStringEntry("NEW_FORM", Form.UNKNOWN);
+        newForm = configG.findStringEntry(NEW_FORM, Form.UNKNOWN);
         if (newForm == null && keys.get(0).indexOf(".ID.") > -1) {
             newForm = Form.UNKNOWN;
         }

--- a/src/main/java/emissary/place/sample/ToLowerPlace.java
+++ b/src/main/java/emissary/place/sample/ToLowerPlace.java
@@ -5,6 +5,9 @@ import emissary.place.ServiceProviderPlace;
 
 import java.io.IOException;
 
+import static emissary.core.constants.Configurations.END_FORM;
+import static emissary.core.constants.Configurations.NEW_FORM;
+
 /**
  * This is the main ToLower program.
  *
@@ -38,8 +41,8 @@ public class ToLowerPlace extends ServiceProviderPlace {
     private void configurePlace() {
 
         // Set configuration items from ToLowerPlace.cfg
-        newForm = configG.findStringEntry("NEW_FORM", newForm);
-        endForm = configG.findStringEntry("END_FORM", endForm);
+        newForm = configG.findStringEntry(NEW_FORM, newForm);
+        endForm = configG.findStringEntry(END_FORM, endForm);
     }
 
     /**

--- a/src/main/java/emissary/place/sample/ToUpperPlace.java
+++ b/src/main/java/emissary/place/sample/ToUpperPlace.java
@@ -5,6 +5,9 @@ import emissary.place.ServiceProviderPlace;
 
 import java.io.IOException;
 
+import static emissary.core.constants.Configurations.END_FORM;
+import static emissary.core.constants.Configurations.NEW_FORM;
+
 /**
  * This is the ToUpper program.
  *
@@ -37,8 +40,8 @@ public class ToUpperPlace extends ServiceProviderPlace {
      */
     private void configurePlace() {
         // Set configuration items from ToUpperPlace.cfg
-        newForm = configG.findStringEntry("NEW_FORM", newForm);
-        endForm = configG.findStringEntry("END_FORM", endForm);
+        newForm = configG.findStringEntry(NEW_FORM, newForm);
+        endForm = configG.findStringEntry(END_FORM, endForm);
     }
 
     /**

--- a/src/main/java/emissary/transform/HtmlEscapePlace.java
+++ b/src/main/java/emissary/transform/HtmlEscapePlace.java
@@ -18,11 +18,16 @@ import org.apache.commons.lang3.StringUtils;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-public class HtmlEscapePlace extends ServiceProviderPlace {
+import static emissary.core.Form.HTML;
+import static emissary.core.Form.PREFIXES_LANG;
+import static emissary.core.Form.SUFFIXES_HTMLESC;
+import static emissary.core.Form.TEXT;
+import static emissary.core.constants.Configurations.OUTPUT_FORM;
+import static emissary.core.constants.Parameters.DOCUMENT_TITLE;
+import static emissary.core.constants.Parameters.SUFFIXES_HTML_ESCAPE;
+import static emissary.core.constants.Parameters.SUMMARY;
 
-    protected static final String HTMLESC = "-HTMLESC";
-    protected static final String SUMMARY = "Summary";
-    protected static final String DOCUMENT_TITLE = "DocumentTitle";
+public class HtmlEscapePlace extends ServiceProviderPlace {
 
     /**
      * Can be overridden from config file
@@ -57,7 +62,7 @@ public class HtmlEscapePlace extends ServiceProviderPlace {
      * Take care of special place configuration
      */
     protected void configurePlace() {
-        outputForm = configG.findStringEntry("OUTPUT_FORM", null);
+        outputForm = configG.findStringEntry(OUTPUT_FORM, null);
 
         // Force statics to load
         HtmlEscape.unescapeHtml(new byte[0]);
@@ -90,10 +95,10 @@ public class HtmlEscapePlace extends ServiceProviderPlace {
                 variance *= -1;
             d.setParameter("HTML_Entity_Decode_Variance", Integer.toString(variance));
             d.setData(newData);
-            d.setFileTypeIfEmpty("HTML");
+            d.setFileTypeIfEmpty(HTML);
 
             for (String key : counters.getKeys()) {
-                d.putParameter(key + "_HTML_ESCAPE", Integer.toString(counters.get(key)));
+                d.putParameter(key + SUFFIXES_HTML_ESCAPE, Integer.toString(counters.get(key)));
             }
 
         } else {
@@ -111,7 +116,7 @@ public class HtmlEscapePlace extends ServiceProviderPlace {
 
     protected void unescapeAltViews(IBaseDataObject d) {
         // Unescape any TEXT alt views we may have
-        d.getAlternateViewNames().stream().filter(v -> v.startsWith("TEXT")).forEach(viewName -> {
+        d.getAlternateViewNames().stream().filter(v -> v.startsWith(TEXT)).forEach(viewName -> {
             byte[] textView = d.getAlternateView(viewName);
             if (ArrayUtils.isNotEmpty(textView)) {
                 byte[] s = HtmlEscape.unescapeHtml(textView);
@@ -151,24 +156,24 @@ public class HtmlEscapePlace extends ServiceProviderPlace {
                 d.putParameter(DOCUMENT_TITLE, s);
             }
         }
-        logger.debug("Retrieved new title "/* + d.getParameter("DocumentTitle") */);
+        logger.debug("Retrieved new title ");
     }
 
     protected void processEncoding(IBaseDataObject d) {
-        // If the encoding or the LANG- form has -HTMLESC from hotspot remove it
+        // If the encoding or the LANG- form has -HTMLESC remove it
         String enc = d.getFontEncoding();
-        if (StringUtils.contains(enc, HTMLESC)) {
-            d.setFontEncoding(enc.replaceFirst(HTMLESC, ""));
+        if (StringUtils.contains(enc, SUFFIXES_HTMLESC)) {
+            d.setFontEncoding(enc.replaceFirst(SUFFIXES_HTMLESC, ""));
         }
     }
 
     protected void processCurrentForms(IBaseDataObject d) {
         for (String cf : d.getAllCurrentForms()) {
-            if (cf.contains("LANG-") && cf.contains(HTMLESC)) {
+            if (cf.contains(PREFIXES_LANG) && cf.contains(SUFFIXES_HTMLESC)) {
                 // Get the old pos
                 int pos = d.searchCurrentForm(cf);
                 d.deleteCurrentForm(cf);
-                cf = cf.replaceFirst(HTMLESC, "");
+                cf = cf.replaceFirst(SUFFIXES_HTMLESC, "");
                 d.addCurrentFormAt(pos, cf);
                 break;
             }

--- a/src/main/java/emissary/transform/JavascriptEscapePlace.java
+++ b/src/main/java/emissary/transform/JavascriptEscapePlace.java
@@ -15,6 +15,8 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.io.IOException;
 
+import static emissary.core.constants.Configurations.OUTPUT_FORM;
+
 public class JavascriptEscapePlace extends ServiceProviderPlace {
 
     /**
@@ -56,7 +58,7 @@ public class JavascriptEscapePlace extends ServiceProviderPlace {
      * Take care of special place configuration
      */
     protected void configurePlace() {
-        outputForm = configG.findStringEntry("OUTPUT_FORM", outputForm);
+        outputForm = configG.findStringEntry(OUTPUT_FORM, outputForm);
     }
 
     /**

--- a/src/main/java/emissary/transform/JsonEscapePlace.java
+++ b/src/main/java/emissary/transform/JsonEscapePlace.java
@@ -15,6 +15,8 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.io.IOException;
 
+import static emissary.core.constants.Configurations.OUTPUT_FORM;
+
 public class JsonEscapePlace extends ServiceProviderPlace {
 
     /**
@@ -56,7 +58,7 @@ public class JsonEscapePlace extends ServiceProviderPlace {
      * Take care of special place configuration
      */
     protected void configurePlace() {
-        outputForm = configG.findStringEntry("OUTPUT_FORM", outputForm);
+        outputForm = configG.findStringEntry(OUTPUT_FORM, outputForm);
     }
 
     /**

--- a/src/main/java/emissary/util/CharsetUtil.java
+++ b/src/main/java/emissary/util/CharsetUtil.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import javax.annotation.Nullable;
 
 /**
@@ -210,14 +211,7 @@ public class CharsetUtil {
      * @return true if string is utf8
      */
     public static boolean isUTF8(final String s) {
-        try {
-            final byte[] b = s.getBytes("UTF-8");
-            return isUTF8(b);
-        } catch (UnsupportedEncodingException uue) {
-            // World must end.
-            logger.warn("JVM must support UTF-8 but doesn't?");
-            return false;
-        }
+        return isUTF8(s.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/src/main/java/emissary/util/DataUtil.java
+++ b/src/main/java/emissary/util/DataUtil.java
@@ -20,6 +20,9 @@ import java.util.TreeSet;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
+import static emissary.core.constants.Parameters.EVENT_DATE;
+import static emissary.core.constants.Parameters.FILE_DATE;
+
 public class DataUtil {
     private static final Logger logger = LoggerFactory.getLogger(DataUtil.class);
     private static final Pattern NL_REPL = Pattern.compile("[\n\r]+");
@@ -120,9 +123,9 @@ public class DataUtil {
      */
     @Deprecated
     public static Calendar getEventDate(final IBaseDataObject payload) {
-        String evDate = payload.getStringParameter("EventDate");
+        String evDate = payload.getStringParameter(EVENT_DATE);
         if (evDate == null) {
-            evDate = payload.getStringParameter("FILE_DATE");
+            evDate = payload.getStringParameter(FILE_DATE);
         }
         Date eventDate = null;
         if (evDate != null) {

--- a/src/main/java/emissary/util/MetadataDictionaryUtil.java
+++ b/src/main/java/emissary/util/MetadataDictionaryUtil.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -30,7 +31,7 @@ public class MetadataDictionaryUtil {
     private Logger logger = LoggerFactory.getLogger(MetadataDictionaryUtil.class);
 
     // The charset of the data
-    private String charset = "UTF-8";
+    private String charset = StandardCharsets.UTF_8.name();
 
     // separator for key and value
     private static final char SEP = ' ';

--- a/src/main/java/emissary/util/shell/Executrix.java
+++ b/src/main/java/emissary/util/shell/Executrix.java
@@ -27,6 +27,9 @@ import java.util.Arrays;
 import java.util.Map;
 import javax.annotation.Nullable;
 
+import static emissary.core.constants.Configurations.PLACE_NAME;
+import static emissary.core.constants.Configurations.SERVICE_KEY;
+
 /**
  * This class wraps up things related to exec-ing of external processes and reading and writing disk files.
  */
@@ -117,9 +120,9 @@ public class Executrix {
         this.tmpDirFile = new File(this.tmpDir);
         this.minimumDataSize = configG.findIntEntry("MINIMUM_DATA_SIZE", 0);
         this.maximumDataSize = configG.findIntEntry("MAXIMUM_DATA_SIZE", 64 * 1024);
-        this.placeName = configG.findStringEntry("PLACE_NAME", null);
+        this.placeName = configG.findStringEntry(PLACE_NAME, null);
         if (this.placeName == null) {
-            final String key = configG.findStringEntry("SERVICE_KEY", null);
+            final String key = configG.findStringEntry(SERVICE_KEY, null);
             this.placeName = key == null ? "UNKNOWN" : KeyManipulator.getServiceName(key);
         }
         this.placeName = this.placeName.replace(' ', '_');

--- a/src/main/java/emissary/util/web/HttpPostParameters.java
+++ b/src/main/java/emissary/util/web/HttpPostParameters.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
  */
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import javax.annotation.Nullable;
 
 public class HttpPostParameters {
@@ -54,7 +55,7 @@ public class HttpPostParameters {
 
         this.thePostData.append(s).append("=");
         try {
-            this.thePostDataEncoded.append(URLEncoder.encode(s, "UTF-8")).append("=");
+            this.thePostDataEncoded.append(URLEncoder.encode(s, StandardCharsets.UTF_8.name())).append("=");
         } catch (NullPointerException e) {
             logger.error("Null first parameter to add method.", e);
         } catch (UnsupportedEncodingException e) {

--- a/src/test/java/emissary/core/FTestMovingAgent.java
+++ b/src/test/java/emissary/core/FTestMovingAgent.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import javax.annotation.Nullable;
 
+import static emissary.core.Form.TEXT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -113,7 +114,7 @@ class FTestMovingAgent extends FunctionalTest {
 
         // Create a payload and send it to the spool for UpperPlace
         IBaseDataObject payload = DataObjectFactory.getInstance(new Object[] {"abcdefghijklmnopqrstuvwxyz".getBytes(), "test_load", "LOWER_CASE"});
-        payload.setFileType("TEXT");
+        payload.setFileType(TEXT);
 
         spool.send(payload);
 

--- a/src/test/java/emissary/output/DropOffUtilTest.java
+++ b/src/test/java/emissary/output/DropOffUtilTest.java
@@ -5,6 +5,7 @@ import emissary.config.ServiceConfigGuide;
 import emissary.core.BaseDataObject;
 import emissary.core.DataObjectFactory;
 import emissary.core.IBaseDataObject;
+import emissary.core.constants.Parameters;
 import emissary.test.core.junit5.UnitTest;
 import emissary.util.TimeUtil;
 
@@ -20,6 +21,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static emissary.core.Form.TEXT;
+import static emissary.core.Form.UNKNOWN;
+import static emissary.core.constants.Parameters.EVENT_DATE;
+import static emissary.core.constants.Parameters.FILE_DATE;
+import static emissary.core.constants.Parameters.ORIGINAL_FILENAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -38,8 +44,8 @@ class DropOffUtilTest extends UnitTest {
     public void createUtil() {
         final Configurator cfg = new ServiceConfigGuide();
         final List<String> dates = new ArrayList<>();
-        dates.add("EventDate");
-        dates.add("FILE_DATE");
+        dates.add(EVENT_DATE);
+        dates.add(FILE_DATE);
         cfg.addEntries("DATE_PARAMETER", dates);
 
         final List<String> ids = new ArrayList<>();
@@ -79,8 +85,8 @@ class DropOffUtilTest extends UnitTest {
         final IBaseDataObject tld = DataObjectFactory.getInstance("This is another test".getBytes(), "/eat/prefix/anotherTestPath", "UNKNOWN");
         Configurator cfg = new ServiceConfigGuide();
         final List<String> dates = new ArrayList<>();
-        dates.add("EventDate");
-        dates.add("FILE_DATE");
+        dates.add(EVENT_DATE);
+        dates.add(FILE_DATE);
         cfg.addEntries("DATE_FORMAT", dates);
 
         List<String> ids = new ArrayList<>();
@@ -184,8 +190,8 @@ class DropOffUtilTest extends UnitTest {
         // Test auto gen //////////////////////////////
         Configurator cfg = new ServiceConfigGuide();
         final List<String> dates = new ArrayList<>();
-        dates.add("EventDate");
-        dates.add("FILE_DATE");
+        dates.add(EVENT_DATE);
+        dates.add(FILE_DATE);
         cfg.addEntries("DATE_FORMAT", dates);
 
         List<String> ids = new ArrayList<>();
@@ -347,10 +353,10 @@ class DropOffUtilTest extends UnitTest {
 
         final IBaseDataObject parent = DataObjectFactory.getInstance("This is a test".getBytes(), "item1", "PARENT_FORM", "PARENT_FTYPE");
         parent.putParameter("FOO", "PARENT_FOO");
-        parent.putParameter("Original-Filename", "parent.tar.gz");
+        parent.putParameter(ORIGINAL_FILENAME, "parent.tar.gz");
 
         final IBaseDataObject child = DataObjectFactory.getInstance("This is a test".getBytes(), "item1-att-1", "CHILD_FORM", "CHILD_FTYPE");
-        child.putParameter("Original-Filename", "child.docx");
+        child.putParameter(ORIGINAL_FILENAME, "child.docx");
         child.putParameter("FOO_FILETYPE", "myFoo");
         child.putParameter("BAR_FILETYPE", "myBar1");
         child.appendParameter("BAR_FILETYPE", "myBar2");
@@ -430,13 +436,13 @@ class DropOffUtilTest extends UnitTest {
     void testGetEventDate() {
         // populate the tld with all the event date options (note: year of 2016)
         IBaseDataObject tld = new BaseDataObject();
-        tld.setParameter("EventDate", "2016-02-13 23:13:03");
-        tld.setParameter("FILE_DATE", "2016-01-05 17:45:53");
+        tld.setParameter(EVENT_DATE, "2016-02-13 23:13:03");
+        tld.setParameter(FILE_DATE, "2016-01-05 17:45:53");
 
         // populate the child with all the event date options (note: year of 2015)
         IBaseDataObject d = new BaseDataObject();
-        d.setParameter("EventDate", "2015-02-13 23:13:03");
-        d.setParameter("FILE_DATE", "2015-01-05 17:45:53");
+        d.setParameter(EVENT_DATE, "2015-02-13 23:13:03");
+        d.setParameter(FILE_DATE, "2015-01-05 17:45:53");
 
         Date start = new Date(); // use this for relative comparison
 
@@ -444,27 +450,27 @@ class DropOffUtilTest extends UnitTest {
         assertEquals("2015-02-13 23:13:03", TimeUtil.getDateAsISO8601(this.util.getEventDate(d, tld).toInstant()));
 
         // removing child EventDate should hit on child FILE_DATE
-        d.deleteParameter("EventDate");
+        d.deleteParameter(EVENT_DATE);
         assertEquals("2015-01-05 17:45:53", TimeUtil.getDateAsISO8601(this.util.getEventDate(d, tld).toInstant()));
 
         // removing child FILE_DATE should hit on tld EventDate
-        d.deleteParameter("FILE_DATE");
+        d.deleteParameter(FILE_DATE);
         assertEquals("2016-02-13 23:13:03", TimeUtil.getDateAsISO8601(this.util.getEventDate(d, tld).toInstant()));
 
         // removing tld EventDate should hit on tld FILE_DATE
-        tld.deleteParameter("EventDate");
+        tld.deleteParameter(EVENT_DATE);
         assertEquals("2016-01-05 17:45:53", TimeUtil.getDateAsISO8601(this.util.getEventDate(d, tld).toInstant()));
 
         // removing tld FILE_DATE should default to now as configured by default
-        tld.deleteParameter("FILE_DATE");
+        tld.deleteParameter(FILE_DATE);
         assertNotNull(this.util.getEventDate(d, tld));
         assertNotEquals(-1, this.util.getEventDate(d, tld).compareTo(start));
 
         // changing the configuration to not default to now should return null
         Configurator cfg = new ServiceConfigGuide();
         final List<String> dates = new ArrayList<>();
-        dates.add("EventDate");
-        dates.add("FILE_DATE");
+        dates.add(EVENT_DATE);
+        dates.add(FILE_DATE);
         cfg.addEntries("DATE_PARAMETER", dates);
         cfg.addEntry("DEFAULT_EVENT_DATE_TO_NOW", "false");
         this.util = new DropOffUtil(cfg);
@@ -476,7 +482,7 @@ class DropOffUtilTest extends UnitTest {
     @Test
     void testDeprecatedGetFileType() {
         Map<String, String> metadata = new HashMap<>();
-        testDeprecatedFileType(metadata, "UNKNOWN", null);
+        testDeprecatedFileType(metadata, UNKNOWN, null);
 
         String poppedForms = "myPoppedForms";
         setupDeprecatedMetadata(metadata, poppedForms, DropOffUtil.FileTypeCheckParameter.POPPED_FORMS);
@@ -500,7 +506,7 @@ class DropOffUtilTest extends UnitTest {
         formsArg = "";
         String fontEncoding = "fontEncoding";
         setupDeprecatedMetadata(metadata, fontEncoding, DropOffUtil.FileTypeCheckParameter.FONT_ENCODING);
-        testDeprecatedFileType(metadata, "TEXT", formsArg);
+        testDeprecatedFileType(metadata, TEXT, formsArg);
 
         metadata.clear();
         formsArg = " MSWORD";
@@ -508,7 +514,7 @@ class DropOffUtilTest extends UnitTest {
 
         metadata.clear();
         formsArg = "QUOTED-PRINTABLE";
-        testDeprecatedFileType(metadata, "TEXT", formsArg);
+        testDeprecatedFileType(metadata, TEXT, formsArg);
     }
 
     private void setupDeprecatedMetadata(Map<String, String> metadata, String fieldValue, DropOffUtil.FileTypeCheckParameter fileTypeCheckParameter) {
@@ -556,7 +562,7 @@ class DropOffUtilTest extends UnitTest {
         formsArg = "";
         String fontEncoding = "fontEncoding";
         setupMetadata(bdo, fontEncoding, DropOffUtil.FileTypeCheckParameter.FONT_ENCODING);
-        testFileType(bdo, metadata, "TEXT", formsArg);
+        testFileType(bdo, metadata, TEXT, formsArg);
 
         bdo.clearParameters();
         metadata.clear();
@@ -565,14 +571,14 @@ class DropOffUtilTest extends UnitTest {
 
         metadata.clear();
         formsArg = "QUOTED-PRINTABLE";
-        testFileType(bdo, metadata, "TEXT", formsArg);
+        testFileType(bdo, metadata, TEXT, formsArg);
     }
 
     @Test
     void testExtractUniqueFileExtensions() {
         // these should be constants
         final String FILEXT = "FILEXT";
-        final String ORIGINAL_FILENAME = "Original-Filename";
+        final String ORIGINAL_FILENAME = Parameters.ORIGINAL_FILENAME;
         DropOffUtil util = new DropOffUtil();
 
         final IBaseDataObject bdo = new BaseDataObject();

--- a/src/test/java/emissary/output/DropOffUtilTest.java
+++ b/src/test/java/emissary/output/DropOffUtilTest.java
@@ -5,7 +5,6 @@ import emissary.config.ServiceConfigGuide;
 import emissary.core.BaseDataObject;
 import emissary.core.DataObjectFactory;
 import emissary.core.IBaseDataObject;
-import emissary.core.constants.Parameters;
 import emissary.test.core.junit5.UnitTest;
 import emissary.util.TimeUtil;
 
@@ -578,7 +577,6 @@ class DropOffUtilTest extends UnitTest {
     void testExtractUniqueFileExtensions() {
         // these should be constants
         final String FILEXT = "FILEXT";
-        final String ORIGINAL_FILENAME = Parameters.ORIGINAL_FILENAME;
         DropOffUtil util = new DropOffUtil();
 
         final IBaseDataObject bdo = new BaseDataObject();

--- a/src/test/java/emissary/pickup/file/FilePickUpClientTest.java
+++ b/src/test/java/emissary/pickup/file/FilePickUpClientTest.java
@@ -20,6 +20,8 @@ import java.security.MessageDigest;
 import java.util.Collection;
 import java.util.Map;
 
+import static emissary.core.constants.Parameters.INPUT_FILENAME;
+import static emissary.core.constants.Parameters.ORIGINAL_FILENAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -54,7 +56,7 @@ class FilePickUpClientTest extends UnitTest {
     @Test
     void testDataObjectCreatedCallbackWithMissingPath() {
         client.dataObjectCreated(payload, new File("/eat/prefix/foo/bar"));
-        assertEquals("bar", payload.getStringParameter("INPUT_FILENAME"), "Input filename must be recorded");
+        assertEquals("bar", payload.getStringParameter(INPUT_FILENAME), "Input filename must be recorded");
         assertEquals("/foo", payload.getStringParameter("TARGETBIN"), "TargetBin must be recorded without prefix");
         assertEquals(bundle.getPriority(), payload.getPriority(), "Priority must be transferred from bundle to payload");
     }
@@ -83,7 +85,7 @@ class FilePickUpClientTest extends UnitTest {
         assertEquals("PETERPAN", payload.getStringParameter("PROJECT"), "Complex case id must be transferred from bundle to payload");
         assertTrue(payload.shortName().startsWith("PETERPAN-"),
                 "Complex case in simple mode must add fn hash to payload not " + payload.shortName());
-        assertEquals("/foo/bar", payload.getStringParameter("Original-Filename"), "Original-Filename should be set in simple mode");
+        assertEquals("/foo/bar", payload.getStringParameter(ORIGINAL_FILENAME), "Original-Filename should be set in simple mode");
     }
 
     @Test

--- a/src/test/java/emissary/place/FTestCoordinatePlace.java
+++ b/src/test/java/emissary/place/FTestCoordinatePlace.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import java.io.InputStream;
 import java.util.Map;
 
+import static emissary.core.constants.Configurations.OUTPUT_FORM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -55,7 +56,7 @@ class FTestCoordinatePlace extends FunctionalTest {
     void testProcessing() throws Exception {
         IBaseDataObject payload = DataObjectFactory.getInstance("test data".getBytes(), "test.dat", place.getPrimaryProxy());
         place.processHeavyDuty(payload);
-        assertEquals(config.findStringEntry("OUTPUT_FORM"), payload.currentForm(), "Current form must be set by coordinate place");
+        assertEquals(config.findStringEntry(OUTPUT_FORM), payload.currentForm(), "Current form must be set by coordinate place");
     }
 
     @Test
@@ -63,7 +64,7 @@ class FTestCoordinatePlace extends FunctionalTest {
         IBaseDataObject payload = DataObjectFactory.getInstance("test data".getBytes(), "test.dat", place.getPrimaryProxy());
         ResourceWatcher rw = new ResourceWatcher();
         place.processHeavyDuty(payload);
-        assertEquals(config.findStringEntry("OUTPUT_FORM"), payload.currentForm(), "Current form must be set by coordinate place");
+        assertEquals(config.findStringEntry(OUTPUT_FORM), payload.currentForm(), "Current form must be set by coordinate place");
         Map<String, Timer> resourcesUsed = rw.getStats();
         rw.quit();
         assertTrue(resourcesUsed.containsKey("ToLowerPlace"), "Resource must be tracked for coordinated place");

--- a/src/test/java/emissary/place/FTestSkippingCoordinationPlace.java
+++ b/src/test/java/emissary/place/FTestSkippingCoordinationPlace.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 
+import static emissary.core.constants.Configurations.OUTPUT_FORM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -55,7 +56,7 @@ class FTestSkippingCoordinationPlace extends FunctionalTest {
     void testProcessing() throws Exception {
         IBaseDataObject payload = DataObjectFactory.getInstance("test data".getBytes(), "test.dat", place.getPrimaryProxy());
         place.processHeavyDuty(payload);
-        assertEquals(config.findStringEntry("OUTPUT_FORM"), payload.currentForm(), "Current form must be set by coordinate place");
+        assertEquals(config.findStringEntry(OUTPUT_FORM), payload.currentForm(), "Current form must be set by coordinate place");
     }
 
     @Test
@@ -63,7 +64,7 @@ class FTestSkippingCoordinationPlace extends FunctionalTest {
         IBaseDataObject payload = DataObjectFactory.getInstance("test data".getBytes(), "test.dat", place.getPrimaryProxy());
         ResourceWatcher rw = new ResourceWatcher();
         place.processHeavyDuty(payload);
-        assertEquals(config.findStringEntry("OUTPUT_FORM"), payload.currentForm(), "Current form must be set by coordinate place");
+        assertEquals(config.findStringEntry(OUTPUT_FORM), payload.currentForm(), "Current form must be set by coordinate place");
         Map<String, Timer> resourcesUsed = rw.getStats();
         rw.quit();
         assertFalse(resourcesUsed.containsKey("ToLowerPlace"), "Resource must not be tracked for coordinated place which should be skipped");

--- a/src/test/java/emissary/transform/HtmlEscapePlaceTest.java
+++ b/src/test/java/emissary/transform/HtmlEscapePlaceTest.java
@@ -15,9 +15,10 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
-import static emissary.transform.HtmlEscapePlace.DOCUMENT_TITLE;
-import static emissary.transform.HtmlEscapePlace.HTMLESC;
-import static emissary.transform.HtmlEscapePlace.SUMMARY;
+import static emissary.core.Form.PREFIXES_LANG;
+import static emissary.core.Form.SUFFIXES_HTMLESC;
+import static emissary.core.constants.Parameters.DOCUMENT_TITLE;
+import static emissary.core.constants.Parameters.SUMMARY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HtmlEscapePlaceTest extends ExtractionTest {
@@ -70,16 +71,16 @@ public class HtmlEscapePlaceTest extends ExtractionTest {
 
         @Test
         void processEncoding() {
-            String expected = "LANG-" + EXPECTED;
-            d.setFontEncoding(expected + HTMLESC);
+            String expected = PREFIXES_LANG + EXPECTED;
+            d.setFontEncoding(expected + SUFFIXES_HTMLESC);
             place.processEncoding(d);
             assertEquals(expected, d.getFontEncoding());
         }
 
         @Test
         void processCurrentForms() {
-            String expected = "LANG-" + EXPECTED;
-            d.setCurrentForm(expected + HTMLESC);
+            String expected = PREFIXES_LANG + EXPECTED;
+            d.setCurrentForm(expected + SUFFIXES_HTMLESC);
             place.processCurrentForms(d);
             assertEquals(expected, d.currentForm());
         }

--- a/src/test/java/emissary/util/DataUtilTest.java
+++ b/src/test/java/emissary/util/DataUtilTest.java
@@ -13,6 +13,8 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 
+import static emissary.core.constants.Parameters.EVENT_DATE;
+import static emissary.core.constants.Parameters.FILE_DATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -98,15 +100,15 @@ class DataUtilTest extends UnitTest {
         Calendar dcal = DataUtil.getEventDate(d);
         assertEquals(TimeUtil.getDateAsPath(now.getTime()), TimeUtil.getDateAsPath(dcal.getTime()), "Default eventDate is now");
 
-        d.putParameter("FILE_DATE", "2013-01-01 12:34:56");
+        d.putParameter(FILE_DATE, "2013-01-01 12:34:56");
         dcal = DataUtil.getEventDate(d);
         assertEquals("2013-01-01/12/30", TimeUtil.getDateAsPath(dcal.getTime()), "FILE_DATE is used when present");
 
-        d.putParameter("EventDate", "2012-01-01 12:34:56");
+        d.putParameter(EVENT_DATE, "2012-01-01 12:34:56");
         dcal = DataUtil.getEventDate(d);
         assertEquals("2012-01-01/12/30", TimeUtil.getDateAsPath(dcal.getTime()), "EventDate is used when present");
 
-        d.setParameter("EventDate", "ArmyBoots");
+        d.setParameter(EVENT_DATE, "ArmyBoots");
         dcal = DataUtil.getEventDate(d);
         assertEquals(TimeUtil.getDateAsPath(now.getTime()), TimeUtil.getDateAsPath(dcal.getTime()), "Now is used when field is invalid");
     }

--- a/src/test/java/emissary/util/LineTokenizerTest.java
+++ b/src/test/java/emissary/util/LineTokenizerTest.java
@@ -22,7 +22,7 @@ class LineTokenizerTest extends UnitTest {
 
     @Test
     void testStringCharset() {
-        LineTokenizer lt = new LineTokenizer((W + "\n").getBytes(), "UTF-8");
+        LineTokenizer lt = new LineTokenizer((W + "\n").getBytes(), StandardCharsets.UTF_8);
         assertEquals(W, lt.nextToken(), "UTF-8 passed through clean");
     }
 


### PR DESCRIPTION
We have classes for Form (form and filetype) and Family that contain constants that are reusable. There are a bunch of string literals and constants that are riddled throughout the code base that seem like it would be helpful to consolidate into one location, e.g. event-date, original-filename, document-title. This is an initial attempt at moving some of the duplicated string literals -- marking this as discussion to hear any thoughts. 