### PR TITLE
Switch to SBC in KFF (incl. HashPlace)

### DIFF
--- a/src/main/java/emissary/core/IBaseDataObjectHelper.java
+++ b/src/main/java/emissary/core/IBaseDataObjectHelper.java
@@ -11,7 +11,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -173,11 +172,7 @@ public final class IBaseDataObjectHelper {
         KffDataObjectHandler.parentToChild(childIBaseDataObject);
 
         // Hash the new child data, overwrites parent hashes if any
-        try {
-            kffDataObjectHandler.hash(childIBaseDataObject, true);
-        } catch (NoSuchAlgorithmException | IOException e) {
-            // Do not add the hash parameters
-        }
+        kffDataObjectHandler.hash(childIBaseDataObject);
     }
 
     /**

--- a/src/main/java/emissary/core/channels/SeekableByteChannelHelper.java
+++ b/src/main/java/emissary/core/channels/SeekableByteChannelHelper.java
@@ -19,6 +19,9 @@ import java.nio.file.Path;
 public final class SeekableByteChannelHelper {
     private static final Logger logger = LoggerFactory.getLogger(SeekableByteChannelHelper.class);
 
+    /** Channel factory backed by an empty byte array. Used for situations when a BDO should have its payload discarded. */
+    public static final SeekableByteChannelFactory EMPTY_CHANNEL_FACTORY = memory(new byte[0]);
+
     private SeekableByteChannelHelper() {}
 
     /**

--- a/src/main/java/emissary/kff/KffDataObjectHandler.java
+++ b/src/main/java/emissary/kff/KffDataObjectHandler.java
@@ -68,6 +68,21 @@ public class KffDataObjectHandler {
     }
 
     /**
+     * Convenience memthod to hash a byte array of data.
+     * 
+     * @param data to hash
+     * @param name the name of the data (for reporting)
+     * @param prefix prepended to hash name entries
+     * @return parameter entries suitable for a BaseDataObject
+     * @throws IOException if the data can't be read
+     * @throws NoSuchAlgorithmException if the checksum can't be computed
+     */
+    public Map<String, String> hashData(final byte[] data, final String name, String prefix)
+            throws IOException, NoSuchAlgorithmException {
+        return hashData(SeekableByteChannelHelper.memory(data), name, prefix);
+    }
+
+    /**
      * Compute the configure hashes and return as a map Also include entries indicating the know file or duplicate file
      * status if so configured
      * 

--- a/src/main/java/emissary/kff/KffDataObjectHandler.java
+++ b/src/main/java/emissary/kff/KffDataObjectHandler.java
@@ -2,6 +2,7 @@ package emissary.kff;
 
 import emissary.core.IBaseDataObject;
 import emissary.core.channels.SeekableByteChannelFactory;
+import emissary.core.channels.SeekableByteChannelHelper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,51 +71,14 @@ public class KffDataObjectHandler {
      * Compute the configure hashes and return as a map Also include entries indicating the know file or duplicate file
      * status if so configured
      * 
-     * @param data the bytes to hash
-     * @param name th name of the data (for reporting)
+     * @param sbcf the data to hash
+     * @param name the name of the data (for reporting)
      * @return parameter entries suitable for a BaseDataObject
+     * @throws IOException if the data can't be read
+     * @throws NoSuchAlgorithmException if the checksum can't be computed
      */
-    public Map<String, String> hashData(byte[] data, String name) {
-        return hashData(data, name, "");
-    }
-
-    /**
-     * Compute the configure hashes and return as a map Also include entries indicating the know file or duplicate file
-     * status if so configured
-     * 
-     * @param data the bytes to hash
-     * @param name th name of the data (for reporting)
-     * @param prefix prepended to hash name entries
-     * @return parameter entries suitable for a BaseDataObject
-     */
-    public Map<String, String> hashData(@Nullable byte[] data, String name, @Nullable String prefix) {
-        Map<String, String> results = new HashMap<String, String>();
-
-        if (prefix == null) {
-            prefix = "";
-        }
-
-        if (data != null && data.length > 0) {
-            try {
-                KffResult kffCheck = kff.check(name, data);
-
-                // Store all computed results in data object params
-                for (String alg : kffCheck.getResultNames()) {
-                    results.put(prefix + KFF_PARAM_BASE + alg, kffCheck.getResultString(alg));
-                }
-
-                // Set params if we have a hit
-                if (kffCheck.isKnown()) {
-                    results.put(prefix + KFF_PARAM_KNOWN_FILTER_NAME, kffCheck.getFilterName());
-                }
-                if (kffCheck.isDupe()) {
-                    results.put(prefix + KFF_PARAM_DUPE_FILTER_NAME, kffCheck.getFilterName());
-                }
-            } catch (Exception kffex) {
-                logger.warn("Unable to compute kff on " + name, kffex);
-            }
-        }
-        return results;
+    public Map<String, String> hashData(final SeekableByteChannelFactory sbcf, final String name) throws NoSuchAlgorithmException, IOException {
+        return hashData(sbcf, name, "");
     }
 
     /**
@@ -122,7 +86,7 @@ public class KffDataObjectHandler {
      * status if so configured
      * 
      * @param sbcf the data to hash
-     * @param name th name of the data (for reporting)
+     * @param name the name of the data (for reporting)
      * @param prefix prepended to hash name entries
      * @return parameter entries suitable for a BaseDataObject
      * @throws IOException if the data can't be read
@@ -166,22 +130,6 @@ public class KffDataObjectHandler {
      * @param d the data object
      */
     public void hash(@Nullable final IBaseDataObject d) {
-        try {
-            hash(d, false);
-        } catch (NoSuchAlgorithmException | IOException e) {
-            // Do nothing
-        }
-    }
-
-    /**
-     * Compute the hash of a data object's data
-     * 
-     * @param d the data object
-     * @param useSbc use the {@link SeekableByteChannel} interface
-     * @throws IOException if the data can't be read
-     * @throws NoSuchAlgorithmException if the checksum can't be computed
-     */
-    public void hash(@Nullable final IBaseDataObject d, final boolean useSbc) throws NoSuchAlgorithmException, IOException {
         if (d != null) {
             removeHash(d);
         }
@@ -190,13 +138,15 @@ public class KffDataObjectHandler {
             return;
         }
 
-        // Compute and add the hashes
-        if (useSbc && d.getChannelSize() > 0) {
-            d.putParameters(hashData(d.getChannelFactory(), d.shortName(), ""));
-        } else if (!useSbc && d.dataLength() > 0) {
-            d.putParameters(hashData(d.data(), d.shortName()));
-        } else {
-            return;
+        try {
+            // Compute and add the hashes
+            if (d.getChannelSize() > 0) {
+                d.putParameters(hashData(d.getChannelFactory(), d.shortName()));
+            } else {
+                return;
+            }
+        } catch (NoSuchAlgorithmException | IOException e) {
+            logger.error("Couldn't hash data {}", d.shortName());
         }
 
         // Set params if we have a hit
@@ -208,7 +158,7 @@ public class KffDataObjectHandler {
                 d.replaceCurrentForm(KFF_DUPE_CURRENT_FORM);
             }
             if (truncateKnownData) {
-                d.setData(null);
+                d.setChannelFactory(SeekableByteChannelHelper.EMPTY_CHANNEL_FACTORY);
             }
         }
     }

--- a/src/main/java/emissary/place/KffHashPlace.java
+++ b/src/main/java/emissary/place/KffHashPlace.java
@@ -6,7 +6,6 @@ import emissary.kff.KffDataObjectHandler;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.NoSuchAlgorithmException;
 
 /**
  * Hashing place to hash payload unless hashes are set or skip flag is set. This place is intended to execute in the
@@ -21,8 +20,6 @@ public class KffHashPlace extends ServiceProviderPlace {
     private static final String TRUE = "TRUE";
 
     public static final String SKIP_KFF_HASH = "SKIP_KFF_HASH";
-
-    private boolean useSbc = false;
 
     public KffHashPlace(String thePlaceLocation) throws IOException {
         super(thePlaceLocation);
@@ -51,7 +48,6 @@ public class KffHashPlace extends ServiceProviderPlace {
     @Override
     protected void setupPlace(String theDir, String placeLocation) throws IOException {
         super.setupPlace(theDir, placeLocation);
-        useSbc = configG.findBooleanEntry("USE_SBC", useSbc);
         initKff();
     }
 
@@ -62,11 +58,7 @@ public class KffHashPlace extends ServiceProviderPlace {
             return;
         }
 
-        try {
-            kff.hash(payload, useSbc);
-        } catch (final NoSuchAlgorithmException | IOException e) {
-            logger.error("KffHashPlace failed to hash data for {} - this shouldn't happen", payload.shortName(), e);
-        }
+        kff.hash(payload);
     }
 
 }

--- a/src/main/resources/emissary/place/KffHashPlace.cfg
+++ b/src/main/resources/emissary/place/KffHashPlace.cfg
@@ -6,6 +6,3 @@ SERVICE_COST = 10
 SERVICE_QUALITY = 100
 
 SERVICE_PROXY = "UNKNOWN"
-
-# Use SeekableByteChannel-related methods (true) vs byte array based (false)
-USE_SBC = false

--- a/src/test/java/emissary/core/IBaseDataObjectHelperTest.java
+++ b/src/test/java/emissary/core/IBaseDataObjectHelperTest.java
@@ -1,6 +1,7 @@
 package emissary.core;
 
 import emissary.core.channels.InMemoryChannelFactory;
+import emissary.core.channels.SeekableByteChannelFactory;
 import emissary.kff.KffDataObjectHandler;
 import emissary.parser.SessionParser;
 
@@ -317,7 +318,8 @@ class IBaseDataObjectHelperTest {
         final IBaseDataObject childIbdo1 = new BaseDataObject();
 
         childIbdo1.setChannelFactory(InMemoryChannelFactory.create("0123456789".getBytes(StandardCharsets.US_ASCII)));
-        Mockito.doThrow(NoSuchAlgorithmException.class).when(mockKffDataObjectHandler1).hash(Mockito.any(BaseDataObject.class), Mockito.anyBoolean());
+        Mockito.doThrow(NoSuchAlgorithmException.class).when(mockKffDataObjectHandler1).hashData(Mockito.any(SeekableByteChannelFactory.class),
+                Mockito.anyString());
         IBaseDataObjectHelper.addParentInformationToChild(parentIbdo, childIbdo1,
                 true, alwaysCopyMetadataKeys, placeKey, mockKffDataObjectHandler1);
         assertFalse(KffDataObjectHandler.hashPresent(childIbdo1));


### PR DESCRIPTION
Removes complexity within HashPlace/KffDataObjectHandler to just use the SBC path. Adds additional tests to confirm behaviour and functionality.