### PR TITLE
sonarlint :: Remove duplicate log configuration code from EnvCommand

### DIFF
--- a/src/main/java/emissary/Emissary.java
+++ b/src/main/java/emissary/Emissary.java
@@ -172,7 +172,7 @@ public class Emissary {
      * 
      * Reinit with a config file if running something like a server where you want the expanded format,
      */
-    static void setupLogbackForConsole() {
+    public static LoggerContext setupLogbackForConsole() {
         // So it looks better when commands are run
         ch.qos.logback.classic.Logger root =
                 (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
@@ -193,6 +193,7 @@ public class Emissary {
         root.addAppender(consoleAppender);
         root.setLevel(Level.INFO);
         root.setAdditive(false);
+        return lc;
     }
 
     static void redirectStdOutStdErr() {

--- a/src/main/java/emissary/command/EnvCommand.java
+++ b/src/main/java/emissary/command/EnvCommand.java
@@ -4,15 +4,14 @@ import emissary.client.EmissaryClient;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.ConsoleAppender;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.apache.http.client.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static emissary.Emissary.setupLogbackForConsole;
 
 @Parameters(commandDescription = "Output the configured values for certain properties")
 public class EnvCommand extends HttpCommand {
@@ -52,25 +51,8 @@ public class EnvCommand extends HttpCommand {
         String endpoint = getScheme() + "://" + getHost() + ":" + getPort() + "/api/env";
 
         if (getBashable()) {
-            ch.qos.logback.classic.Logger root =
-                    (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
-            root.detachAndStopAllAppenders();
             setup();
-            LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
-            PatternLayoutEncoder ple = new PatternLayoutEncoder();
-
-            ple.setPattern("%msg%n");
-            ple.setContext(lc);
-            ple.start();
-
-            ConsoleAppender<ILoggingEvent> consoleAppender = new ConsoleAppender<>();
-            consoleAppender.setEncoder(ple);
-            consoleAppender.setContext(lc);
-            consoleAppender.start();
-
-            root.addAppender(consoleAppender);
-            root.setLevel(Level.INFO);
-            root.setAdditive(false);
+            LoggerContext lc = setupLogbackForConsole();
 
             // still gotta hide org.eclipse.jetty.util.log INFO
             ch.qos.logback.classic.Logger jettyUtilLogger = lc.getLogger("org.eclipse.jetty.util.log");


### PR DESCRIPTION
Env output command:
```
./emissary env
 ________  ________ _____ _____  ___  ________   __
|  ___|  \/  |_   _/  ___/  ___|/ _ \ | ___ \ \ / /
| |__ | .  . | | | \ `--.\ `--./ /_\ \| |_/ /\ V /
|  __|| |\/| | | |  `--. \`--. \  _  ||    /  \ /
| |___| |  | |_| |_/\__/ /\__/ / | | || |\ \  | |
\____/\_|  |_/\___/\____/\____/\_| |_/\_| \_| \_/

Emissary Version: 7.12.0-SNAPSHOT - built on 2022-12-15T14:01:09-0500 - git hash: 43f0365
PROJECT_BASE is set to /Users/connor/Projects/work/emissary/target
Setting emissary.config.dir to /Users/connor/Projects/work/emissary/target/config
Setting emissary.bin.dir to /Users/connor/Projects/work/emissary/target/bin
Setting emissary.output.root to /Users/connor/Projects/work/emissary/target/localoutput
Emissary error dir set to /Users/connor/Projects/work/emissary/target/localerror
{"errors":[],"response":{"BIN_DIR":"/Users/connor/Projects/work/emissary/target/bin","CONFIG_DIR":"/Users/connor/Projects/work/emissary/target/config","HOST":"localhost","OUTPUT_ROOT":"/Users/connor/Projects/work/emissary/target/localoutput","PORT":"8001","PROJECT_BASE":"/Users/connor/Projects/work/emissary/target","SCHEME":"http"}}
```
