### PR TITLE
Initial pass at adding generics to the SCBF Framework

### DIFF
--- a/src/main/java/emissary/core/BaseDataObject.java
+++ b/src/main/java/emissary/core/BaseDataObject.java
@@ -180,7 +180,7 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
     /**
      * A factory to create channels for the referenced data.
      */
-    protected SeekableByteChannelFactory seekableByteChannelFactory;
+    protected SeekableByteChannelFactory<?> seekableByteChannelFactory;
 
     protected enum DataState {
         NO_DATA, CHANNEL_ONLY, BYTE_ARRAY_ONLY, BYTE_ARRAY_AND_CHANNEL
@@ -319,11 +319,13 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
 
     /**
      * Set the byte channel factory using whichever implementation is providing access to the data.
-     * 
+     *
      * Setting this will null out {@link #theData}
+     * 
+     * @param sbcf the new channel factory to set on this object
      */
     @Override
-    public void setChannelFactory(final SeekableByteChannelFactory sbcf) {
+    public void setChannelFactory(final SeekableByteChannelFactory<?> sbcf) {
         Validate.notNull(sbcf, "Required: SeekableByteChannelFactory not null");
         this.theData = null;
         this.seekableByteChannelFactory = sbcf;
@@ -336,7 +338,7 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
      * @return the factory containing the data reference or the data wrapped in a new factory
      */
     @Override
-    public SeekableByteChannelFactory getChannelFactory() {
+    public SeekableByteChannelFactory<?> getChannelFactory() {
         switch (getDataState()) {
             case BYTE_ARRAY_AND_CHANNEL:
                 throw new IllegalStateException(String.format(INVALID_STATE_MSG, shortName()));

--- a/src/main/java/emissary/core/IBaseDataObject.java
+++ b/src/main/java/emissary/core/IBaseDataObject.java
@@ -56,14 +56,14 @@ public interface IBaseDataObject {
      * 
      * @param sbcf the new channel factory to set on this object
      */
-    void setChannelFactory(final SeekableByteChannelFactory sbcf);
+    void setChannelFactory(final SeekableByteChannelFactory<?> sbcf);
 
     /**
      * Returns the seekable byte channel factory containing a reference to the data
      * 
      * @return the factory containing the data reference
      */
-    SeekableByteChannelFactory getChannelFactory();
+    SeekableByteChannelFactory<?> getChannelFactory();
 
     /**
      * Get the size of the channel referenced by this object

--- a/src/main/java/emissary/core/channels/FileChannelFactory.java
+++ b/src/main/java/emissary/core/channels/FileChannelFactory.java
@@ -2,14 +2,8 @@ package emissary.core.channels;
 
 import org.apache.commons.lang3.Validate;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.Collections;
-import java.util.Set;
 
 /**
  * Provide a file-backed implementation for streaming data to a consumer
@@ -28,14 +22,14 @@ public final class FileChannelFactory {
      * @return a new instance
      * @see SeekableByteChannelHelper#file(Path)
      */
-    public static SeekableByteChannelFactory create(final Path path) {
-        return ImmutableChannelFactory.create(new FileChannelFactoryImpl(path));
+    public static ImmutableChannelFactory<?> createFactory(final Path path) {
+        return ImmutableChannelFactory.createFactory(new FileChannelFactoryImpl(path));
     }
 
     /**
      * Private class to hide implementation details from callers
      */
-    private static final class FileChannelFactoryImpl implements SeekableByteChannelFactory {
+    private static final class FileChannelFactoryImpl implements SeekableByteChannelFactory<LazyOpeningFileChannel> {
         private final Path path;
 
         private FileChannelFactoryImpl(final Path path) {
@@ -49,47 +43,9 @@ public final class FileChannelFactory {
          * @return the new channel instance
          */
         @Override
-        public SeekableByteChannel create() {
-            return new LazyFileChannelImpl(path);
+        public LazyOpeningFileChannel create() {
+            return new LazyOpeningFileChannel(path);
         }
     }
 
-    private static final class LazyFileChannelImpl extends AbstractSeekableByteChannel {
-
-        private static final Set<StandardOpenOption> OPTIONS = Collections.singleton(StandardOpenOption.READ);
-
-        private final Path path;
-
-        private FileChannel channel;
-
-        private LazyFileChannelImpl(final Path path) {
-            this.path = path;
-        }
-
-        protected void initialiseChannel() throws IOException {
-            if (channel == null) {
-                channel = FileChannel.open(path, OPTIONS);
-            }
-        }
-
-        @Override
-        protected void closeImpl() throws IOException {
-            if (channel != null) {
-                channel.close();
-            }
-        }
-
-        @Override
-        protected int readImpl(ByteBuffer byteBuffer, int maxBytesToRead) throws IOException {
-            initialiseChannel();
-            return channel.read(byteBuffer);
-        }
-
-        @Override
-        protected long sizeImpl() throws IOException {
-            initialiseChannel();
-            return channel.size();
-        }
-
-    }
 }

--- a/src/main/java/emissary/core/channels/FillChannelFactory.java
+++ b/src/main/java/emissary/core/channels/FillChannelFactory.java
@@ -4,7 +4,6 @@ import org.apache.commons.lang3.Validate;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.SeekableByteChannel;
 import java.util.Arrays;
 
 /**
@@ -20,14 +19,14 @@ public class FillChannelFactory {
      * @param value of each element in the seekable byte channel.
      * @return an immutable version of the seekable byte channel with the designated value.
      */
-    public static SeekableByteChannelFactory create(final long size, final byte value) {
+    public static ImmutableChannelFactory<?> createFactory(final long size, final byte value) {
         return SeekableByteChannelHelper.immutable(new FillChannelFactoryImpl(size, value));
     }
 
     /**
      * The SeekableByteChannelFactory implementation that returns a "fill" SeekableByteChannel.
      */
-    private static final class FillChannelFactoryImpl implements SeekableByteChannelFactory {
+    private static final class FillChannelFactoryImpl implements SeekableByteChannelFactory<ImmutableChannel<?>> {
 
         /**
          * The size of the SeekableByteChannel that is returned.
@@ -47,8 +46,8 @@ public class FillChannelFactory {
         }
 
         @Override
-        public SeekableByteChannel create() {
-            return new FillChannel(size, value);
+        public ImmutableChannel<?> create() {
+            return new ImmutableChannel<>(new FillChannel(size, value));
         }
     }
 
@@ -70,18 +69,18 @@ public class FillChannelFactory {
         }
 
         @Override
-        protected long sizeImpl() throws IOException {
+        protected long sizeImpl() {
             return size;
         }
 
         @Override
-        protected void closeImpl() throws IOException {
+        protected void closeImpl() {
             // Nothing to do.
         }
 
         @Override
         protected int readImpl(final ByteBuffer byteBuffer, final int maxBytesToRead) throws IOException {
-            final int bytesToFill = Math.min(maxBytesToRead, Integer.MAX_VALUE);
+            final int bytesToFill = Math.min(maxBytesToRead, byteBuffer.remaining());
 
             if (byteBuffer.hasArray()) {
                 Arrays.fill(byteBuffer.array(), byteBuffer.position(), byteBuffer.position() + bytesToFill, value);

--- a/src/main/java/emissary/core/channels/ImmutableChannel.java
+++ b/src/main/java/emissary/core/channels/ImmutableChannel.java
@@ -1,0 +1,72 @@
+package emissary.core.channels;
+
+import org.apache.commons.lang3.Validate;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.NonWritableChannelException;
+import java.nio.channels.SeekableByteChannel;
+
+/**
+ * Decorator class that wraps an existing {@link SeekableByteChannel} instance and makes it immutable
+ * 
+ * @param <T> Type of SeekableByteChannel to wrap
+ */
+public final class ImmutableChannel<T extends SeekableByteChannel> implements SeekableByteChannel {
+
+    /**
+     * The SeekableByteChannel to be made immutable.
+     */
+    private final T channel;
+
+    /**
+     * Creates a new SeekableByteChannel that provides immutable access to another existing channel
+     *
+     * @param channel channel for which immutable access is to be provided
+     */
+    ImmutableChannel(final T channel) {
+        Validate.notNull(channel, "Required: channel not null");
+        this.channel = channel;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return channel.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.close();
+    }
+
+    @Override
+    public int read(final ByteBuffer dst) throws IOException {
+        return channel.read(dst);
+    }
+
+    @Override
+    public long position() throws IOException {
+        return channel.position();
+    }
+
+    @Override
+    public T position(final long newPosition) throws IOException {
+        channel.position(newPosition);
+        return channel;
+    }
+
+    @Override
+    public long size() throws IOException {
+        return channel.size();
+    }
+
+    @Override
+    public int write(final ByteBuffer src) throws IOException {
+        throw new NonWritableChannelException();
+    }
+
+    @Override
+    public T truncate(final long size) throws IOException {
+        throw new NonWritableChannelException();
+    }
+}

--- a/src/main/java/emissary/core/channels/ImmutableChannelFactory.java
+++ b/src/main/java/emissary/core/channels/ImmutableChannelFactory.java
@@ -2,117 +2,49 @@ package emissary.core.channels;
 
 import org.apache.commons.lang3.Validate;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.NonWritableChannelException;
 import java.nio.channels.SeekableByteChannel;
 
 /**
- * Wrap {@link SeekableByteChannelFactory} objects to make them immutable
+ * Helper {@link SeekableByteChannelFactory} used to provide immutable access to channels created by an existing channel
+ * factory
+ * 
+ * @param <T> Type of {@link SeekableByteChannel} instances for which immutable access will be provided
  */
-public final class ImmutableChannelFactory {
-    private ImmutableChannelFactory() {}
+public final class ImmutableChannelFactory<T extends SeekableByteChannel> implements SeekableByteChannelFactory<ImmutableChannel<T>> {
+    private final SeekableByteChannelFactory<T> sbcf;
+
 
     /**
      * <p>
      * Wrap a provided channel factory with immutability i.e. write, truncate etc are all disabled.
      * </p>
-     * 
+     *
      * <p>
      * Position *can* be changed on individual channels
      * </p>
-     * 
-     * @param sbcf to wrap
+     *
+     * @param sbcf channel factory instance to wrap
+     * @param <T> Type of {@link SeekableByteChannel} instances for which immutable access will be provided
      * @return the wrapped channel factory
      */
-    public static SeekableByteChannelFactory create(final SeekableByteChannelFactory sbcf) {
-        return new ImmutableChannelFactoryImpl(sbcf);
+    public static <T extends SeekableByteChannel> ImmutableChannelFactory<T> createFactory(final SeekableByteChannelFactory<T> sbcf) {
+        return new ImmutableChannelFactory<>(sbcf);
+    }
+
+    private ImmutableChannelFactory(final SeekableByteChannelFactory<T> sbcf) {
+        Validate.notNull(sbcf, "Required: sbcf not null");
+
+        this.sbcf = sbcf;
     }
 
     /**
-     * Wraps an existing channel factory in immutability.
+     * Creates an immutable channel instance upon invocation.
+     *
+     * @return an immutable channel instance
      */
-    private static final class ImmutableChannelFactoryImpl implements SeekableByteChannelFactory {
-        /**
-         * The SeekableByteChannelFactory to be made immutable.
-         */
-        private final SeekableByteChannelFactory sbcf;
-
-        /**
-         * Configure an immutable factory instance with the provided factory
-         * 
-         * @param sbcf to wrap
-         */
-        private ImmutableChannelFactoryImpl(final SeekableByteChannelFactory sbcf) {
-            Validate.notNull(sbcf, "Required: sbcf not null");
-
-            this.sbcf = sbcf;
-        }
-
-        /**
-         * Creates an immutable channel instance upon invocation.
-         * 
-         * @return an immutable channel instance
-         */
-        @Override
-        public SeekableByteChannel create() {
-            return new ImmutableSeekableByteChannel(sbcf.create());
-        }
-
+    @Override
+    public ImmutableChannel<T> create() {
+        return new ImmutableChannel<>(sbcf.create());
     }
 
-    /**
-     * Immutable overrides for the actual implementation.
-     */
-    private static final class ImmutableSeekableByteChannel implements SeekableByteChannel {
-        /**
-         * The SeekableByteChannel to be made immutable.
-         */
-        private final SeekableByteChannel channel;
-
-        private ImmutableSeekableByteChannel(final SeekableByteChannel channel) {
-            Validate.notNull(channel, "Required: channel not null");
-            this.channel = channel;
-        }
-
-        @Override
-        public boolean isOpen() {
-            return channel.isOpen();
-        }
-
-        @Override
-        public void close() throws IOException {
-            channel.close();
-        }
-
-        @Override
-        public int read(final ByteBuffer dst) throws IOException {
-            return channel.read(dst);
-        }
-
-        @Override
-        public long position() throws IOException {
-            return channel.position();
-        }
-
-        @Override
-        public SeekableByteChannel position(final long newPosition) throws IOException {
-            return channel.position(newPosition);
-        }
-
-        @Override
-        public long size() throws IOException {
-            return channel.size();
-        }
-
-        @Override
-        public int write(final ByteBuffer src) throws IOException {
-            throw new NonWritableChannelException();
-        }
-
-        @Override
-        public SeekableByteChannel truncate(final long size) throws IOException {
-            throw new NonWritableChannelException();
-        }
-    }
 }

--- a/src/main/java/emissary/core/channels/InMemoryChannelFactory.java
+++ b/src/main/java/emissary/core/channels/InMemoryChannelFactory.java
@@ -17,14 +17,14 @@ public final class InMemoryChannelFactory {
      * @param bytes containing the data to provide to consumers in an immutable manner
      * @return a new instance
      */
-    public static SeekableByteChannelFactory create(final byte[] bytes) {
-        return ImmutableChannelFactory.create(new InMemoryChannelFactoryImpl(bytes));
+    public static ImmutableChannelFactory<?> createFactory(final byte[] bytes) {
+        return ImmutableChannelFactory.createFactory(new InMemoryChannelFactoryImpl(bytes));
     }
 
     /**
      * Private class to hide implementation details from callers
      */
-    private static final class InMemoryChannelFactoryImpl implements SeekableByteChannelFactory {
+    private static final class InMemoryChannelFactoryImpl implements SeekableByteChannelFactory<SeekableByteChannel> {
         /**
          * The byte array this SeekableByteChannel is to represent.
          */

--- a/src/main/java/emissary/core/channels/InputStreamChannel.java
+++ b/src/main/java/emissary/core/channels/InputStreamChannel.java
@@ -1,0 +1,86 @@
+package emissary.core.channels;
+
+import org.apache.commons.lang3.Validate;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+
+/**
+ * {@link SeekableByteChannel} implementation the provides a channel interface to a backing InputStream instance
+ * 
+ * @param <T> Type of {@link InputStream} exposed by this channel
+ */
+public class InputStreamChannel<T extends InputStream> extends AbstractSeekableByteChannel {
+    /**
+     * The InputStreamFactory used to get InputStream instances.
+     */
+    private final InputStreamFactory<T> inputStreamFactory;
+
+    /**
+     * The current InputStream instance.
+     */
+    private InputStream inputStream;
+
+    /**
+     * The current position in the current InputStream instance.
+     */
+    private long streamPosition;
+
+    private long size;
+
+    /**
+     * Create a new InputStreamChannel instance with a fixed size and data source
+     *
+     * @param size of the InputStreamChannel
+     * @param inputStreamFactory data source
+     */
+    public InputStreamChannel(final long size, final InputStreamFactory<T> inputStreamFactory) {
+        Validate.notNull(inputStreamFactory, "Required: inputStreamFactory not null!");
+        this.size = size;
+        this.inputStreamFactory = inputStreamFactory;
+    }
+
+    @Override
+    protected final int readImpl(final ByteBuffer byteBuffer, final int maxBytesToRead) throws IOException {
+        if (position() < streamPosition) {
+            streamPosition = 0;
+            inputStream.close();
+            inputStream = null;
+        }
+
+        if (inputStream == null) {
+            inputStream = inputStreamFactory.create();
+        }
+
+        // Actually perform the read
+        final int bytesRead = SeekableByteChannelHelper.getFromInputStream(inputStream, byteBuffer,
+                position() - streamPosition, maxBytesToRead);
+
+        // Update positioning
+        position(position() + bytesRead);
+        streamPosition = position();
+
+        return bytesRead;
+    }
+
+
+    @Override
+    protected long sizeImpl() throws IOException {
+        if (size < 0) {
+            try (final InputStream is = inputStreamFactory.create()) {
+                size = SeekableByteChannelHelper.available(is);
+            }
+        }
+        return size;
+    }
+
+    @Override
+    protected final void closeImpl() throws IOException {
+        if (inputStream != null) {
+            inputStream.close();
+            inputStream = null;
+        }
+    }
+}

--- a/src/main/java/emissary/core/channels/InputStreamChannelFactory.java
+++ b/src/main/java/emissary/core/channels/InputStreamChannelFactory.java
@@ -2,112 +2,47 @@ package emissary.core.channels;
 
 import org.apache.commons.lang3.Validate;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
-import java.nio.channels.SeekableByteChannel;
+import java.util.function.BiFunction;
 
+/**
+ * Channel factory used to provide channel-like access to input stream data. Channel instances provided by these
+ * factories are immutable.
+ */
 public class InputStreamChannelFactory {
     private InputStreamChannelFactory() {}
 
     /**
-     * Creates a factory implementation based on an {@link InputStreamFactory}
-     * 
-     * @param size if known, else provide a negative value to allow the factory to work out the size upon first create
-     * @param inputStreamFactory for the data
-     * @return an InputStreamChannelFactory instance of the data
+     * Creates a factory instance used to provide channel-like access to input stream data.
+     *
+     * @param size stream length, if known. A negative value forces the factory to work out the size upon first create
+     * @param inputStreamFactory factory for the input stream access
+     * @return a channel factory instance enabling channel-like access to the underlying input stream data
      */
-    public static SeekableByteChannelFactory create(final long size, final InputStreamFactory inputStreamFactory) {
-        return new InputStreamChannelFactoryImpl(size, inputStreamFactory);
+    public static ImmutableChannelFactory<InputStreamChannel<?>> createFactory(final long size,
+            final InputStreamFactory<?> inputStreamFactory) {
+        Validate.notNull(inputStreamFactory, "Required: inputStream not null");
+
+        return ImmutableChannelFactory.createFactory(() -> new InputStreamChannel<>(size, inputStreamFactory));
     }
 
-    private static class InputStreamChannelFactoryImpl implements SeekableByteChannelFactory {
-        private long size;
-        private final InputStreamFactory inputStreamFactory;
+    /**
+     * Creates a factory implementation based on an {@link InputStreamFactory}. Unlike the other
+     * {@link InputStreamChannelFactory#createFactory} overload, this overload allows the use of a custom
+     * {@link InputStreamChannel} subtype so that explicit {@link InputStream} subtypes can be returned by the factory.
+     *
+     * @param size stream length, if known. A negative value forces the factory to work out the size upon first create
+     * @param inputStreamFactory factory for the input stream access
+     * @param channelProvider function reference used to create the specific type of {@link InputStreamChannel}.
+     * @param <T> Type of InputStream subtype for which this factory will provide channel-like access
+     * @param <U> Type of InputStreamChannel that works with these specific InputStream subtypes
+     * @return a channel factory instance enabling channel-like access to the underlying input stream data
+     */
+    public static <T extends InputStream, U extends InputStreamChannel<T>> ImmutableChannelFactory<U> createFactory(final Long size,
+            final InputStreamFactory<T> inputStreamFactory, BiFunction<Long, InputStreamFactory<T>, U> channelProvider) {
+        Validate.notNull(inputStreamFactory, "Required: inputStream not null");
 
-        public InputStreamChannelFactoryImpl(final long size, final InputStreamFactory inputStreamFactory) {
-            Validate.notNull(inputStreamFactory, "Required: inputStream not null");
-
-            this.size = size;
-            this.inputStreamFactory = inputStreamFactory;
-        }
-
-        @Override
-        public SeekableByteChannel create() {
-            return new InputStreamChannel(size, inputStreamFactory);
-        }
+        return ImmutableChannelFactory.createFactory(() -> channelProvider.apply(size, inputStreamFactory));
     }
 
-    private static class InputStreamChannel extends AbstractSeekableByteChannel {
-        /**
-         * The InputStreamFactory used to get InputStream instances.
-         */
-        private final InputStreamFactory inputStreamFactory;
-
-        /**
-         * The current InputStream instance.
-         */
-        private InputStream inputStream;
-
-        /**
-         * The current position in the current InputStream instance.
-         */
-        private long streamPosition;
-
-        private long size;
-
-        /**
-         * Create a new InputStreamChannel instance with a fixed size and data source
-         * 
-         * @param size of the InputStreamChannel
-         * @param inputStreamFactory data source
-         */
-        public InputStreamChannel(final long size, final InputStreamFactory inputStreamFactory) {
-            Validate.notNull(inputStreamFactory, "Required: inputStreamFactory not null!");
-            this.size = size;
-            this.inputStreamFactory = inputStreamFactory;
-        }
-
-        @Override
-        protected final int readImpl(final ByteBuffer byteBuffer, final int maxBytesToRead) throws IOException {
-            if (position() < streamPosition) {
-                streamPosition = 0;
-                inputStream.close();
-                inputStream = null;
-            }
-
-            if (inputStream == null) {
-                inputStream = inputStreamFactory.create();
-            }
-
-            // Actually perform the read
-            final int bytesRead = SeekableByteChannelHelper.getFromInputStream(inputStream, byteBuffer,
-                    position() - streamPosition, maxBytesToRead);
-
-            // Update positioning
-            position(position() + bytesRead);
-            streamPosition = position();
-
-            return bytesRead;
-        }
-
-
-        @Override
-        protected long sizeImpl() throws IOException {
-            if (size < 0) {
-                try (final InputStream is = inputStreamFactory.create()) {
-                    size = SeekableByteChannelHelper.available(is);
-                }
-            }
-            return size;
-        }
-
-        @Override
-        protected final void closeImpl() throws IOException {
-            if (inputStream != null) {
-                inputStream.close();
-                inputStream = null;
-            }
-        }
-    }
 }

--- a/src/main/java/emissary/core/channels/InputStreamFactory.java
+++ b/src/main/java/emissary/core/channels/InputStreamFactory.java
@@ -5,12 +5,15 @@ import java.io.InputStream;
 
 /**
  * A repeatable way to obtain an InputStream from an object.
+ *
+ * @param <T> Type of {@link InputStream} instances that the factory can create
  */
-public interface InputStreamFactory {
+public interface InputStreamFactory<T extends InputStream> {
     /**
      * Get an InputStream instance for the factory object
-     * 
+     *
      * @return an InputStream instance
+     * @throws IOException if there is a problem creating or retrieving the input stream
      */
-    InputStream create() throws IOException;
+    T create() throws IOException;
 }

--- a/src/main/java/emissary/core/channels/LazyOpeningFileChannel.java
+++ b/src/main/java/emissary/core/channels/LazyOpeningFileChannel.java
@@ -1,0 +1,89 @@
+package emissary.core.channels;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * {@link SeekableByteChannel} implementation that provides immutable access to a {@link FileChannel} instance. The
+ * FileChannel instance is only created upon the first attempt to access the file content
+ */
+final class LazyOpeningFileChannel implements SeekableByteChannel {
+
+    private static final Set<StandardOpenOption> OPTIONS = Collections.singleton(StandardOpenOption.READ);
+
+    private final Path path;
+
+    // leverage the defined immutability support
+    private ImmutableChannel<FileChannel> channel;
+
+    LazyOpeningFileChannel(final Path path) {
+        this.path = path;
+    }
+
+    protected void initialiseChannel() throws IOException {
+        if (channel == null) {
+            channel = new ImmutableChannel<>(FileChannel.open(path, OPTIONS));
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (channel != null) {
+            channel.close();
+        }
+    }
+
+    @Override
+    public int read(ByteBuffer byteBuffer) throws IOException {
+        initialiseChannel();
+        return channel.read(byteBuffer);
+    }
+
+    @Override
+    public int write(ByteBuffer byteBuffer) throws IOException {
+        initialiseChannel();
+        // delegate immutability to the channel instance
+        return channel.write(byteBuffer);
+    }
+
+    @Override
+    public long position() throws IOException {
+        initialiseChannel();
+        return channel.position();
+    }
+
+    @Override
+    public SeekableByteChannel position(long l) throws IOException {
+        return channel.position(l);
+    }
+
+    @Override
+    public long size() throws IOException {
+        initialiseChannel();
+        return channel.size();
+    }
+
+    @Override
+    public SeekableByteChannel truncate(long l) throws IOException {
+        initialiseChannel();
+        // delegate immutability to the instance
+        channel.truncate(l);
+        return null;
+    }
+
+    @Override
+    public boolean isOpen() {
+        try {
+            initialiseChannel();
+        } catch (IOException e) {
+            return false;
+        }
+        return channel.isOpen();
+    }
+}

--- a/src/main/java/emissary/core/channels/SeekableByteChannelFactory.java
+++ b/src/main/java/emissary/core/channels/SeekableByteChannelFactory.java
@@ -4,15 +4,17 @@ import java.nio.channels.SeekableByteChannel;
 
 /**
  * Interface to provide a consistent experience dealing with streaming data.
+ * 
+ * @param <T> Type of {@link SeekableByteChannel} instances that this factory can construct
  */
-public interface SeekableByteChannelFactory {
+public interface SeekableByteChannelFactory<T extends SeekableByteChannel> {
 
     /**
      * Creates a channel from the referenced data that already exists as part of the factory's parent.
-     * 
+     *
      * See {@link InMemoryChannelFactory} for an example of how to implement this.
-     * 
+     *
      * @return a channel with access to the data
      */
-    SeekableByteChannel create();
+    T create();
 }

--- a/src/main/java/emissary/util/DisposeHelper.java
+++ b/src/main/java/emissary/util/DisposeHelper.java
@@ -1,6 +1,7 @@
 package emissary.util;
 
 import emissary.core.IBaseDataObject;
+import emissary.core.channels.SeekableByteChannelFactory;
 
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
@@ -13,8 +14,7 @@ import java.util.List;
 /**
  * Helper methods to ease handling of Dispose objects
  * 
- * Dispose objects are added to BDOs to handle clean-up after a
- * {@link emissary.core.channels.SeekableByteChannelFactory} is finished with
+ * Dispose objects are added to BDOs to handle clean-up after a {@link SeekableByteChannelFactory} is finished with
  */
 public final class DisposeHelper {
     private DisposeHelper() {}

--- a/src/test/java/emissary/core/BaseDataObjectTest.java
+++ b/src/test/java/emissary/core/BaseDataObjectTest.java
@@ -101,7 +101,7 @@ class BaseDataObjectTest extends UnitTest {
     void testDataLengthWithChannel() {
         this.b.setData(null);
         assertEquals(0, this.b.dataLength());
-        this.b.setChannelFactory(InMemoryChannelFactory.create(new byte[10]));
+        this.b.setChannelFactory(InMemoryChannelFactory.createFactory(new byte[10]));
         assertEquals(10, this.b.dataLength());
         this.b.setData(new byte[10]);
         assertEquals(10, this.b.dataLength());
@@ -112,7 +112,7 @@ class BaseDataObjectTest extends UnitTest {
     void testLargestFile() throws IOException {
         final BaseDataObject bdo = new BaseDataObject();
         final long fileSize = Long.MAX_VALUE;
-        final SeekableByteChannelFactory sbcf = FillChannelFactory.create(fileSize, (byte) 0);
+        final SeekableByteChannelFactory sbcf = FillChannelFactory.createFactory(fileSize, (byte) 0);
         bdo.setChannelFactory(sbcf);
         assertEquals(fileSize, bdo.getChannelSize());
         assertEquals(BaseDataObject.MAX_BYTE_ARRAY_SIZE, bdo.dataLength());
@@ -1096,7 +1096,7 @@ class BaseDataObjectTest extends UnitTest {
             this.b.popCurrentForm();
             assertEquals(this.b.currentFormSize(), clone.currentFormSize() - 1, "Current form stack must be detached after clone");
             final String newData = "some new data";
-            final SeekableByteChannelFactory sbcf = InMemoryChannelFactory.create(newData.getBytes());
+            final SeekableByteChannelFactory sbcf = InMemoryChannelFactory.createFactory(newData.getBytes());
             this.b.setChannelFactory(sbcf);
             final IBaseDataObject cloneSbc = this.b.clone();
             assertEquals(13, cloneSbc.getChannelFactory().create().read(ByteBuffer.allocate(newData.length())));
@@ -1208,7 +1208,7 @@ class BaseDataObjectTest extends UnitTest {
         this.b.getChannelFactory().create().read(buff);
         assertEquals(testData, new String(buff.array()));
 
-        final SeekableByteChannelFactory sbcf = InMemoryChannelFactory.create(testArray);
+        final SeekableByteChannelFactory sbcf = InMemoryChannelFactory.createFactory(testArray);
         this.b.setChannelFactory(sbcf);
 
         // data() check with sbcf

--- a/src/test/java/emissary/core/IBaseDataObjectHelperTest.java
+++ b/src/test/java/emissary/core/IBaseDataObjectHelperTest.java
@@ -17,7 +17,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
-import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -146,7 +146,7 @@ class IBaseDataObjectHelperTest {
 
     @Test
     void testCloneChannelFactory() {
-        ibdo1.setChannelFactory(InMemoryChannelFactory.create("0123456789".getBytes(StandardCharsets.US_ASCII)));
+        ibdo1.setChannelFactory(InMemoryChannelFactory.createFactory("0123456789".getBytes(US_ASCII)));
         verifyClone("getChannelFactory", ibdo1, IS_SAME, IS_EQUALS, EQUAL_WITHOUT_FULL_CLONE);
     }
 
@@ -180,9 +180,9 @@ class IBaseDataObjectHelperTest {
 
     @Test
     void testCloneAlternateViews() {
-        ibdo1.addAlternateView("AAA", "AAA".getBytes(StandardCharsets.US_ASCII));
-        ibdo1.addAlternateView("BBB", "BBB".getBytes(StandardCharsets.US_ASCII));
-        ibdo1.addAlternateView("CCC", "CCC".getBytes(StandardCharsets.US_ASCII));
+        ibdo1.addAlternateView("AAA", "AAA".getBytes(US_ASCII));
+        ibdo1.addAlternateView("BBB", "BBB".getBytes(US_ASCII));
+        ibdo1.addAlternateView("CCC", "CCC".getBytes(US_ASCII));
         verifyClone("getAlternateViews", ibdo1, IS_NOT_SAME, IS_EQUALS, EQUAL_WITHOUT_FULL_CLONE);
     }
 
@@ -258,13 +258,13 @@ class IBaseDataObjectHelperTest {
 
     @Test
     void testCloneHeader() {
-        ibdo1.setHeader("header".getBytes(StandardCharsets.US_ASCII));
+        ibdo1.setHeader("header".getBytes(US_ASCII));
         verifyClone("header", ibdo1, IS_NOT_SAME, IS_NOT_EQUALS, EQUAL_AFTER_FULL_CLONE);
     }
 
     @Test
     void testCloneFooter() {
-        ibdo1.setFooter("footer".getBytes(StandardCharsets.US_ASCII));
+        ibdo1.setFooter("footer".getBytes(US_ASCII));
         verifyClone("footer", ibdo1, IS_NOT_SAME, IS_NOT_EQUALS, EQUAL_AFTER_FULL_CLONE);
     }
 
@@ -345,8 +345,8 @@ class IBaseDataObjectHelperTest {
         ibdo2.setData(new byte[1]);
         verifyDiff(1, true, false, false, false);
 
-        ibdo1.setChannelFactory(InMemoryChannelFactory.create("0123456789".getBytes(StandardCharsets.US_ASCII)));
-        ibdo2.setChannelFactory(InMemoryChannelFactory.create("9876543210".getBytes(StandardCharsets.US_ASCII)));
+        ibdo1.setChannelFactory(InMemoryChannelFactory.createFactory("0123456789".getBytes(US_ASCII)));
+        ibdo2.setChannelFactory(InMemoryChannelFactory.createFactory("9876543210".getBytes(US_ASCII)));
         verifyDiff(1, true, false, false, false);
 
         ibdo2.setChannelFactory(new SeekableByteChannelFactory() {
@@ -398,14 +398,14 @@ class IBaseDataObjectHelperTest {
 
     @Test
     void testDiffAlternateViews() {
-        ibdo1.addAlternateView("AAA", "AAA".getBytes(StandardCharsets.US_ASCII));
-        ibdo1.addAlternateView("BBB", "BBB".getBytes(StandardCharsets.US_ASCII));
-        ibdo1.addAlternateView("CCC", "CCC".getBytes(StandardCharsets.US_ASCII));
+        ibdo1.addAlternateView("AAA", "AAA".getBytes(US_ASCII));
+        ibdo1.addAlternateView("BBB", "BBB".getBytes(US_ASCII));
+        ibdo1.addAlternateView("CCC", "CCC".getBytes(US_ASCII));
         verifyDiff(1);
 
-        ibdo2.addAlternateView("DDD", "DDD".getBytes(StandardCharsets.US_ASCII));
-        ibdo2.addAlternateView("EEE", "EEE".getBytes(StandardCharsets.US_ASCII));
-        ibdo2.addAlternateView("FFF", "FFF".getBytes(StandardCharsets.US_ASCII));
+        ibdo2.addAlternateView("DDD", "DDD".getBytes(US_ASCII));
+        ibdo2.addAlternateView("EEE", "EEE".getBytes(US_ASCII));
+        ibdo2.addAlternateView("FFF", "FFF".getBytes(US_ASCII));
         verifyDiff(1);
     }
 
@@ -472,13 +472,13 @@ class IBaseDataObjectHelperTest {
 
     @Test
     void testDiffHeader() {
-        ibdo1.setHeader("header".getBytes(StandardCharsets.US_ASCII));
+        ibdo1.setHeader("header".getBytes(US_ASCII));
         verifyDiff(1);
     }
 
     @Test
     void testDiffFooter() {
-        ibdo1.setFooter("footer".getBytes(StandardCharsets.US_ASCII));
+        ibdo1.setFooter("footer".getBytes(US_ASCII));
         verifyDiff(1);
     }
 
@@ -575,7 +575,7 @@ class IBaseDataObjectHelperTest {
         final KffDataObjectHandler mockKffDataObjectHandler1 = Mockito.mock(KffDataObjectHandler.class);
         final IBaseDataObject childIbdo1 = new BaseDataObject();
 
-        childIbdo1.setChannelFactory(InMemoryChannelFactory.create("0123456789".getBytes(StandardCharsets.US_ASCII)));
+        childIbdo1.setChannelFactory(InMemoryChannelFactory.createFactory("0123456789".getBytes(US_ASCII)));
         Mockito.doThrow(NoSuchAlgorithmException.class).when(mockKffDataObjectHandler1).hash(Mockito.any(BaseDataObject.class), Mockito.anyBoolean());
         IBaseDataObjectHelper.addParentInformationToChild(parentIbdo, childIbdo1,
                 true, alwaysCopyMetadataKeys, placeKey, mockKffDataObjectHandler1);

--- a/src/test/java/emissary/core/channels/ChannelTestHelper.java
+++ b/src/test/java/emissary/core/channels/ChannelTestHelper.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ChannelTestHelper {
     private ChannelTestHelper() {};
 
-    public static void checkByteArrayAgainstSbc(final byte[] bytesToVerify, final SeekableByteChannelFactory sbcf)
+    public static void checkByteArrayAgainstSbc(final byte[] bytesToVerify, final SeekableByteChannelFactory<?> sbcf)
             throws IOException {
         try (final SeekableByteChannel sbc = sbcf.create()) {
             int startIndex, length;
@@ -19,16 +19,21 @@ public class ChannelTestHelper {
                 for (length = bytesToVerify.length - startIndex; length > 0; length--) { // Check length
                     // Seek to starting point
                     sbc.position(startIndex);
+
                     // Confirm the 'requested' position is the 'current' position
                     // Because of lazy evaluation, we're just storing that the consumer wants to seek to the requested
                     // position - the channel hasn't actually changed position yet
                     assertEquals(startIndex, sbc.position());
+
                     // Get ready to read
                     final ByteBuffer buff = ByteBuffer.allocate(length);
+
                     // Actually read (at this point, the channel/input streams are created and updated as required)
                     sbc.read(buff);
+
                     // Confirm that the current position is where we expect - the point in the file that we read to.
                     assertEquals(startIndex + length, sbc.position());
+
                     // Check we actually got the right stuff
                     assertArrayEquals(Arrays.copyOfRange(bytesToVerify, startIndex, startIndex + length), buff.array());
                 }

--- a/src/test/java/emissary/core/channels/FileChannelFactoryTest.java
+++ b/src/test/java/emissary/core/channels/FileChannelFactoryTest.java
@@ -26,8 +26,8 @@ class FileChannelFactoryTest {
 
         Files.write(TEST_BYTES, path.toFile());
 
-        final SeekableByteChannel sbc = FileChannelFactory.create(path).create();
-        final SeekableByteChannel sbc2 = FileChannelFactory.create(path).create();
+        final SeekableByteChannel sbc = FileChannelFactory.createFactory(path).create();
+        final SeekableByteChannel sbc2 = FileChannelFactory.createFactory(path).create();
 
         final ByteBuffer buff = ByteBuffer.allocate(4);
         sbc.read(buff);
@@ -38,7 +38,7 @@ class FileChannelFactoryTest {
 
     @Test
     void testCannotCreateFactoryWithNullByteArray() {
-        assertThrows(NullPointerException.class, () -> FileChannelFactory.create(null),
+        assertThrows(NullPointerException.class, () -> FileChannelFactory.createFactory(null),
                 "Factory allowed null to be set, which would fail when getting an instance later");
     }
 
@@ -48,7 +48,7 @@ class FileChannelFactoryTest {
 
         Files.write(TEST_BYTES, path.toFile());
 
-        final SeekableByteChannelFactory sbcf = FileChannelFactory.create(path);
+        final SeekableByteChannelFactory<?> sbcf = FileChannelFactory.createFactory(path);
         final ByteBuffer buff = ByteBuffer.allocate(TEST_STRING.length());
         sbcf.create().read(buff);
         assertEquals(TEST_STRING, new String(buff.array()));
@@ -58,7 +58,7 @@ class FileChannelFactoryTest {
     void testClose(@TempDir Path tempDir) throws IOException {
         final Path path = tempDir.resolve("testBytes");
         Files.write(TEST_BYTES, path.toFile());
-        final SeekableByteChannelFactory sbcf = FileChannelFactory.create(path);
+        final SeekableByteChannelFactory<?> sbcf = FileChannelFactory.createFactory(path);
         try (final SeekableByteChannel sbc = sbcf.create()) {
             assertTrue(sbc.isOpen());
             sbc.close();
@@ -79,7 +79,7 @@ class FileChannelFactoryTest {
 
         Files.write(TEST_BYTES, path.toFile());
 
-        final SeekableByteChannelFactory sbcf = FileChannelFactory.create(path);
+        final SeekableByteChannelFactory<?> sbcf = FileChannelFactory.createFactory(path);
         final SeekableByteChannel sbc = sbcf.create();
         final ByteBuffer buff = ByteBuffer.wrap("New data".getBytes());
         assertThrows(NonWritableChannelException.class, () -> sbc.write(buff), "Can't write to byte channel as it's immutable");
@@ -92,7 +92,7 @@ class FileChannelFactoryTest {
 
         Files.write(new byte[0], path.toFile());
 
-        final SeekableByteChannelFactory simbcf = FileChannelFactory.create(path);
+        final SeekableByteChannelFactory<?> simbcf = FileChannelFactory.createFactory(path);
         assertEquals(0L, simbcf.create().size());
     }
 
@@ -102,8 +102,8 @@ class FileChannelFactoryTest {
 
         Files.write(TEST_BYTES, path.toFile());
 
-        final SeekableByteChannelFactory sbcf = FileChannelFactory.create(path);
+        final SeekableByteChannelFactory<?> sbcf = FileChannelFactory.createFactory(path);
         assertEquals(9, sbcf.create().size());
-        assertThrows(NullPointerException.class, () -> FileChannelFactory.create(null), "Can't create a FCF with nulls");
+        assertThrows(NullPointerException.class, () -> FileChannelFactory.createFactory(null), "Can't create a FCF with nulls");
     }
 }

--- a/src/test/java/emissary/core/channels/FillChannelFactoryTest.java
+++ b/src/test/java/emissary/core/channels/FillChannelFactoryTest.java
@@ -14,8 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class FillChannelFactoryTest {
     @Test
-    void testCreate() throws IOException {
-        assertThrows(IllegalArgumentException.class, () -> FillChannelFactory.create(-1, (byte) 0));
+    void testCreateFactory() {
+        assertThrows(IllegalArgumentException.class, () -> FillChannelFactory.createFactory(-1, (byte) 0));
     }
 
     @Test
@@ -25,7 +25,7 @@ class FillChannelFactoryTest {
         for (byte b = -100; b < 100; b++) {
             Arrays.fill(bytes, b);
 
-            ChannelTestHelper.checkByteArrayAgainstSbc(bytes, FillChannelFactory.create(bytes.length, b));
+            ChannelTestHelper.checkByteArrayAgainstSbc(bytes, FillChannelFactory.createFactory(bytes.length, b));
         }
     }
 
@@ -38,7 +38,7 @@ class FillChannelFactoryTest {
         final ByteBuffer byteBuffer = ByteBuffer.allocateDirect(bytes.length);
         final byte[] byteBufferBytes = new byte[bytes.length];
 
-        try (SeekableByteChannel sbc = FillChannelFactory.create(bytes.length, bytes[0]).create()) {
+        try (SeekableByteChannel sbc = FillChannelFactory.createFactory(bytes.length, bytes[0]).create()) {
             assertEquals(15, IOUtils.read(sbc, byteBuffer));
 
             byteBuffer.position(0);

--- a/src/test/java/emissary/core/channels/ImmutableChannelFactoryTest.java
+++ b/src/test/java/emissary/core/channels/ImmutableChannelFactoryTest.java
@@ -18,13 +18,8 @@ class ImmutableChannelFactoryTest {
 
     @Test
     void testNormalPath() throws IOException {
-        final SeekableByteChannelFactory simbcf = new SeekableByteChannelFactory() {
-            @Override
-            public SeekableByteChannel create() {
-                return new SeekableInMemoryByteChannel(TEST_STRING.getBytes());
-            }
-        };
-        final SeekableByteChannelFactory sbcf = ImmutableChannelFactory.create(simbcf);
+        final SeekableByteChannelFactory<?> simbcf = () -> new SeekableInMemoryByteChannel(TEST_STRING.getBytes());
+        final SeekableByteChannelFactory<?> sbcf = ImmutableChannelFactory.createFactory(simbcf);
         final ByteBuffer buff = ByteBuffer.wrap(TEST_STRING.concat(TEST_STRING).getBytes());
         try (final SeekableByteChannel sbc = sbcf.create()) {
             assertThrows(NonWritableChannelException.class, () -> sbc.write(buff), "Writes aren't allowed to immutable channels");
@@ -33,17 +28,17 @@ class ImmutableChannelFactoryTest {
 
     @Test
     void testCanCreateAndRetrieveEmptyByteArray() throws IOException {
-        assertThrows(NullPointerException.class, () -> ImmutableChannelFactory.create(null),
+        assertThrows(NullPointerException.class, () -> ImmutableChannelFactory.createFactory(null),
                 "Must provide a channel to make unmodifiable");
-        SeekableByteChannelFactory sbcf = InMemoryChannelFactory.create(new byte[0]);
-        SeekableByteChannel sbc = ImmutableChannelFactory.create(sbcf).create();
+        SeekableByteChannelFactory<?> sbcf = InMemoryChannelFactory.createFactory(new byte[0]);
+        SeekableByteChannel sbc = ImmutableChannelFactory.createFactory(sbcf).create();
         assertEquals(0, sbc.size());
     }
 
     @Test
     void testOverrides() throws IOException {
-        final SeekableByteChannelFactory sbcf = InMemoryChannelFactory.create(TEST_STRING.getBytes());
-        final SeekableByteChannel sbc = ImmutableChannelFactory.create(sbcf).create();
+        final SeekableByteChannelFactory<?> sbcf = InMemoryChannelFactory.createFactory(TEST_STRING.getBytes());
+        final SeekableByteChannel sbc = ImmutableChannelFactory.createFactory(sbcf).create();
         assertTrue(sbc.isOpen());
         sbc.position(3);
         assertEquals(3, sbc.position());

--- a/src/test/java/emissary/core/channels/InMemoryChannelFactoryTest.java
+++ b/src/test/java/emissary/core/channels/InMemoryChannelFactoryTest.java
@@ -15,22 +15,22 @@ class InMemoryChannelFactoryTest {
 
     @Test
     void testCannotCreateFactoryWithNullByteArray() {
-        assertThrows(NullPointerException.class, () -> InMemoryChannelFactory.create(null),
+        assertThrows(NullPointerException.class, () -> InMemoryChannelFactory.createFactory(null),
                 "Factory allowed null to be set, which would fail when getting an instance later");
     }
 
     @Test
     void testNormalPath() throws IOException {
         final String testString = "Test data";
-        final SeekableByteChannelFactory sbcf = InMemoryChannelFactory.create(testString.getBytes());
+        final SeekableByteChannelFactory<?> sbcf = InMemoryChannelFactory.createFactory(testString.getBytes());
         final ByteBuffer buff = ByteBuffer.allocate(testString.length());
         sbcf.create().read(buff);
         assertEquals(testString, new String(buff.array()));
     }
 
     @Test
-    void testImmutability() throws IOException {
-        final SeekableByteChannelFactory sbcf = InMemoryChannelFactory.create("Test data".getBytes());
+    void testImmutability() {
+        final SeekableByteChannelFactory<?> sbcf = InMemoryChannelFactory.createFactory("Test data".getBytes());
         final SeekableByteChannel sbc = sbcf.create();
         final ByteBuffer buff = ByteBuffer.wrap("New data".getBytes());
         assertThrows(NonWritableChannelException.class, () -> sbc.write(buff), "Can't write to byte channel as it's immutable");
@@ -41,7 +41,7 @@ class InMemoryChannelFactoryTest {
 
     @Test
     void testCanCreateAndRetrieveEmptyByteArray() throws IOException {
-        final SeekableByteChannelFactory simbcf = InMemoryChannelFactory.create(new byte[0]);
+        final SeekableByteChannelFactory<?> simbcf = InMemoryChannelFactory.createFactory(new byte[0]);
         assertEquals(0L, simbcf.create().size());
     }
 }

--- a/src/test/java/emissary/kff/ChecksumCalculatorTest.java
+++ b/src/test/java/emissary/kff/ChecksumCalculatorTest.java
@@ -158,7 +158,7 @@ class ChecksumCalculatorTest extends UnitTest {
             for (int j = 0; j < i; j++) {
                 b[j] = (byte) 'a';
             }
-            final SeekableByteChannelFactory sbcf = FillChannelFactory.create((long) i, (byte) 'a');
+            final SeekableByteChannelFactory sbcf = FillChannelFactory.createFactory((long) i, (byte) 'a');
             final ChecksumResults crByte = cc.digest(b);
             final ChecksumResults crSbcf = cc.digest(sbcf);
 


### PR DESCRIPTION
Trial approach for review/consideration.  Much like the initial PR that introduced the SCBF framework, the potential value of the changes won't really be evident until integrated in a downstream code base.  Right now this looks like a lot of angle brackets and ceremony with no obvious benefit. That may also prove to be the case once a trial integration is evaluated, but I'm hopeful these changes will enable some more explicitly constrained interfaces without getting in the way.