### PR TITLE
Remove deprecated configuration property dependencyLocationsEnabled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -903,7 +903,6 @@
           <version>3.3.0</version>
           <configuration>
             <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
-            <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Just removes a property that is no longer supported by the plugin.  It causes IntelliJ to mark the pom with errors.

Its presence doesn't do anything - I verified the site builds the same with or without it.  Removing it just removes errors that we need to ignore from the IDE.