### PR TITLE
Refactor diff methods into a more cohesive structure

### DIFF
--- a/src/main/java/emissary/core/DiffCheckConfiguration.java
+++ b/src/main/java/emissary/core/DiffCheckConfiguration.java
@@ -1,0 +1,223 @@
+package emissary.core;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Utility class to help simplify configuration of {@link IBaseDataObjectDiffHelper}
+ */
+public class DiffCheckConfiguration {
+    /**
+     * Possible configuration options
+     */
+    public enum DiffCheckOptions {
+        DATA, TIMESTAMP, INTERNAL_ID, TRANSFORM_HISTORY;
+    }
+
+    /**
+     * Stateful field of 'enabled' options
+     */
+    private final EnumSet<DiffCheckOptions> enabled;
+
+    /**
+     * Start building a new configuration
+     * 
+     * @return a new builder instance
+     */
+    public static DiffCheckConfiguration.DiffCheckBuilder configure() {
+        return new DiffCheckConfiguration.DiffCheckBuilder();
+    }
+
+    /**
+     * Helper method to simplify only enable checking of data
+     * 
+     * @return a new config instance which only enables checking data
+     */
+    public static DiffCheckConfiguration onlyCheckData() {
+        return new DiffCheckConfiguration(EnumSet.of(DiffCheckOptions.DATA));
+    }
+
+    /**
+     * Check if data should be diffed
+     * 
+     * @return if checking data is enabled
+     */
+    public boolean checkData() {
+        return enabled.contains(DiffCheckOptions.DATA);
+    }
+
+    /**
+     * Check if the timestamp should be diffed
+     * 
+     * @return if checking timestamps is enabled
+     */
+    public boolean checkTimestamp() {
+        return enabled.contains(DiffCheckOptions.TIMESTAMP);
+    }
+
+    /**
+     * Check if the internal ID should be diffed
+     * 
+     * @return if checking the internal ID is enabled
+     */
+    public boolean checkInternalId() {
+        return enabled.contains(DiffCheckOptions.INTERNAL_ID);
+    }
+
+    /**
+     * Check if the transform history should be diffed
+     * 
+     * @return if checking the transform history is enabled
+     */
+    public boolean checkTransformHistory() {
+        return enabled.contains(DiffCheckOptions.TRANSFORM_HISTORY);
+    }
+
+    /**
+     * Accessor for enabled options
+     * 
+     * @return the enabled options
+     */
+    public Set<DiffCheckOptions> getEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Private constructor to skip builder pattern
+     * 
+     * @param enabled set of pre-configured options
+     */
+    private DiffCheckConfiguration(final EnumSet<DiffCheckOptions> enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * Builder class for {@link DiffCheckConfiguration}
+     */
+    public static class DiffCheckBuilder {
+
+        /**
+         * Internal state whilst building
+         */
+        private EnumSet<DiffCheckOptions> building;
+
+        /**
+         * Finish building and create the final DiffCheckConfiguration object
+         * 
+         * @return a new Configuration instance with the enabled options
+         */
+        public DiffCheckConfiguration build() {
+            return new DiffCheckConfiguration(building);
+        }
+
+        /**
+         * Provide explicit list of options to enable
+         * 
+         * @param options to enable explicitly
+         * @return a new Configuration instance with the enabled options
+         */
+        public DiffCheckConfiguration explicit(final DiffCheckOptions... options) {
+            reset();
+            building.addAll(Arrays.asList(options));
+            return build();
+        }
+
+        /**
+         * Private constructor
+         */
+        private DiffCheckBuilder() {
+            building = EnumSet.noneOf(DiffCheckOptions.class);
+        }
+
+        /**
+         * Reset the list of enabled options
+         * 
+         * @return the builder
+         */
+        public DiffCheckBuilder reset() {
+            building.clear();
+            return this;
+        }
+
+        /**
+         * Enable data for diff checking
+         * 
+         * @return the builder
+         */
+        public DiffCheckBuilder enableData() {
+            building.add(DiffCheckOptions.DATA);
+            return this;
+        }
+
+        /**
+         * Disable data for diff checking
+         * 
+         * @return the builder
+         */
+        public DiffCheckBuilder disableData() {
+            building.remove(DiffCheckOptions.DATA);
+            return this;
+        }
+
+        /**
+         * Enable timestamp for diff checking
+         * 
+         * @return the builder
+         */
+        public DiffCheckBuilder enableTimestamp() {
+            building.add(DiffCheckOptions.TIMESTAMP);
+            return this;
+        }
+
+        /**
+         * Disable timestamp for diff checking
+         * 
+         * @return the builder
+         */
+        public DiffCheckBuilder disableTimestamp() {
+            building.remove(DiffCheckOptions.TIMESTAMP);
+            return this;
+        }
+
+        /**
+         * Enable internal ID for diff checking
+         * 
+         * @return the builder
+         */
+        public DiffCheckBuilder enableInternalId() {
+            building.add(DiffCheckOptions.INTERNAL_ID);
+            return this;
+        }
+
+        /**
+         * Disable internal ID for diff checking
+         * 
+         * @return the builder
+         */
+        public DiffCheckBuilder disableInternalId() {
+            building.remove(DiffCheckOptions.INTERNAL_ID);
+            return this;
+        }
+
+        /**
+         * Enable transform history for diff checking
+         * 
+         * @return the builder
+         */
+        public DiffCheckBuilder enableTransformHistory() {
+            building.add(DiffCheckOptions.TRANSFORM_HISTORY);
+            return this;
+        }
+
+        /**
+         * Disable transform history for diff checking
+         * 
+         * @return the builder
+         */
+        public DiffCheckBuilder disableTransformHistory() {
+            building.remove(DiffCheckOptions.TRANSFORM_HISTORY);
+            return this;
+        }
+    }
+}

--- a/src/main/java/emissary/core/IBaseDataObjectDiffHelper.java
+++ b/src/main/java/emissary/core/IBaseDataObjectDiffHelper.java
@@ -1,0 +1,226 @@
+package emissary.core;
+
+import emissary.core.channels.SeekableByteChannelFactory;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.Validate;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.SeekableByteChannel;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class IBaseDataObjectDiffHelper {
+
+    private static final String DIFF_NOT_NULL_MSG = "Required: differences not null";
+    private static final String ID_NOT_NULL_MSG = "Required: identifier not null";
+    private static final String ARE_NOT_EQUAL = " are not equal";
+
+    private IBaseDataObjectDiffHelper() {}
+
+    /**
+     * This method compares two IBaseDataObject's and adds any differences to the provided string list.
+     * 
+     * @param ibdo1 the first IBaseDataObject to compare.
+     * @param ibdo2 the second IBaseDataObject to compare.
+     * @param differences the string list differences are to be added to.
+     * @param options {@link DiffCheckConfiguration} containing config to specify whether to check data etc.
+     */
+    public static void diff(final IBaseDataObject ibdo1, final IBaseDataObject ibdo2,
+            final List<String> differences, final DiffCheckConfiguration options) {
+        Validate.notNull(ibdo1, "Required: ibdo1 not null");
+        Validate.notNull(ibdo2, "Required: ibdo2 not null");
+        Validate.notNull(differences, DIFF_NOT_NULL_MSG);
+
+        if (options.checkData()) {
+            final SeekableByteChannelFactory sbcf1 = ibdo1.getChannelFactory();
+            final SeekableByteChannelFactory sbcf2 = ibdo2.getChannelFactory();
+            diff(sbcf1, sbcf2, "sbcf", differences);
+        }
+
+        diff(ibdo1.getFilename(), ibdo2.getFilename(), "filename", differences);
+        diff(ibdo1.shortName(), ibdo2.shortName(), "shortName", differences);
+        if (options.checkInternalId()) {
+            diff(ibdo1.getInternalId(), ibdo2.getInternalId(), "internalId", differences);
+        }
+        diff(ibdo1.currentForm(), ibdo2.currentForm(), "currentForm", differences);
+        diff(ibdo1.getProcessingError(), ibdo2.getProcessingError(), "processingError", differences);
+
+        if (options.checkTransformHistory()) {
+            diff(ibdo1.transformHistory(), ibdo2.transformHistory(), "transformHistory", differences);
+        }
+
+        diff(ibdo1.getFontEncoding(), ibdo2.getFontEncoding(), "fontEncoding", differences);
+        diff(ibdo1.getParameters(), ibdo2.getParameters(), "parameters", differences);
+        diff(ibdo1.getNumChildren(), ibdo2.getNumChildren(), "numChildren", differences);
+        diff(ibdo1.getNumSiblings(), ibdo2.getNumSiblings(), "numSiblings", differences);
+        diff(ibdo1.getBirthOrder(), ibdo2.getBirthOrder(), "birthOrder", differences);
+        diff(ibdo1.getAlternateViews(), ibdo2.getAlternateViews(), "alternateViews", differences);
+        diff(ibdo1.header(), ibdo2.header(), "header", differences);
+        diff(ibdo1.footer(), ibdo2.footer(), "footer", differences);
+        diff(ibdo1.getHeaderEncoding(), ibdo2.getHeaderEncoding(), "headerEncoding", differences);
+        diff(ibdo1.getClassification(), ibdo2.getClassification(), "classification", differences);
+        diff(ibdo1.isBroken(), ibdo2.isBroken(), "broken", differences);
+        diff(ibdo1.isFileTypeEmpty(), ibdo2.isFileTypeEmpty(), "fileTypeEmpty", differences);
+        diff(ibdo1.getPriority(), ibdo2.getPriority(), "priority", differences);
+        if (options.checkTimestamp()) {
+            diff(ibdo1.getCreationTimestamp(), ibdo2.getCreationTimestamp(), "creationTimestamp", differences);
+        }
+        diff(ibdo1.isOutputable(), ibdo2.isOutputable(), "outputable", differences);
+        diff(ibdo1.getId(), ibdo2.getId(), "id", differences);
+        diff(ibdo1.getWorkBundleId(), ibdo2.getWorkBundleId(), "workBundleId", differences);
+        diff(ibdo1.getTransactionId(), ibdo2.getTransactionId(), "transactionId", differences);
+
+        // Special case - pass through DiffCheckConfiguration options. This also ensures the right method is called (Object vs
+        // List<IBDO>)
+        diff(ibdo1.getExtractedRecords(), ibdo2.getExtractedRecords(), "extractedRecords", differences, options);
+    }
+
+    /**
+     * This method compares two lists of IBaseDataObject's and adds any differences to the provided string list.
+     * 
+     * @param ibdoList1 the first list of IBaseDataObjects to compare.
+     * @param ibdoList2 the second list of IBaseDataObjects to compare.
+     * @param identifier a string that helps identify the context of comparing these two list of IBaseDataObjects.
+     * @param differences the string list differences are to be added to.
+     * @param options {@link DiffCheckConfiguration} containing config to specify whether to check data etc.
+     */
+    public static void diff(final List<IBaseDataObject> ibdoList1, final List<IBaseDataObject> ibdoList2,
+            final String identifier, final List<String> differences, final DiffCheckConfiguration options) {
+        Validate.notNull(identifier, ID_NOT_NULL_MSG);
+        Validate.notNull(differences, DIFF_NOT_NULL_MSG);
+
+        final int ibdoList1Size = (ibdoList1 == null) ? 0 : ibdoList1.size();
+        final int ibdoList2Size = (ibdoList2 == null) ? 0 : ibdoList2.size();
+
+        if (ibdoList1Size != ibdoList2Size) {
+            differences.add(String.format("%s%s: 1.s=%s 2.s=%s", identifier, ARE_NOT_EQUAL, ibdoList1Size, ibdoList2Size));
+        } else if (ibdoList1 != null && ibdoList2 != null) {
+            final List<String> childDifferences = new ArrayList<>();
+            for (int i = 0; i < ibdoList1.size(); i++) {
+                childDifferences.clear();
+
+                diff(ibdoList1.get(i), ibdoList2.get(i), childDifferences, options);
+
+                final String prefix = identifier + " : " + i + " : ";
+                while (!childDifferences.isEmpty()) {
+                    differences.add(prefix + childDifferences.remove(0)); // NOSONAR Used correctly
+                }
+            }
+        }
+    }
+
+    /**
+     * This method compares two {@link SeekableByteChannelFactory} (SBCF) objects and adds any differences to the provided
+     * string list.
+     * 
+     * @param sbcf1 the first SBCF to compare.
+     * @param sbcf2 the second SBCF to compare.
+     * @param identifier an identifier to describe the context of this SBCF comparison.
+     * @param differences the string list differences are to be added to.
+     */
+    public static void diff(final SeekableByteChannelFactory sbcf1, final SeekableByteChannelFactory sbcf2,
+            final String identifier, final List<String> differences) {
+        Validate.notNull(identifier, ID_NOT_NULL_MSG);
+        Validate.notNull(differences, DIFF_NOT_NULL_MSG);
+
+        if (sbcf1 != null && sbcf2 != null) {
+            try (SeekableByteChannel sbc1 = sbcf1.create();
+                    SeekableByteChannel sbc2 = sbcf2.create();
+                    InputStream is1 = Channels.newInputStream(sbc1);
+                    InputStream is2 = Channels.newInputStream(sbc2)) {
+                if (!IOUtils.contentEquals(is1, is2)) {
+                    differences.add(String.format("%s not equal. 1.cs=%s 2.cs=%s",
+                            identifier, sbc1.size(), sbc2.size()));
+                }
+            } catch (IOException e) {
+                differences.add(String.format("Failed to compare %s: %s", identifier, e.getMessage()));
+            }
+        } else if (sbcf1 == null && sbcf2 == null) {
+            // Do nothing as they are considered equal.
+        } else {
+            differences.add(String.format("%s not equal. sbcf1=%s sbcf2=%s", identifier, sbcf1, sbcf2));
+        }
+    }
+
+    /**
+     * This method compares two Objects and adds any differences to the provided string list.
+     * 
+     * @param object1 the first Object to compare.
+     * @param object2 the second Object to compare.
+     * @param identifier an identifier to describe the context of this Object comparison.
+     * @param differences the string list differences are to be added to.
+     */
+    public static void diff(final Object object1, final Object object2, final String identifier,
+            final List<String> differences) {
+        Validate.notNull(identifier, ID_NOT_NULL_MSG);
+        Validate.notNull(differences, DIFF_NOT_NULL_MSG);
+
+        if (!Objects.deepEquals(object1, object2)) {
+            differences.add(String.format("%s%s: %s : %s", identifier, ARE_NOT_EQUAL, object1, object2));
+        }
+    }
+
+    /**
+     * This method compares two integers and adds any differences to the provided string list.
+     * 
+     * @param integer1 the first integer to compare.
+     * @param integer2 the second integer to compare.
+     * @param identifier an identifier to describe the context of this integer comparison.
+     * @param differences the string list differences are to be added to.
+     */
+    public static void diff(final int integer1, final int integer2, final String identifier,
+            final List<String> differences) {
+        Validate.notNull(identifier, ID_NOT_NULL_MSG);
+        Validate.notNull(differences, DIFF_NOT_NULL_MSG);
+
+        if (integer1 != integer2) {
+            differences.add(identifier + ARE_NOT_EQUAL);
+        }
+    }
+
+    /**
+     * This method compares two booleans and adds any differences to the provided string list.
+     * 
+     * @param boolean1 the first boolean to compare.
+     * @param boolean2 the second boolean to compare.
+     * @param identifier an identifier to describe the context of this boolean comparison.
+     * @param differences the string list differences are to be added to.
+     */
+    public static void diff(final boolean boolean1, final boolean boolean2, final String identifier,
+            final List<String> differences) {
+        Validate.notNull(identifier, ID_NOT_NULL_MSG);
+        Validate.notNull(differences, DIFF_NOT_NULL_MSG);
+
+        if (boolean1 != boolean2) {
+            differences.add(identifier + ARE_NOT_EQUAL);
+        }
+    }
+
+    /**
+     * This method compares two maps and adds any differences to the provided string list.
+     * 
+     * @param map1 the first map to compare.
+     * @param map2 the second map to compare.
+     * @param identifier an identifier to describe the context of this map comparison.
+     * @param differences the string list differences are to be added to.
+     */
+    public static void diff(final Map<String, byte[]> map1, final Map<String, byte[]> map2, final String identifier,
+            final List<String> differences) {
+        Validate.notNull(map1, "Required: map1 not null!");
+        Validate.notNull(map2, "Required: map2 not null!");
+        Validate.notNull(identifier, ID_NOT_NULL_MSG);
+        Validate.notNull(differences, DIFF_NOT_NULL_MSG);
+
+        if (map1.size() != map2.size() ||
+                !map1.entrySet().stream().allMatch(e -> Arrays.equals(e.getValue(), map2.get(e.getKey())))) {
+            differences.add(identifier + ARE_NOT_EQUAL);
+        }
+    }
+
+}

--- a/src/test/java/emissary/core/IBaseDataObjectDiffHelperTest.java
+++ b/src/test/java/emissary/core/IBaseDataObjectDiffHelperTest.java
@@ -1,0 +1,297 @@
+package emissary.core;
+
+import emissary.core.channels.AbstractSeekableByteChannel;
+import emissary.core.channels.InMemoryChannelFactory;
+import emissary.core.channels.SeekableByteChannelFactory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class IBaseDataObjectDiffHelperTest {
+
+    private IBaseDataObject ibdo1;
+    private IBaseDataObject ibdo2;
+    private List<IBaseDataObject> ibdoList1;
+    private List<IBaseDataObject> ibdoList2;
+    private List<String> differences;
+    private static final DiffCheckConfiguration EMPTY_OPTIONS = DiffCheckConfiguration.configure().build();
+    private static final DiffCheckConfiguration CHECK_DATA = DiffCheckConfiguration.onlyCheckData();
+
+    @BeforeEach
+    void setup() {
+        ibdo1 = new BaseDataObject();
+        ibdo2 = new BaseDataObject();
+        ibdoList1 = Arrays.asList(ibdo1);
+        ibdoList2 = Arrays.asList(ibdo2);
+        differences = new ArrayList<>();
+    }
+
+    private void verifyDiff(final int expectedDifferences) {
+        verifyDiff(expectedDifferences, EMPTY_OPTIONS);
+    }
+
+    private void verifyDiff(final int expectedDifferences, final DiffCheckConfiguration options) {
+        IBaseDataObjectDiffHelper.diff(ibdo1, ibdo1, differences, options);
+        assertEquals(0, differences.size());
+        IBaseDataObjectDiffHelper.diff(ibdo1, ibdo2, differences, options);
+        assertEquals(expectedDifferences, differences.size());
+        differences.clear();
+        IBaseDataObjectDiffHelper.diff(ibdo2, ibdo1, differences, options);
+        assertEquals(expectedDifferences, differences.size());
+        differences.clear();
+    }
+
+    private void verifyDiffList(final int expectedDifferences, final List<IBaseDataObject> list1, final List<IBaseDataObject> list2) {
+        IBaseDataObjectDiffHelper.diff(list1, list1, "test", differences, EMPTY_OPTIONS);
+        assertEquals(0, differences.size());
+        IBaseDataObjectDiffHelper.diff(list1, list2, "test", differences, EMPTY_OPTIONS);
+        assertEquals(expectedDifferences, differences.size());
+        differences.clear();
+    }
+
+    private void checkThrowsNull(final Executable e) {
+        assertThrows(NullPointerException.class, e);
+    }
+
+    @Test
+    void testDiffArguments() {
+        // Objects
+        checkThrowsNull(() -> IBaseDataObjectDiffHelper.diff(null, ibdo2, differences, EMPTY_OPTIONS));
+        checkThrowsNull(() -> IBaseDataObjectDiffHelper.diff(ibdo1, null, differences, EMPTY_OPTIONS));
+        checkThrowsNull(() -> IBaseDataObjectDiffHelper.diff(ibdo1, ibdo2, null, EMPTY_OPTIONS));
+        checkThrowsNull(() -> IBaseDataObjectDiffHelper.diff(ibdoList1, ibdoList2, null, differences, EMPTY_OPTIONS));
+        checkThrowsNull(() -> IBaseDataObjectDiffHelper.diff(ibdoList1, ibdoList2, "id", null, EMPTY_OPTIONS));
+        checkThrowsNull(() -> IBaseDataObjectDiffHelper.diff(ibdo1, ibdo2, differences, null));
+        checkThrowsNull(() -> IBaseDataObjectDiffHelper.diff(new Object(), new Object(), null, differences));
+        checkThrowsNull(() -> IBaseDataObjectDiffHelper.diff(new Object(), new Object(), "id", null));
+
+        // Integers
+        checkThrowsNull(() -> IBaseDataObjectDiffHelper.diff(0, 0, null, differences));
+        checkThrowsNull(() -> IBaseDataObjectDiffHelper.diff(0, 0, "id", null));
+
+        // Booleans
+        checkThrowsNull(() -> IBaseDataObjectDiffHelper.diff(false, false, null, differences));
+        checkThrowsNull(() -> IBaseDataObjectDiffHelper.diff(false, false, "id", null));
+
+        // Maps
+        checkThrowsNull(() -> IBaseDataObjectDiffHelper.diff(null, new HashMap<>(), "id", differences));
+        checkThrowsNull(() -> IBaseDataObjectDiffHelper.diff(new HashMap<>(), null, "id", differences));
+        checkThrowsNull(() -> IBaseDataObjectDiffHelper.diff(new HashMap<>(), new HashMap<>(), null, differences));
+        checkThrowsNull(() -> IBaseDataObjectDiffHelper.diff(new HashMap<>(), new HashMap<>(), "id", null));
+    }
+
+    @Test
+    void testDiffChannelFactory() {
+        ibdo2.setData(new byte[1]);
+        verifyDiff(1, CHECK_DATA);
+
+        ibdo1.setChannelFactory(InMemoryChannelFactory.create("0123456789".getBytes(StandardCharsets.US_ASCII)));
+        ibdo2.setChannelFactory(InMemoryChannelFactory.create("9876543210".getBytes(StandardCharsets.US_ASCII)));
+        verifyDiff(1, CHECK_DATA);
+
+        ibdo2.setChannelFactory(new SeekableByteChannelFactory() {
+            @Override
+            public SeekableByteChannel create() {
+                return new AbstractSeekableByteChannel() {
+                    @Override
+                    protected void closeImpl() throws IOException {
+                        throw new IOException("Test SBC that always throws IOException!");
+                    }
+
+                    @Override
+                    protected int readImpl(ByteBuffer byteBuffer, int maxBytesToRead) throws IOException {
+                        throw new IOException("Test SBC that always throws IOException!");
+                    }
+
+                    @Override
+                    protected long sizeImpl() throws IOException {
+                        throw new IOException("Test SBC that always throws IOException!");
+                    }
+                };
+            }
+        });
+
+        verifyDiff(1, CHECK_DATA);
+    }
+
+    @Test
+    void testDiffCurrentForm() {
+        ibdo1.pushCurrentForm("AAA");
+        ibdo1.pushCurrentForm("BBB");
+        ibdo1.pushCurrentForm("CCC");
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffHistory() {
+        ibdo1.appendTransformHistory("AAA", false);
+        ibdo1.appendTransformHistory("BBB", true);
+        final DiffCheckConfiguration checkTransformHistory = DiffCheckConfiguration.configure().enableTransformHistory().build();
+        verifyDiff(1, checkTransformHistory);
+    }
+
+    @Test
+    void testDiffParameters() {
+        ibdo1.putParameter("STRING", "string");
+        ibdo1.putParameter("LIST", Arrays.asList("first", "second", "third"));
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffAlternateViews() {
+        ibdo1.addAlternateView("AAA", "AAA".getBytes(StandardCharsets.US_ASCII));
+        ibdo1.addAlternateView("BBB", "BBB".getBytes(StandardCharsets.US_ASCII));
+        ibdo1.addAlternateView("CCC", "CCC".getBytes(StandardCharsets.US_ASCII));
+        verifyDiff(1);
+
+        ibdo2.addAlternateView("DDD", "DDD".getBytes(StandardCharsets.US_ASCII));
+        ibdo2.addAlternateView("EEE", "EEE".getBytes(StandardCharsets.US_ASCII));
+        ibdo2.addAlternateView("FFF", "FFF".getBytes(StandardCharsets.US_ASCII));
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffPriority() {
+        ibdo1.setPriority(13);
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffCreationTimestamp() {
+        ibdo1.setCreationTimestamp(new Date(1234567890));
+        final DiffCheckConfiguration options = DiffCheckConfiguration.configure().enableTimestamp().build();
+        verifyDiff(1, options);
+    }
+
+    @Test
+    void testDiffExtractedRecords() {
+        ibdo1.addExtractedRecord(new BaseDataObject());
+        ibdo1.addExtractedRecord(new BaseDataObject());
+        ibdo1.addExtractedRecord(new BaseDataObject());
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffFilename() {
+        ibdo1.setFilename("filename");
+        verifyDiff(2);
+    }
+
+    @Test
+    void testDiffInternalId() {
+        final DiffCheckConfiguration options = DiffCheckConfiguration.configure().enableInternalId().build();
+        verifyDiff(1, options);
+    }
+
+    @Test
+    void testDiffProcessingError() {
+        ibdo1.addProcessingError("processing_error");
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffFontEncoding() {
+        ibdo1.setFontEncoding("font_encoding");
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffNumChildren() {
+        ibdo1.setNumChildren(13);
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffNumSiblings() {
+        ibdo1.setNumSiblings(13);
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffBirthOrder() {
+        ibdo1.setBirthOrder(13);
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffHeader() {
+        ibdo1.setHeader("header".getBytes(StandardCharsets.US_ASCII));
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffFooter() {
+        ibdo1.setFooter("footer".getBytes(StandardCharsets.US_ASCII));
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffHeaderEncoding() {
+        ibdo1.setHeaderEncoding("header_encoding");
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffClassification() {
+        ibdo1.setClassification("classification");
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffBroken() {
+        ibdo1.setBroken("broken");
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffOutputable() {
+        ibdo1.setOutputable(false);
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffId() {
+        ibdo1.setId("id");
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffWorkBundleId() {
+        ibdo1.setWorkBundleId("workbundle_id");
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffTransactionId() {
+        ibdo1.setTransactionId("transaction_id");
+        verifyDiff(1);
+    }
+
+    @Test
+    void testDiffList() {
+        final List<IBaseDataObject> ibdoList3 = Arrays.asList(ibdo1, ibdo2);
+        verifyDiffList(0, null, null);
+        verifyDiffList(0, new ArrayList<>(), null);
+        verifyDiffList(0, null, new ArrayList<>());
+        verifyDiffList(0, ibdoList1, ibdoList1);
+        verifyDiffList(1, ibdoList3, ibdoList2);
+        verifyDiffList(1, ibdoList1, ibdoList3);
+
+        ibdo2.setClassification("classification");
+        verifyDiffList(1, ibdoList1, ibdoList2);
+    }
+}

--- a/src/test/java/emissary/core/IBaseDataObjectHelperTest.java
+++ b/src/test/java/emissary/core/IBaseDataObjectHelperTest.java
@@ -1,8 +1,6 @@
 package emissary.core;
 
-import emissary.core.channels.AbstractSeekableByteChannel;
 import emissary.core.channels.InMemoryChannelFactory;
-import emissary.core.channels.SeekableByteChannelFactory;
 import emissary.kff.KffDataObjectHandler;
 import emissary.parser.SessionParser;
 
@@ -15,14 +13,11 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.nio.ByteBuffer;
-import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -44,9 +39,6 @@ class IBaseDataObjectHelperTest {
 
     private IBaseDataObject ibdo1;
     private IBaseDataObject ibdo2;
-    private List<IBaseDataObject> ibdoList1;
-    private List<IBaseDataObject> ibdoList2;
-    private List<String> differences;
 
     private static final Boolean IS_SAME = true;
     private static final Boolean IS_EQUALS = true;
@@ -60,33 +52,6 @@ class IBaseDataObjectHelperTest {
     void setup() {
         ibdo1 = new BaseDataObject();
         ibdo2 = new BaseDataObject();
-        ibdoList1 = Arrays.asList(ibdo1);
-        ibdoList2 = Arrays.asList(ibdo2);
-        differences = new ArrayList<>();
-    }
-
-    private void verifyDiff(final int expectedDifferences) {
-        verifyDiff(expectedDifferences, false, false, false, false);
-    }
-
-    private void verifyDiff(final int expectedDifferences, final boolean checkData, final boolean checkTimestamp, final boolean checkInternalId,
-            final boolean checkTransformHistory) {
-        IBaseDataObjectHelper.diff(ibdo1, ibdo1, differences, checkData, checkTimestamp, checkInternalId, checkTransformHistory);
-        assertEquals(0, differences.size());
-        IBaseDataObjectHelper.diff(ibdo1, ibdo2, differences, checkData, checkTimestamp, checkInternalId, checkTransformHistory);
-        assertEquals(expectedDifferences, differences.size());
-        differences.clear();
-        IBaseDataObjectHelper.diff(ibdo2, ibdo1, differences, checkData, checkTimestamp, checkInternalId, checkTransformHistory);
-        assertEquals(expectedDifferences, differences.size());
-        differences.clear();
-    }
-
-    private void verifyDiffList(final int expectedDifferences, final List<IBaseDataObject> list1, final List<IBaseDataObject> list2) {
-        IBaseDataObjectHelper.diff(list1, list1, "test", differences, false, false, false, false);
-        assertEquals(0, differences.size());
-        IBaseDataObjectHelper.diff(list1, list2, "test", differences, false, false, false, false);
-        assertEquals(expectedDifferences, differences.size());
-        differences.clear();
     }
 
     private void verifyClone(final String methodName, final IBaseDataObject origObj, final Boolean isSame, final Boolean isEquals,
@@ -312,230 +277,6 @@ class IBaseDataObjectHelperTest {
 
     private void checkThrowsNull(final Executable e) {
         assertThrows(NullPointerException.class, e);
-    }
-
-    @Test
-    void testDiffArguments() {
-        // Objects
-        checkThrowsNull(() -> IBaseDataObjectHelper.diff(null, ibdo2, differences, false, false, false, false));
-        checkThrowsNull(() -> IBaseDataObjectHelper.diff(ibdo1, null, differences, false, false, false, false));
-        checkThrowsNull(() -> IBaseDataObjectHelper.diff(ibdo1, ibdo2, null, false, false, false, false));
-        checkThrowsNull(() -> IBaseDataObjectHelper.diff(ibdoList1, ibdoList2, null, differences, false, false, false, false));
-        checkThrowsNull(() -> IBaseDataObjectHelper.diff(ibdoList1, ibdoList2, "id", null, false, false, false, false));
-        checkThrowsNull(() -> IBaseDataObjectHelper.diff(new Object(), new Object(), null, differences));
-        checkThrowsNull(() -> IBaseDataObjectHelper.diff(new Object(), new Object(), "id", null));
-
-        // Integers
-        checkThrowsNull(() -> IBaseDataObjectHelper.diff(0, 0, null, differences));
-        checkThrowsNull(() -> IBaseDataObjectHelper.diff(0, 0, "id", null));
-
-        // Booleans
-        checkThrowsNull(() -> IBaseDataObjectHelper.diff(false, false, null, differences));
-        checkThrowsNull(() -> IBaseDataObjectHelper.diff(false, false, "id", null));
-
-        // Maps
-        checkThrowsNull(() -> IBaseDataObjectHelper.diff(null, new HashMap<>(), "id", differences));
-        checkThrowsNull(() -> IBaseDataObjectHelper.diff(new HashMap<>(), null, "id", differences));
-        checkThrowsNull(() -> IBaseDataObjectHelper.diff(new HashMap<>(), new HashMap<>(), null, differences));
-        checkThrowsNull(() -> IBaseDataObjectHelper.diff(new HashMap<>(), new HashMap<>(), "id", null));
-    }
-
-    @Test
-    void testDiffChannelFactory() {
-        ibdo2.setData(new byte[1]);
-        verifyDiff(1, true, false, false, false);
-
-        ibdo1.setChannelFactory(InMemoryChannelFactory.create("0123456789".getBytes(StandardCharsets.US_ASCII)));
-        ibdo2.setChannelFactory(InMemoryChannelFactory.create("9876543210".getBytes(StandardCharsets.US_ASCII)));
-        verifyDiff(1, true, false, false, false);
-
-        ibdo2.setChannelFactory(new SeekableByteChannelFactory() {
-            @Override
-            public SeekableByteChannel create() {
-                return new AbstractSeekableByteChannel() {
-                    @Override
-                    protected void closeImpl() throws IOException {
-                        throw new IOException("Test SBC that always throws IOException!");
-                    }
-
-                    @Override
-                    protected int readImpl(ByteBuffer byteBuffer, int maxBytesToRead) throws IOException {
-                        throw new IOException("Test SBC that always throws IOException!");
-                    }
-
-                    @Override
-                    protected long sizeImpl() throws IOException {
-                        throw new IOException("Test SBC that always throws IOException!");
-                    }
-                };
-            }
-        });
-
-        verifyDiff(1, true, false, false, false);
-    }
-
-    @Test
-    void testDiffCurrentForm() {
-        ibdo1.pushCurrentForm("AAA");
-        ibdo1.pushCurrentForm("BBB");
-        ibdo1.pushCurrentForm("CCC");
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffHistory() {
-        ibdo1.appendTransformHistory("AAA", false);
-        ibdo1.appendTransformHistory("BBB", true);
-        verifyDiff(1, false, false, false, true);
-    }
-
-    @Test
-    void testDiffParameters() {
-        ibdo1.putParameter("STRING", "string");
-        ibdo1.putParameter("LIST", Arrays.asList("first", "second", "third"));
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffAlternateViews() {
-        ibdo1.addAlternateView("AAA", "AAA".getBytes(StandardCharsets.US_ASCII));
-        ibdo1.addAlternateView("BBB", "BBB".getBytes(StandardCharsets.US_ASCII));
-        ibdo1.addAlternateView("CCC", "CCC".getBytes(StandardCharsets.US_ASCII));
-        verifyDiff(1);
-
-        ibdo2.addAlternateView("DDD", "DDD".getBytes(StandardCharsets.US_ASCII));
-        ibdo2.addAlternateView("EEE", "EEE".getBytes(StandardCharsets.US_ASCII));
-        ibdo2.addAlternateView("FFF", "FFF".getBytes(StandardCharsets.US_ASCII));
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffPriority() {
-        ibdo1.setPriority(13);
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffCreationTimestamp() {
-        ibdo1.setCreationTimestamp(new Date(1234567890));
-        verifyDiff(1, false, true, false, false);
-    }
-
-    @Test
-    void testDiffExtractedRecords() {
-        ibdo1.addExtractedRecord(new BaseDataObject());
-        ibdo1.addExtractedRecord(new BaseDataObject());
-        ibdo1.addExtractedRecord(new BaseDataObject());
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffFilename() {
-        ibdo1.setFilename("filename");
-        verifyDiff(2);
-    }
-
-    @Test
-    void testDiffInternalId() {
-        verifyDiff(1, false, false, true, false);
-    }
-
-    @Test
-    void testDiffProcessingError() {
-        ibdo1.addProcessingError("processing_error");
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffFontEncoding() {
-        ibdo1.setFontEncoding("font_encoding");
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffNumChildren() {
-        ibdo1.setNumChildren(13);
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffNumSiblings() {
-        ibdo1.setNumSiblings(13);
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffBirthOrder() {
-        ibdo1.setBirthOrder(13);
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffHeader() {
-        ibdo1.setHeader("header".getBytes(StandardCharsets.US_ASCII));
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffFooter() {
-        ibdo1.setFooter("footer".getBytes(StandardCharsets.US_ASCII));
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffHeaderEncoding() {
-        ibdo1.setHeaderEncoding("header_encoding");
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffClassification() {
-        ibdo1.setClassification("classification");
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffBroken() {
-        ibdo1.setBroken("broken");
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffOutputable() {
-        ibdo1.setOutputable(false);
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffId() {
-        ibdo1.setId("id");
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffWorkBundleId() {
-        ibdo1.setWorkBundleId("workbundle_id");
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffTransactionId() {
-        ibdo1.setTransactionId("transaction_id");
-        verifyDiff(1);
-    }
-
-    @Test
-    void testDiffList() {
-        final List<IBaseDataObject> ibdoList3 = Arrays.asList(ibdo1, ibdo2);
-        verifyDiffList(0, null, null);
-        verifyDiffList(0, new ArrayList<>(), null);
-        verifyDiffList(0, null, new ArrayList<>());
-        verifyDiffList(0, ibdoList1, ibdoList1);
-        verifyDiffList(1, ibdoList3, ibdoList2);
-        verifyDiffList(1, ibdoList1, ibdoList3);
-
-        ibdo2.setClassification("classification");
-        verifyDiffList(1, ibdoList1, ibdoList2);
     }
 
     @Test

--- a/src/test/java/emissary/util/PlaceComparisonHelperTest.java
+++ b/src/test/java/emissary/util/PlaceComparisonHelperTest.java
@@ -3,10 +3,12 @@ package emissary.util;
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
 import emissary.core.BaseDataObject;
+import emissary.core.DiffCheckConfiguration;
 import emissary.core.IBaseDataObject;
 import emissary.place.ServiceProviderPlace;
 import emissary.test.core.junit5.UnitTest;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -22,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PlaceComparisonHelperTest extends UnitTest {
 
+    private static final DiffCheckConfiguration DIFF_OPTIONS = DiffCheckConfiguration.onlyCheckData();
+
     private static final byte[] configurationBytes = new StringBuilder()
             .append("PLACE_NAME = \"TesterPlace\"")
             .append("SERVICE_NAME = \"TESTER\"")
@@ -30,6 +34,20 @@ class PlaceComparisonHelperTest extends UnitTest {
             .append("SERVICE_COST = 50")
             .append("SERVICE_QUALITY = 50")
             .append("SERVICE_PROXY = \"UNKNOWN\"").toString().getBytes(StandardCharsets.UTF_8);
+
+    private IBaseDataObject ibdoNewPlace;
+    private IBaseDataObject ibdoOldPlace;
+    private List<IBaseDataObject> resultsNewPlace;
+    private List<IBaseDataObject> resultsOldPlace;
+    private static final String identifier = "identifier";
+
+    @BeforeEach
+    void setup() {
+        ibdoNewPlace = new BaseDataObject();
+        ibdoOldPlace = new BaseDataObject();
+        resultsNewPlace = new ArrayList<>();
+        resultsOldPlace = new ArrayList<>();
+    }
 
     @Test
     void testGetPlaceToCompareArguments() throws Exception {
@@ -45,71 +63,60 @@ class PlaceComparisonHelperTest extends UnitTest {
 
     @Test
     void testCompareToPlaceArguments() throws IOException {
-        final List<IBaseDataObject> newResults = new ArrayList<>();
-        final IBaseDataObject ibdoForNewPlace = new BaseDataObject();
         final ServiceProviderPlace newPlace = new TestMinimalServiceProviderPlace(new ByteArrayInputStream(configurationBytes));
         final String newMethodName = "newMethodName";
         final ServiceProviderPlace oldPlace = new TestMinimalServiceProviderPlace(new ByteArrayInputStream(configurationBytes));
         final String oldMethodName = "oldMethodName";
-        checkThrowsNull(() -> PlaceComparisonHelper.compareToPlace(null, ibdoForNewPlace,
-                newPlace, newMethodName, oldPlace, oldMethodName));
-        checkThrowsNull(() -> PlaceComparisonHelper.compareToPlace(newResults, null,
-                newPlace, newMethodName, oldPlace, oldMethodName));
-        checkThrowsNull(() -> PlaceComparisonHelper.compareToPlace(newResults, ibdoForNewPlace,
-                null, newMethodName, oldPlace, oldMethodName));
-        checkThrowsNull(() -> PlaceComparisonHelper.compareToPlace(newResults, ibdoForNewPlace,
-                newPlace, null, oldPlace, oldMethodName));
-        checkThrowsNull(() -> PlaceComparisonHelper.compareToPlace(newResults, ibdoForNewPlace,
-                newPlace, newMethodName, null, oldMethodName));
-        checkThrowsNull(() -> PlaceComparisonHelper.compareToPlace(newResults, ibdoForNewPlace,
-                newPlace, newMethodName, oldPlace, null));
+        checkThrowsNull(() -> PlaceComparisonHelper.compareToPlace(null, ibdoNewPlace,
+                newPlace, newMethodName, oldPlace, oldMethodName, DIFF_OPTIONS));
+        checkThrowsNull(() -> PlaceComparisonHelper.compareToPlace(resultsNewPlace, null,
+                newPlace, newMethodName, oldPlace, oldMethodName, DIFF_OPTIONS));
+        checkThrowsNull(() -> PlaceComparisonHelper.compareToPlace(resultsNewPlace, ibdoNewPlace,
+                null, newMethodName, oldPlace, oldMethodName, DIFF_OPTIONS));
+        checkThrowsNull(() -> PlaceComparisonHelper.compareToPlace(resultsNewPlace, ibdoNewPlace,
+                newPlace, null, oldPlace, oldMethodName, DIFF_OPTIONS));
+        checkThrowsNull(() -> PlaceComparisonHelper.compareToPlace(resultsNewPlace, ibdoNewPlace,
+                newPlace, newMethodName, null, oldMethodName, DIFF_OPTIONS));
+        checkThrowsNull(() -> PlaceComparisonHelper.compareToPlace(resultsNewPlace, ibdoNewPlace,
+                newPlace, newMethodName, oldPlace, null, DIFF_OPTIONS));
+        checkThrowsNull(() -> PlaceComparisonHelper.compareToPlace(resultsNewPlace, ibdoNewPlace,
+                newPlace, newMethodName, oldPlace, oldMethodName, null));
     }
 
     @Test
     void testCompareToPlace() throws Exception {
-        final List<IBaseDataObject> newResults = new ArrayList<>();
-        final IBaseDataObject ibdoForNewPlace = new BaseDataObject();
         final ServiceProviderPlace newPlace = new TestMinimalServiceProviderPlace(new ByteArrayInputStream(configurationBytes));
         final String newMethodName = "processHeavyDuty";
         final ServiceProviderPlace oldPlace = new TestMinimalServiceProviderPlace(new ByteArrayInputStream(configurationBytes));
         final String oldMethodName = "processHeavyDuty";
 
         assertNull(PlaceComparisonHelper.compareToPlace(
-                newResults, ibdoForNewPlace, newPlace, newMethodName, oldPlace, oldMethodName));
+                resultsNewPlace, ibdoNewPlace, newPlace, newMethodName, oldPlace, oldMethodName, DIFF_OPTIONS));
     }
 
     @Test
     void testCheckDifferencesArguments() {
-        final IBaseDataObject ibdoForOldPlace = new BaseDataObject();
-        final IBaseDataObject ibdoForNewPlace = new BaseDataObject();
-        final List<IBaseDataObject> oldResults = new ArrayList<>();
-        final List<IBaseDataObject> newResults = new ArrayList<>();
-        final String identifier = "identifier";
-
         checkThrowsNull(() -> PlaceComparisonHelper.checkDifferences(
-                null, ibdoForNewPlace, oldResults, newResults, identifier));
+                null, ibdoNewPlace, resultsOldPlace, resultsNewPlace, identifier, DIFF_OPTIONS));
         checkThrowsNull(() -> PlaceComparisonHelper.checkDifferences(
-                ibdoForOldPlace, null, oldResults, newResults, identifier));
+                ibdoOldPlace, null, resultsOldPlace, resultsNewPlace, identifier, DIFF_OPTIONS));
         checkThrowsNull(() -> PlaceComparisonHelper.checkDifferences(
-                ibdoForOldPlace, ibdoForNewPlace, null, newResults, identifier));
+                ibdoOldPlace, ibdoNewPlace, null, resultsNewPlace, identifier, DIFF_OPTIONS));
         checkThrowsNull(() -> PlaceComparisonHelper.checkDifferences(
-                ibdoForOldPlace, ibdoForNewPlace, oldResults, null, identifier));
+                ibdoOldPlace, ibdoNewPlace, resultsOldPlace, null, identifier, DIFF_OPTIONS));
         checkThrowsNull(() -> PlaceComparisonHelper.checkDifferences(
-                ibdoForOldPlace, ibdoForNewPlace, oldResults, newResults, null));
+                ibdoOldPlace, ibdoNewPlace, resultsOldPlace, resultsNewPlace, null, DIFF_OPTIONS));
+        checkThrowsNull(() -> PlaceComparisonHelper.checkDifferences(
+                ibdoOldPlace, ibdoNewPlace, resultsOldPlace, resultsNewPlace, identifier, null));
     }
 
     @Test
     void testCheckDifferences() {
-        final IBaseDataObject ibdoForOldPlace = new BaseDataObject();
-        final IBaseDataObject ibdoForNewPlace = new BaseDataObject();
         final IBaseDataObject ibdoForNewPlaceOneChange = new BaseDataObject();
         final IBaseDataObject ibdoForNewPlaceTwoChanges = new BaseDataObject();
-        final List<IBaseDataObject> oldResults = new ArrayList<>();
         final List<IBaseDataObject> oldResultsTwoChanges = new ArrayList<>();
-        final List<IBaseDataObject> newResults = new ArrayList<>();
         final List<IBaseDataObject> newResultsOneChange = new ArrayList<>();
         final List<IBaseDataObject> newResultsTwoChanges = new ArrayList<>();
-        final String identifier = "identifier";
 
         ibdoForNewPlaceOneChange.setData(new byte[1]);
         newResultsOneChange.add(new BaseDataObject());
@@ -124,14 +131,14 @@ class PlaceComparisonHelperTest extends UnitTest {
         oldResultsTwoChanges.get(0).addAlternateView("alternateView3", new byte[3]);
 
         assertNull(PlaceComparisonHelper.checkDifferences(
-                ibdoForOldPlace, ibdoForNewPlace, oldResults, newResults, identifier));
+                ibdoOldPlace, ibdoNewPlace, resultsOldPlace, resultsNewPlace, identifier, DIFF_OPTIONS));
         assertNotNull(PlaceComparisonHelper.checkDifferences(
-                ibdoForOldPlace, ibdoForNewPlaceOneChange, oldResults, newResults, identifier));
+                ibdoOldPlace, ibdoForNewPlaceOneChange, resultsOldPlace, resultsNewPlace, identifier, DIFF_OPTIONS));
         assertNotNull(PlaceComparisonHelper.checkDifferences(
-                ibdoForOldPlace, ibdoForNewPlace, oldResults, newResultsOneChange, identifier));
+                ibdoOldPlace, ibdoNewPlace, resultsOldPlace, newResultsOneChange, identifier, DIFF_OPTIONS));
         assertNotNull(PlaceComparisonHelper.checkDifferences(
-                ibdoForOldPlace, ibdoForNewPlaceOneChange, oldResults, newResultsOneChange, identifier));
+                ibdoOldPlace, ibdoForNewPlaceOneChange, resultsOldPlace, newResultsOneChange, identifier, DIFF_OPTIONS));
         assertNotNull(PlaceComparisonHelper.checkDifferences(
-                ibdoForOldPlace, ibdoForNewPlaceTwoChanges, oldResultsTwoChanges, newResultsTwoChanges, identifier));
+                ibdoOldPlace, ibdoForNewPlaceTwoChanges, oldResultsTwoChanges, newResultsTwoChanges, identifier, DIFF_OPTIONS));
     }
 }


### PR DESCRIPTION
Fundamentally this PR can be considered as two parts:

- refactor `IBaseDataObjectHelper` to move all the diff-related methods to a separate, new class called `IBaseDataObjectDiffHelper`
- introduce a `DiffCheckConfiguration` class to help tidy up the various places where options can be passed in to customise diff behaviour.