### PR TITLE
sonarlint :: cast long operands before assignment

### DIFF
--- a/src/main/java/emissary/kff/KffFile.java
+++ b/src/main/java/emissary/kff/KffFile.java
@@ -164,7 +164,7 @@ public class KffFile implements KffFilter {
             // mappedBuf.position(record.length * mid);
             // mappedBuf.get(record);
             try {
-                knownFile.seek(record.length * mid);
+                knownFile.seek(record.length * (long) mid);
                 int count = knownFile.read(record);
                 if (count != record.length) {
                     logger.warn("Short read on KffFile at " + (record.length * mid) + " read " + count + " expected " + record.length);

--- a/src/main/java/emissary/output/DropOffUtil.java
+++ b/src/main/java/emissary/output/DropOffUtil.java
@@ -249,7 +249,7 @@ public class DropOffUtil {
                 thePath.mkdirs();
                 if (!thePath.exists()) {
                     try {
-                        Thread.sleep(50 * tryCount);
+                        Thread.sleep(50L * tryCount);
                     } catch (InterruptedException e) {
                         // Ignored.
                     }

--- a/src/main/java/emissary/parser/ParserFactory.java
+++ b/src/main/java/emissary/parser/ParserFactory.java
@@ -43,7 +43,7 @@ public class ParserFactory {
 
     // For channel sizes larger than this no fallback to a byte[]
     // parser is attempted.
-    protected long nioFallbackMax = 1024 * 1024 * 100; // 100 Mb
+    protected long nioFallbackMax = 1024L * 1024L * 100L; // 100 Mb
 
     protected String DEFAULT_NIO_PARSER = "emissary.parser.SimpleNioParser";
 

--- a/src/main/java/emissary/util/WindowedSeekableByteChannel.java
+++ b/src/main/java/emissary/util/WindowedSeekableByteChannel.java
@@ -91,7 +91,7 @@ public class WindowedSeekableByteChannel implements SeekableByteChannel {
             return;
         }
         // keep track of our position
-        final int offset = this.buff1.position() + this.buff2.position();
+        final long offset = (long) this.buff1.position() + this.buff2.position();
         this.buff1.position(qtr);
         // push them forward
         this.buff1.compact();


### PR DESCRIPTION
Attempting to solve sonar bug reports for casting operands before assignment: 

- in-line cast to make as little impact as possible
- promote numeric values