### PR TITLE
update actions checkout to 3.3.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.3.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.3.0
 
     - name: Configure Java & Maven
       uses: actions/setup-java@v3


### PR DESCRIPTION
This updates the maven and codeql action to the latest checkout version.
Previous version gives a warning due to node.js actions being deprecated