### PR TITLE
Move position update during read up to AbstractSeekableByteChannel

### DIFF
--- a/src/main/java/emissary/core/channels/AbstractSeekableByteChannel.java
+++ b/src/main/java/emissary/core/channels/AbstractSeekableByteChannel.java
@@ -121,7 +121,10 @@ public abstract class AbstractSeekableByteChannel implements SeekableByteChannel
             return -1;
         }
         final int maxBytesToRead = (int) Math.min(size() - position(), byteBuffer.remaining());
-        return readImpl(byteBuffer, maxBytesToRead);
+        final int bytesRead = readImpl(byteBuffer, maxBytesToRead);
+        // Update position of channel
+        position(position() + bytesRead);
+        return bytesRead;
     }
 
     /**

--- a/src/main/java/emissary/core/channels/FileChannelFactory.java
+++ b/src/main/java/emissary/core/channels/FileChannelFactory.java
@@ -82,6 +82,8 @@ public final class FileChannelFactory {
         @Override
         protected int readImpl(ByteBuffer byteBuffer, int maxBytesToRead) throws IOException {
             initialiseChannel();
+            // Set position for underlying channel, otherwise this won't match the outer channel position
+            channel.position(position());
             return channel.read(byteBuffer);
         }
 

--- a/src/main/java/emissary/core/channels/FillChannelFactory.java
+++ b/src/main/java/emissary/core/channels/FillChannelFactory.java
@@ -91,8 +91,6 @@ public class FillChannelFactory {
                 }
             }
 
-            position(position() + bytesToFill);
-
             return bytesToFill;
         }
     }

--- a/src/main/java/emissary/core/channels/InputStreamChannelFactory.java
+++ b/src/main/java/emissary/core/channels/InputStreamChannelFactory.java
@@ -84,9 +84,8 @@ public class InputStreamChannelFactory {
             final int bytesRead = SeekableByteChannelHelper.getFromInputStream(inputStream, byteBuffer,
                     position() - streamPosition, maxBytesToRead);
 
-            // Update positioning
-            position(position() + bytesRead);
-            streamPosition = position();
+            // Update stream position
+            streamPosition = position() + bytesRead;
 
             return bytesRead;
         }

--- a/src/test/java/emissary/core/channels/AbstractSeekableByteChannelTest.java
+++ b/src/test/java/emissary/core/channels/AbstractSeekableByteChannelTest.java
@@ -32,7 +32,6 @@ class AbstractSeekableByteChannelTest {
         @Override
         protected int readImpl(final ByteBuffer byteBuffer, final int maxBytesToRead) throws IOException {
             byteBuffer.position(byteBuffer.capacity());
-            position(position() + maxBytesToRead);
 
             return maxBytesToRead;
         }

--- a/src/test/java/emissary/core/channels/FileChannelFactoryTest.java
+++ b/src/test/java/emissary/core/channels/FileChannelFactoryTest.java
@@ -1,7 +1,6 @@
 package emissary.core.channels;
 
 import com.google.common.io.Files;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -56,6 +55,13 @@ class FileChannelFactoryTest {
         final ByteBuffer buff = ByteBuffer.allocate(TEST_STRING.length());
         sbcf.create().read(buff);
         assertEquals(TEST_STRING, new String(buff.array()));
+    }
+
+    @Test
+    void testPositioning() throws IOException {
+        final ByteBuffer buff = ByteBuffer.allocate(TEST_STRING.length() - 2);
+        sbcf.create().position(2).read(buff);
+        assertEquals(TEST_STRING.substring(2), new String(buff.array()));
     }
 
     @Test


### PR DESCRIPTION
We spotted this earlier as a potential source of bugs (indeed, `FileChannelFactory` would likely exhibit this behaviour), and would like to resolve it sooner rather than later before more implementations get created downstream (we're not aware of any that would result in having to co-ordinate this release with integration work though).

The old behaviour relied on a child class of `AbstractSeekableByteChannel` to update the position of the channel during the read, but this could easily be forgotten. This change moves this into Abstract to avoid the implementer having to do this in every `readImpl` override.