### PR TITLE
Refactor file IO Utils and address path security concerns

### DIFF
--- a/src/main/java/emissary/output/DropOffUtil.java
+++ b/src/main/java/emissary/output/DropOffUtil.java
@@ -35,6 +35,7 @@ import static emissary.core.Form.PREFIXES_LANG;
 import static emissary.core.Form.TEXT;
 import static emissary.core.Form.UNKNOWN;
 import static emissary.core.constants.Parameters.ORIGINAL_FILENAME;
+import static emissary.util.io.FileIoUtils.cleanSpecPath;
 
 public class DropOffUtil {
     protected static final Logger logger = LoggerFactory.getLogger(DropOffUtil.class);
@@ -223,7 +224,7 @@ public class DropOffUtil {
         // If a file already exists under this name, we're going
         // go have to move it aside. This is going to break the link
         // if it is an attachment to another parent document.
-        final File theFile = new File(fileName);
+        final File theFile = new File(cleanSpecPath(fileName));
 
         if (theFile.exists()) {
             theFile.delete();
@@ -240,7 +241,7 @@ public class DropOffUtil {
      */
     public boolean setupPath(final String fileName) {
         final String pathName = fileName.substring(0, fileName.lastIndexOf(SEPARATOR));
-        final File thePath = new File(pathName);
+        final File thePath = new File(cleanSpecPath(pathName));
 
         // If the specified output directory doesn't exist try creating it
         if (!thePath.exists()) {
@@ -478,10 +479,6 @@ public class DropOffUtil {
         answer = answer.replaceAll("\\.([/\\\\])", "_$1");
 
         return answer;
-    }
-
-    protected String cleanSpecPath(@Nullable String token) {
-        return token == null ? null : token.replaceAll("[.]+", ".");
     }
 
     /**

--- a/src/main/java/emissary/output/filter/DataFilter.java
+++ b/src/main/java/emissary/output/filter/DataFilter.java
@@ -14,6 +14,8 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 
+import static emissary.util.io.FileIoUtils.cleanSpecPath;
+
 /**
  * Filter that writes unadorned data as raw bytes
  */
@@ -163,7 +165,7 @@ public class DataFilter extends AbstractFilter {
         }
 
         // Write it out
-        try (FileOutputStream fos = new FileOutputStream(fileName)) {
+        try (FileOutputStream fos = new FileOutputStream(cleanSpecPath(fileName))) {
             fos.write(data, 0, data.length);
         } catch (IOException ex) {
             logger.error("Cannot write output to {}", fileName, ex);

--- a/src/main/java/emissary/place/Main.java
+++ b/src/main/java/emissary/place/Main.java
@@ -23,7 +23,6 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -31,8 +30,6 @@ import org.slf4j.MDC;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,6 +41,8 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
+
+import static emissary.util.io.FileIoUtils.filePathIsWithinBaseDirectory;
 
 /**
  * This class handles running a the main method from a ServiceProviderPlace instance in a well defined but extensible
@@ -1077,40 +1076,6 @@ public class Main {
                 logger.error("Could not write output to {}", fn, e);
             }
         }
-    }
-
-    /**
-     * Normalizes the provided paths and tests to see whether the file path is within the required base directory.
-     *
-     * @param requiredBase required base directory
-     * @param filePath file path to be tested
-     * @return the normalized file path
-     * @throws IllegalArgumentException if the filePath contains illegal characters or is outside the required base
-     *         directory
-     */
-    static String filePathIsWithinBaseDirectory(final String requiredBase, final String filePath) throws IllegalArgumentException {
-
-        if (StringUtils.isBlank(requiredBase)) {
-            throw new IllegalArgumentException("requiredBase must not be blank");
-        }
-
-        if (StringUtils.isBlank(filePath)) {
-            throw new IllegalArgumentException("filePath must not be blank");
-        }
-
-        // probably an overly simplistic test
-        if (filePath.contains("..")) {
-            throw new IllegalArgumentException("filePath contains illegal character sequence \"..\"");
-        }
-        Path normalizedBasePath = Paths.get(requiredBase).normalize().toAbsolutePath();
-        Path normalizedFilePath = Paths.get(filePath).normalize().toAbsolutePath();
-
-        // append path separator to defeat traversal via a sibling directory with a similar name
-        if (!normalizedFilePath.startsWith(normalizedBasePath.toString() + "/")) {
-            throw new IllegalArgumentException("Normalized file path (\"" + filePath + "\") is outside the required base path (\""
-                    + requiredBase + "\")");
-        }
-        return normalizedFilePath.toString();
     }
 
     /**

--- a/src/main/java/emissary/util/io/FileIoUtils.java
+++ b/src/main/java/emissary/util/io/FileIoUtils.java
@@ -1,0 +1,53 @@
+package emissary.util.io;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import javax.annotation.Nullable;
+
+public class FileIoUtils {
+
+    /** This class is not meant to be instantiated. */
+    private FileIoUtils() {}
+
+    /**
+     * Normalizes the provided paths and tests to see whether the file path is within the required base directory.
+     *
+     * @param requiredBase required base directory
+     * @param filePath file path to be tested
+     * @return the normalized file path
+     * @throws IllegalArgumentException if the filePath contains illegal characters or is outside the required base
+     *         directory
+     */
+    public static String filePathIsWithinBaseDirectory(final String requiredBase, final String filePath) throws IllegalArgumentException {
+
+        if (StringUtils.isBlank(requiredBase)) {
+            throw new IllegalArgumentException("requiredBase must not be blank");
+        }
+
+        if (StringUtils.isBlank(filePath)) {
+            throw new IllegalArgumentException("filePath must not be blank");
+        }
+
+        // probably an overly simplistic test
+        if (filePath.contains("..")) {
+            throw new IllegalArgumentException("filePath contains illegal character sequence \"..\"");
+        }
+        Path normalizedBasePath = Paths.get(requiredBase).normalize().toAbsolutePath();
+        Path normalizedFilePath = Paths.get(filePath).normalize().toAbsolutePath();
+
+        // append path separator to defeat traversal via a sibling directory with a similar name
+        if (!normalizedFilePath.startsWith(normalizedBasePath.toString() + "/")) {
+            throw new IllegalArgumentException("Normalized file path (\"" + filePath + "\") is outside the required base path (\""
+                    + requiredBase + "\")");
+        }
+        return normalizedFilePath.toString();
+    }
+
+    public static String cleanSpecPath(@Nullable String token) {
+        return token == null ? null : token.replaceAll("[.]+", ".");
+    }
+
+
+}

--- a/src/test/java/emissary/io/FileIoUtilsTest.java
+++ b/src/test/java/emissary/io/FileIoUtilsTest.java
@@ -1,0 +1,52 @@
+package emissary.io;
+
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static emissary.util.io.FileIoUtils.cleanSpecPath;
+import static emissary.util.io.FileIoUtils.filePathIsWithinBaseDirectory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class FileIoUtilsTest extends UnitTest {
+
+    @TempDir
+    public Path testOutputFolder;
+
+    @Test
+    void testFilePathIsWithinBaseDirectory() {
+
+        String basePath = testOutputFolder.resolve("foo").toString();
+        assertEquals(basePath + "/somefile", filePathIsWithinBaseDirectory(basePath, basePath + "/somefile"));
+        assertEquals(basePath + "/otherfile", filePathIsWithinBaseDirectory(basePath, basePath + "//otherfile"));
+        assertEquals(basePath + "/foo/otherfile", filePathIsWithinBaseDirectory(basePath, basePath + "/./foo/otherfile"));
+        assertEquals(basePath + "/sub/otherfile", filePathIsWithinBaseDirectory(basePath, basePath + "/sub/././otherfile"));
+
+        // Each of these should have thrown an Exception
+        assertThrows(IllegalArgumentException.class, () -> filePathIsWithinBaseDirectory(basePath, "/var/log/somelog"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> filePathIsWithinBaseDirectory(basePath, basePath + "/../foo2/otherfile"),
+                "Expected an IllegalArgumentException from input " + basePath + "/../foo2/otherfile");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> filePathIsWithinBaseDirectory(basePath, basePath + "/../../somefile"),
+                "Expected an IllegalArgumentException from input " + basePath + "/../../somefile");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> filePathIsWithinBaseDirectory(basePath, basePath + "/path/../../../otherpath"),
+                "Expected an IllegalArgumentException from input " + basePath + "/path/../../../otherpath");
+    }
+
+    @Test
+    void testCleanSpecPath() {
+        assertEquals("/this/is/fine", cleanSpecPath("/this/is/fine"));
+        assertEquals("/this/./is/fine", cleanSpecPath("/this/../is/fine"));
+        assertEquals("/this/./is/./fine", cleanSpecPath("/this/../is/../fine"));
+        assertEquals("/this/./././/./is/fine", cleanSpecPath("/this/....../../..//./is/fine"));
+    }
+}

--- a/src/test/java/emissary/output/DropOffUtilTest.java
+++ b/src/test/java/emissary/output/DropOffUtilTest.java
@@ -601,14 +601,6 @@ class DropOffUtilTest extends UnitTest {
         assertTrue(fileExts.contains("mp3"), "FILEXT values should contain \"mp3\"");
     }
 
-    @Test
-    void testCleanSpecPath() {
-        assertEquals("/this/is/fine", util.cleanSpecPath("/this/is/fine"));
-        assertEquals("/this/./is/fine", util.cleanSpecPath("/this/../is/fine"));
-        assertEquals("/this/./is/./fine", util.cleanSpecPath("/this/../is/../fine"));
-        assertEquals("/this/./././/./is/fine", util.cleanSpecPath("/this/....../../..//./is/fine"));
-    }
-
     private void setupMetadata(IBaseDataObject bdo, String fieldValue, DropOffUtil.FileTypeCheckParameter fileTypeCheckParameter) {
         bdo.clearParameters();
         bdo.putParameter(fileTypeCheckParameter.getFieldName(), fieldValue);

--- a/src/test/java/emissary/place/MainTest.java
+++ b/src/test/java/emissary/place/MainTest.java
@@ -24,12 +24,10 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-import static emissary.place.Main.filePathIsWithinBaseDirectory;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -245,31 +243,6 @@ final class MainTest extends UnitTest {
 
         normalizedPath = outputFolder + "/" + att3.shortName() + "." + att3.currentForm();
         assertFalse(Files.exists(Paths.get(normalizedPath).normalize()), "File \"" + normalizedPath + "\" should have NOT been created");
-    }
-
-    @Test
-    void testFilePathIsWithinBaseDirectory() {
-
-        String basePath = testOutputFolder.resolve("foo").toString();
-        assertEquals(basePath + "/somefile", filePathIsWithinBaseDirectory(basePath, basePath + "/somefile"));
-        assertEquals(basePath + "/otherfile", filePathIsWithinBaseDirectory(basePath, basePath + "//otherfile"));
-        assertEquals(basePath + "/foo/otherfile", filePathIsWithinBaseDirectory(basePath, basePath + "/./foo/otherfile"));
-        assertEquals(basePath + "/sub/otherfile", filePathIsWithinBaseDirectory(basePath, basePath + "/sub/././otherfile"));
-
-        // Each of these should thrown an Exception
-        assertThrows(IllegalArgumentException.class, () -> filePathIsWithinBaseDirectory(basePath, "/var/log/somelog"));
-
-        assertThrows(IllegalArgumentException.class,
-                () -> filePathIsWithinBaseDirectory(basePath, basePath + "/../foo2/otherfile"),
-                "Expected an IllegalArgumentException from input " + basePath + "/../foo2/otherfile");
-
-        assertThrows(IllegalArgumentException.class,
-                () -> filePathIsWithinBaseDirectory(basePath, basePath + "/../../somefile"),
-                "Expected an IllegalArgumentException from input " + basePath + "/../../somefile");
-
-        assertThrows(IllegalArgumentException.class,
-                () -> filePathIsWithinBaseDirectory(basePath, basePath + "/path/../../../otherpath"),
-                "Expected an IllegalArgumentException from input " + basePath + "/path/../../../otherpath");
     }
 
     // Override the hooks. The calls to super in these


### PR DESCRIPTION
Attempting to address:
https://github.com/NationalSecurityAgency/emissary/security/code-scanning/38
https://github.com/NationalSecurityAgency/emissary/security/code-scanning/37
https://github.com/NationalSecurityAgency/emissary/security/code-scanning/36

Created a fileIoUtil class that more methods can be moved into in the future if we want?
The methods were just moved. Originally created by @drivenflywheel and @dev-mlb and have been well tested in production the last few months.