### PR TITLE
Create BufferedChannelFactory.

### DIFF
--- a/src/main/java/emissary/core/channels/BufferedChannelFactory.java
+++ b/src/main/java/emissary/core/channels/BufferedChannelFactory.java
@@ -1,0 +1,131 @@
+package emissary.core.channels;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.Validate;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+
+/**
+ * Creates a SeekableByteChannel cache of a defined size analogous to BufferedInputStream.
+ */
+public final class BufferedChannelFactory {
+    private BufferedChannelFactory() {}
+
+    /**
+     * Creates a SeekableByteChannelFactory that caches the bytes of the passed in SeekableByteChannelFactory.
+     * 
+     * @param seekableByteChannelFactory to be cached.
+     * @param bufferSize of the buffer of bytes.
+     * @return the caching SeekableByteChannelFactory.
+     */
+    public static SeekableByteChannelFactory create(final SeekableByteChannelFactory seekableByteChannelFactory,
+            final int bufferSize) {
+        return new BufferedChannelFactoryImpl(seekableByteChannelFactory, bufferSize);
+    }
+
+    /**
+     * A SeekableByteChannelFactory that caches the bytes of the passed in SeekableByteChannelFactory.
+     */
+    private static class BufferedChannelFactoryImpl implements SeekableByteChannelFactory {
+        /**
+         * The SeekableByteChannel to cache.
+         */
+        private final SeekableByteChannelFactory seekableByteChannelFactory;
+        /**
+         * The size of the buffer of bytes.
+         */
+        private final int bufferSize;
+
+        /**
+         * Creates a SeekableByteChannelFactory that caches the bytes of the passed in SeekableByteChannelFactory.
+         * 
+         * @param seekableByteChannelFactory to be cached.
+         * @param bufferSize of the buffer of bytes.
+         */
+        public BufferedChannelFactoryImpl(final SeekableByteChannelFactory seekableByteChannelFactory,
+                final int bufferSize) {
+            Validate.notNull(seekableByteChannelFactory, "Required: seekableByteChannelFactory not null!");
+            Validate.isTrue(bufferSize > 0, "Required: bufferSize > 0");
+
+            this.seekableByteChannelFactory = seekableByteChannelFactory;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public SeekableByteChannel create() {
+            return new BufferedSeekableByteChannel(seekableByteChannelFactory.create(), bufferSize);
+        }
+    }
+
+    /**
+     * SeekableByteChannel that caches the bytes of the passed in SeekableByteChannel
+     */
+    private static class BufferedSeekableByteChannel extends AbstractSeekableByteChannel {
+        /**
+         * The SeekableByteChannel to cache.
+         */
+        private final SeekableByteChannel seekableByteChannel;
+        /**
+         * The size of the buffer of bytes.
+         */
+        private final int bufferSize;
+        /**
+         * The buffer of bytes.
+         */
+        private final ByteBuffer buffer;
+
+        /**
+         * The starting offset of the current buffer.
+         */
+        private long bufferStart = -1;
+        /**
+         * The number of valid bytes in the current buffer.
+         */
+        private int bufferValidBytes = -1;
+
+        /**
+         * Creates a SeekableByteChannel cache where there is a single buffer of bytes aligned on bufferSize boundaries.
+         * 
+         * @param seekableByteChannel to be cached.
+         * @param bufferSize of the buffer of bytes.
+         */
+        public BufferedSeekableByteChannel(final SeekableByteChannel seekableByteChannel, final int bufferSize) {
+            this.seekableByteChannel = seekableByteChannel;
+            this.bufferSize = bufferSize;
+            this.buffer = ByteBuffer.allocate(bufferSize);
+        }
+
+        @Override
+        protected void closeImpl() throws IOException {
+            seekableByteChannel.close();
+        }
+
+        @Override
+        protected int readImpl(final ByteBuffer byteBuffer) throws IOException {
+            // Determines the start of the buffer that contains the current position.
+            final long bufferStartFromPosition = position() / bufferSize * bufferSize;
+
+            if (bufferStartFromPosition != bufferStart) {
+                buffer.position(0);
+                seekableByteChannel.position(bufferStartFromPosition);
+
+                bufferValidBytes = IOUtils.read(seekableByteChannel, buffer);
+                bufferStart = bufferStartFromPosition;
+            }
+
+            final int bufferStartOffset = (int) (position() % bufferSize);
+            final int bytesToReturn = Math.min(byteBuffer.remaining(), bufferValidBytes - bufferStartOffset);
+
+            byteBuffer.put(buffer.array(), bufferStartOffset, bytesToReturn);
+
+            return bytesToReturn;
+        }
+
+        @Override
+        protected long sizeImpl() throws IOException {
+            return seekableByteChannel.size();
+        }
+    }
+}

--- a/src/main/java/emissary/core/channels/FillChannelFactory.java
+++ b/src/main/java/emissary/core/channels/FillChannelFactory.java
@@ -85,6 +85,7 @@ public class FillChannelFactory {
 
             if (byteBuffer.hasArray()) {
                 Arrays.fill(byteBuffer.array(), byteBuffer.position(), byteBuffer.position() + bytesToFill, value);
+                byteBuffer.position(byteBuffer.position() + bytesToFill);
             } else {
                 for (int i = 0; i < bytesToFill; i++) {
                     byteBuffer.put(value);

--- a/src/test/java/emissary/core/channels/BufferedChannelFactoryTest.java
+++ b/src/test/java/emissary/core/channels/BufferedChannelFactoryTest.java
@@ -1,0 +1,28 @@
+package emissary.core.channels;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BufferedChannelFactoryTest {
+    @Test
+    void testCache() throws IOException {
+
+        final byte[] bytes = new byte[67];
+        final SeekableByteChannelFactory bytesSbcf = InMemoryChannelFactory.create(bytes);
+
+        new Random(0).nextBytes(bytes);
+
+        assertThrows(NullPointerException.class, () -> BufferedChannelFactory.create(null, 10));
+        assertThrows(IllegalArgumentException.class, () -> BufferedChannelFactory.create(bytesSbcf, -1));
+
+        for (int bufferSize = 1; bufferSize < bytes.length * 3; bufferSize++) {
+            final SeekableByteChannelFactory bufferedSbcf = BufferedChannelFactory.create(bytesSbcf, bufferSize);
+
+            ChannelTestHelper.checkByteArrayAgainstSbc(bytes, bufferedSbcf);
+        }
+    }
+}

--- a/src/test/java/emissary/core/channels/ChannelTestHelper.java
+++ b/src/test/java/emissary/core/channels/ChannelTestHelper.java
@@ -1,5 +1,7 @@
 package emissary.core.channels;
 
+import org.apache.commons.io.IOUtils;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
@@ -15,36 +17,32 @@ public class ChannelTestHelper {
             throws IOException {
         try (final SeekableByteChannel sbc = sbcf.create()) {
             int startIndex, length;
-            for (startIndex = 0; startIndex < bytesToVerify.length; startIndex++) { // Check position
-                for (length = bytesToVerify.length - startIndex; length > 0; length--) { // Check length
-                    // Seek to starting point
-                    sbc.position(startIndex);
-                    // Confirm the 'requested' position is the 'current' position
-                    // Because of lazy evaluation, we're just storing that the consumer wants to seek to the requested
-                    // position - the channel hasn't actually changed position yet
-                    assertEquals(startIndex, sbc.position());
-                    // Get ready to read
-                    final ByteBuffer buff = ByteBuffer.allocate(length);
-                    // Actually read (at this point, the channel/input streams are created and updated as required)
-                    sbc.read(buff);
-                    // Confirm that the current position is where we expect - the point in the file that we read to.
-                    assertEquals(startIndex + length, sbc.position());
-                    // Check we actually got the right stuff
-                    assertArrayEquals(Arrays.copyOfRange(bytesToVerify, startIndex, startIndex + length), buff.array());
+            for (startIndex = 0; startIndex < bytesToVerify.length; startIndex++) {
+                for (length = bytesToVerify.length - startIndex; length > 0; length--) {
+                    checkSegment(sbc, bytesToVerify, startIndex, length);
                 }
             }
 
             // Do the same as above but starting from the end of the string/file
-            for (startIndex = (bytesToVerify.length - 1); startIndex > -1; startIndex--) { // Check position
-                for (length = bytesToVerify.length - startIndex; length > 0; length--) { // Check length
-                    sbc.position(startIndex);
-                    assertEquals(startIndex, sbc.position());
-                    final ByteBuffer buff = ByteBuffer.allocate(length);
-                    sbc.read(buff);
-                    assertEquals(startIndex + length, sbc.position());
-                    assertArrayEquals(Arrays.copyOfRange(bytesToVerify, startIndex, startIndex + length), buff.array());
+            for (startIndex = (bytesToVerify.length - 1); startIndex > -1; startIndex--) {
+                for (length = bytesToVerify.length - startIndex; length > 0; length--) {
+                    checkSegment(sbc, bytesToVerify, startIndex, length);
                 }
             }
         }
+    }
+
+    private static void checkSegment(final SeekableByteChannel sbc, final byte[] bytesToVerify, final int startIndex,
+            final int length) throws IOException {
+        sbc.position(startIndex);
+        assertEquals(startIndex, sbc.position(), "Setting initial position of sbc is incorrect!");
+
+        final ByteBuffer buff = ByteBuffer.allocate(length);
+        final int bytesRead = IOUtils.read(sbc, buff);
+
+        assertEquals(length, bytesRead, "bytesRead value is incorrect!");
+        assertEquals(startIndex + length, sbc.position(), "Sbc position after read is incorrect!");
+        assertArrayEquals(Arrays.copyOfRange(bytesToVerify, startIndex, startIndex + length), buff.array(),
+                "Bytes read are incorrect!");
     }
 }


### PR DESCRIPTION
This PR creates a BufferedChannelFactory for SeekableByteChannels which is analogous to BufferedInputStream for InputStreams.

NOTE 1: This PR will be affected by PR#393 ("Move position update during read up to AbstractSeekableByteChannel").
NOTE 2: The BufferedChannelFactoryTest showed a bug in ChannelTestHelper, so that was fixed and cleaned up.
NOTE 3: The fixed ChannelTestHelper caused FileChannelFactoryTest to fail, so that was addressed.