### PR TITLE
Add maven dependency version reports

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -485,7 +485,7 @@ mvn clean test -Dtest=ServerCommandTest -Dmaven.surefire.debug="-Xdebug -Xrunjdw
 
 ### View Dependency Reports
 
-To generate a report to display plugins, properties, dependency that have updates available run the following maven commands.
+To generate a report to display dependencies, plugins, and properties that have updates available run the following maven commands:
 
 ```
 mvn versions:display-dependency-updates

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -483,6 +483,16 @@ debugger attaches, and you can then step through the code.
 mvn clean test -Dtest=ServerCommandTest -Dmaven.surefire.debug="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000 -Xnoagent -Djava.compiler=NONE"
 ```
 
+### View Dependency Reports
+
+To generate a report to display plugins, properties, dependency that have updates available run the following maven commands.
+
+```
+mvn versions:display-dependency-updates
+mvn versions:display-plugin-updates
+mvn versions:display-property-updates
+```
+
 ## Running Emissary
 
 There is one bash script in Emissary that runs everything.  It is in the top level Emissary directory.

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <dep.spullara.mustache.compiler.version>0.9.10</dep.spullara.mustache.compiler.version>
     <dep.spymemcached.version>2.12.3</dep.spymemcached.version>
     <dep.tika.version>1.24</dep.tika.version>
+    <dep.versions.maven.plugin.version>2.14.2</dep.versions.maven.plugin.version>
     <dep.webjars.bootstrap.version>5.1.3</dep.webjars.bootstrap.version>
     <dep.webjars.jquery.version>3.6.0</dep.webjars.jquery.version>
     <dep.webjars.popper.version>2.9.3</dep.webjars.popper.version>
@@ -982,7 +983,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.10.0</version>
+          <version>${dep.versions.maven.plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
@@ -1253,6 +1254,20 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>${dep.versions.maven.plugin.version}</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>dependency-updates-aggregate-report</report>
+              <report>plugin-updates-aggregate-report</report>
+              <report>property-updates-aggregate-report</report>
+            </reports>
+          </reportSet>
+        </reportSets>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
Not sure if this is something we want but thought it was helpful when looking at what dependency could be updated.

By running `mvn site` the reports are generated. The reports can also be generated by using the mvn versions target `mvn versions:display-dependency-updates`

The output with site adds the reports and looks like this:
![image](https://user-images.githubusercontent.com/83408002/215919850-9b0841c0-e233-4659-a34f-94c73bf04753.png)
