### PR TITLE
Non impact full Plugin updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ services, their cost and quality and keep the P2P network connected.
 
 - Linux or MacOSX operating system
 - [JDK 8](https://docs.aws.amazon.com/corretto/latest/corretto-8-ug/downloads-list.html)
-- [Apache Maven 3.6+](http://maven.apache.org)
+- [Apache Maven 3.5+](http://maven.apache.org)
 
 ## Getting Started
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.min-version>3.3.9</maven.min-version>
+    <maven.min-version>3.5.0</maven.min-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- With Java 8 and the latest version of surefire, user.timezone is not read correctly.  Reevaluate one day.
@@ -752,12 +752,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.1</version>
           <configuration>
             <configLocation>${checkstyleFormatter}</configLocation>
             <!-- this combination of these two configurations
@@ -814,12 +814,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.0.0-M1</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0-M2</version>
+          <version>3.2.1</version>
           <executions>
             <execution>
               <id>check-maven-version</id>
@@ -848,12 +848,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.0.0-M1</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.2.2</version>
+          <version>3.3.0</version>
           <executions>
             <execution>
               <goals>
@@ -870,7 +870,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.4.1</version>
           <configuration>
             <quiet>true</quiet>
             <doclint>all,-missing</doclint>
@@ -891,12 +891,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jxr-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
-          <version>3.16.0</version>
+          <version>3.20.0</version>
           <configuration>
             <excludes />
             <failOnViolation>true</failOnViolation>
@@ -921,7 +921,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.2</version>
           <configuration>
             <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
           </configuration>
@@ -929,7 +929,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>3.0.0</version>
           <configuration>
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <pushChanges>true</pushChanges>
@@ -941,7 +941,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
           <configuration>
             <delimiters>
               <delimiter>${*}</delimiter>
@@ -954,7 +954,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.12.1</version>
           <configuration>
             <attach>true</attach>
             <relativizeDecorationLinks>false</relativizeDecorationLinks>
@@ -967,7 +967,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.2.1</version>
           <executions>
             <execution>
               <id>attach-sources</id>
@@ -1091,7 +1091,7 @@
         <plugin>
           <groupId>org.sonarsource.scanner.maven</groupId>
           <artifactId>sonar-maven-plugin</artifactId>
-          <version>3.7.0.1746</version>
+          <version>3.9.1.2184</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -1151,7 +1151,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <goals>
@@ -1656,7 +1656,7 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>docker-build</id>


### PR DESCRIPTION
## Before:
```
mvn versions:display-plugin-updates:
[INFO] The following plugin updates are available:
[INFO]   com.github.ekryd.sortpom:sortpom-maven-plugin ..... 2.15.0 -> 3.2.1
[INFO]   io.github.git-commit-id:git-commit-id-maven-plugin . 4.9.9 -> 5.0.0
[INFO]   maven-assembly-plugin .............................. 3.3.0 -> 3.4.2
[INFO]   maven-checkstyle-plugin ............................ 3.1.1 -> 3.2.1
[INFO]   maven-dependency-plugin ............................ 3.3.0 -> 3.5.0
[INFO]   maven-deploy-plugin ............................. 3.0.0-M1 -> 3.0.0
[INFO]   maven-enforcer-plugin ........................... 3.0.0-M2 -> 3.2.1
[INFO]   maven-failsafe-plugin ........................ 3.0.0-M3 -> 3.0.0-M8
[INFO]   maven-install-plugin ............................ 3.0.0-M1 -> 3.1.0
[INFO]   maven-jar-plugin ................................... 3.2.2 -> 3.3.0
[INFO]   maven-javadoc-plugin ............................... 3.4.0 -> 3.4.1
[INFO]   maven-jxr-plugin ................................... 3.2.0 -> 3.3.0
[INFO]   maven-pmd-plugin ................................. 3.16.0 -> 3.20.0
[INFO]   maven-project-info-reports-plugin .................. 3.3.0 -> 3.4.2
[INFO]   maven-release-plugin ............................ 2.5.3 -> 3.0.0-M7
[INFO]   maven-resources-plugin ............................. 3.2.0 -> 3.3.0
[INFO]   maven-site-plugin .............................. 3.11.0 -> 4.0.0-M4
[INFO]   maven-source-plugin ................................ 3.2.0 -> 3.2.1
[INFO]   maven-surefire-plugin ........................ 3.0.0-M3 -> 3.0.0-M8
[INFO]   maven-surefire-report-plugin ................. 3.0.0-M3 -> 3.0.0-M8
[INFO]   net.revelc.code.formatter:formatter-maven-plugin . 2.11.0 -> 2.21.0
[INFO]   org.codehaus.mojo:exec-maven-plugin ................ 3.0.0 -> 3.1.0
[INFO]   org.codehaus.mojo:versions-maven-plugin .......... 2.10.0 -> 2.14.2
[INFO]   org.sonarsource.scanner.maven:sonar-maven-plugin  3.7.0.1746 -> 3.9.1.2184
```

## After:
```
mvn versions:display-plugin-updates:
[INFO]   com.github.ekryd.sortpom:sortpom-maven-plugin ..... 2.15.0 -> 3.2.1
[INFO]   io.github.git-commit-id:git-commit-id-maven-plugin . 4.9.9 -> 5.0.0
[INFO]   net.revelc.code.formatter:formatter-maven-plugin . 2.11.0 -> 2.21.0
[INFO]   org.codehaus.mojo:versions-maven-plugin .......... 2.10.0 -> 2.14.2
```

Formatter is going to be updated in a seperate PR: https://github.com/NationalSecurityAgency/emissary/pull/406

# Couple of tasks:
- [x] Revert git plugin update (Not compatible with java 8 build environment)
- [x] Verify all versions are available in our build repos