### PR TITLE
bump guava to 31.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <dep.dropwizard.metrics.version>4.2.4</dep.dropwizard.metrics.version>
     <dep.errorprone.javac.version>9+181-r4173-1</dep.errorprone.javac.version>
     <dep.errorprone.version>2.10.0</dep.errorprone.version>
-    <dep.guava.version>30.1.1-jre</dep.guava.version>
+    <dep.guava.version>31.1-jre</dep.guava.version>
     <dep.httpclient.version>4.5.13</dep.httpclient.version>
     <dep.httpcore.version>4.4.15</dep.httpcore.version>
     <dep.jackson.version>2.13.4</dep.jackson.version>


### PR DESCRIPTION
Fixes - 'com.google.common.net.HostAndPort' is marked unstable with @Beta