### PR TITLE
Simplify AbstractSeekableByteChannel by right-sizing the provided byteBuffer

### DIFF
--- a/src/main/java/emissary/core/channels/FileChannelFactory.java
+++ b/src/main/java/emissary/core/channels/FileChannelFactory.java
@@ -80,7 +80,7 @@ public final class FileChannelFactory {
         }
 
         @Override
-        protected int readImpl(ByteBuffer byteBuffer, int maxBytesToRead) throws IOException {
+        protected int readImpl(final ByteBuffer byteBuffer) throws IOException {
             initialiseChannel();
             // Set position for underlying channel, otherwise this won't match the outer channel position
             channel.position(position());

--- a/src/main/java/emissary/core/channels/FillChannelFactory.java
+++ b/src/main/java/emissary/core/channels/FillChannelFactory.java
@@ -80,8 +80,8 @@ public class FillChannelFactory {
         }
 
         @Override
-        protected int readImpl(final ByteBuffer byteBuffer, final int maxBytesToRead) throws IOException {
-            final int bytesToFill = Math.min(maxBytesToRead, Integer.MAX_VALUE);
+        protected int readImpl(final ByteBuffer byteBuffer) throws IOException {
+            final int bytesToFill = byteBuffer.remaining();
 
             if (byteBuffer.hasArray()) {
                 Arrays.fill(byteBuffer.array(), byteBuffer.position(), byteBuffer.position() + bytesToFill, value);

--- a/src/main/java/emissary/core/channels/InputStreamChannelFactory.java
+++ b/src/main/java/emissary/core/channels/InputStreamChannelFactory.java
@@ -65,7 +65,7 @@ public class InputStreamChannelFactory {
         }
 
         @Override
-        protected final int readImpl(final ByteBuffer byteBuffer, final int maxBytesToRead) throws IOException {
+        protected final int readImpl(final ByteBuffer byteBuffer) throws IOException {
             if (inputStream != null && position() < inputStream.getByteCount()) {
                 inputStream.close();
                 inputStream = null;
@@ -76,8 +76,7 @@ public class InputStreamChannelFactory {
             }
 
             // Actually perform the read
-            return SeekableByteChannelHelper.getFromInputStream(inputStream, byteBuffer, position() - inputStream.getByteCount(),
-                    maxBytesToRead);
+            return SeekableByteChannelHelper.getFromInputStream(inputStream, byteBuffer, position() - inputStream.getByteCount());
         }
 
 

--- a/src/main/java/emissary/core/channels/SeekableByteChannelHelper.java
+++ b/src/main/java/emissary/core/channels/SeekableByteChannelHelper.java
@@ -164,7 +164,7 @@ public final class SeekableByteChannelHelper {
             }
             return bytesRead;
         } else {
-            final byte[] internalBuff = new byte[byteBuffer.remaining()];
+            final byte[] internalBuff = new byte[bytesToRead];
             final int bytesRead = inputStream.read(internalBuff);
             if (bytesRead > 0) {
                 byteBuffer.put(internalBuff, 0, bytesRead);

--- a/src/main/java/emissary/core/channels/SeekableByteChannelHelper.java
+++ b/src/main/java/emissary/core/channels/SeekableByteChannelHelper.java
@@ -145,11 +145,9 @@ public final class SeekableByteChannelHelper {
      * @param inputStream to read from
      * @param byteBuffer to read into
      * @param bytesToSkip within the {@code is} to get to the next read location
-     * @param maxBytesToRead to limit the amount of data returned from the inputStream
      * @throws IOException if an error occurs
      */
-    public static int getFromInputStream(final InputStream inputStream, final ByteBuffer byteBuffer, final long bytesToSkip,
-            final int maxBytesToRead) throws IOException {
+    public static int getFromInputStream(final InputStream inputStream, final ByteBuffer byteBuffer, final long bytesToSkip) throws IOException {
         Validate.notNull(inputStream, "Required: inputStream");
         Validate.notNull(byteBuffer, "Required: byteBuffer");
         Validate.isTrue(bytesToSkip > -1, "Required: bytesToSkip > -1");
@@ -158,7 +156,7 @@ public final class SeekableByteChannelHelper {
         IOUtils.skipFully(inputStream, bytesToSkip);
 
         // Read direct into buffer's array if possible, otherwise copy through an internal buffer
-        final int bytesToRead = Math.min(maxBytesToRead, byteBuffer.remaining());
+        final int bytesToRead = byteBuffer.remaining();
         if (byteBuffer.hasArray()) {
             final int bytesRead = inputStream.read(byteBuffer.array(), byteBuffer.position(), bytesToRead);
             if (bytesRead > 0) {
@@ -166,7 +164,7 @@ public final class SeekableByteChannelHelper {
             }
             return bytesRead;
         } else {
-            final byte[] internalBuff = new byte[bytesToRead];
+            final byte[] internalBuff = new byte[byteBuffer.remaining()];
             final int bytesRead = inputStream.read(internalBuff);
             if (bytesRead > 0) {
                 byteBuffer.put(internalBuff, 0, bytesRead);

--- a/src/test/java/emissary/core/IBaseDataObjectDiffHelperTest.java
+++ b/src/test/java/emissary/core/IBaseDataObjectDiffHelperTest.java
@@ -113,7 +113,7 @@ class IBaseDataObjectDiffHelperTest {
                     }
 
                     @Override
-                    protected int readImpl(ByteBuffer byteBuffer, int maxBytesToRead) throws IOException {
+                    protected int readImpl(final ByteBuffer byteBuffer) throws IOException {
                         throw new IOException("Test SBC that always throws IOException!");
                     }
 

--- a/src/test/java/emissary/core/channels/AbstractSeekableByteChannelTest.java
+++ b/src/test/java/emissary/core/channels/AbstractSeekableByteChannelTest.java
@@ -30,10 +30,11 @@ class AbstractSeekableByteChannelTest {
         protected void closeImpl() throws IOException {}
 
         @Override
-        protected int readImpl(final ByteBuffer byteBuffer, final int maxBytesToRead) throws IOException {
-            byteBuffer.position(byteBuffer.capacity());
+        protected int readImpl(final ByteBuffer byteBuffer) throws IOException {
+            final int remaining = byteBuffer.remaining();
+            byteBuffer.position(byteBuffer.limit());
 
-            return maxBytesToRead;
+            return remaining;
         }
     }
 

--- a/src/test/java/emissary/core/channels/SeekableByteChannelHelperTest.java
+++ b/src/test/java/emissary/core/channels/SeekableByteChannelHelperTest.java
@@ -100,26 +100,26 @@ class SeekableByteChannelHelperTest {
     void testGetFromInputStreamWithArrayByteBuffer() throws IOException {
         final ByteBuffer buff = ByteBuffer.allocate(4);
         assertTrue(buff.hasArray());
-        assertEquals(4, SeekableByteChannelHelper.getFromInputStream(IS, buff, 0, 4));
+        assertEquals(4, SeekableByteChannelHelper.getFromInputStream(IS, buff, 0));
 
         assertEquals(-1, SeekableByteChannelHelper.getFromInputStream(
-                new ByteArrayInputStream(new byte[0]), ByteBuffer.allocate(1), 0, 4));
+                new ByteArrayInputStream(new byte[0]), ByteBuffer.allocate(1), 0));
     }
 
     @Test
     void testGetFromInputStreamWithDirectByteBuffer() throws IOException {
         final ByteBuffer buff = ByteBuffer.allocateDirect(4);
         assertFalse(buff.hasArray());
-        assertEquals(4, SeekableByteChannelHelper.getFromInputStream(IS, buff, 0, 4));
+        assertEquals(4, SeekableByteChannelHelper.getFromInputStream(IS, buff, 0));
 
         assertEquals(-1, SeekableByteChannelHelper.getFromInputStream(
-                new ByteArrayInputStream(new byte[0]), ByteBuffer.allocateDirect(1), 0, 4));
+                new ByteArrayInputStream(new byte[0]), ByteBuffer.allocateDirect(1), 0));
     }
 
     @Test
     void testGetFromInputStreamWithInvalidOffset() {
         final ByteBuffer buff = ByteBuffer.allocate(1);
-        assertThrows(IllegalArgumentException.class, () -> SeekableByteChannelHelper.getFromInputStream(IS, buff, -2, 4));
+        assertThrows(IllegalArgumentException.class, () -> SeekableByteChannelHelper.getFromInputStream(IS, buff, -2));
     }
 
     private static class ExceptionInputStream extends InputStream {


### PR DESCRIPTION
This builds on #393 by also right-sizing the provided byteBuffer to avoid reading more than we should, and abstracting this away from implementations. Now, the provided byteBuffer to implement against will have the right amount of remaining bytes to read into based on its position and capacity.

This PR is blocked until #393 is merged.