### PR TITLE
Fix builds with more recent versions of Maven, incl GitHub actions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <dep.guava.version>31.1-jre</dep.guava.version>
     <dep.httpclient.version>4.5.13</dep.httpclient.version>
     <dep.httpcore.version>4.4.15</dep.httpcore.version>
+    <dep.impsort.version>1.6.2</dep.impsort.version>
     <dep.jackson.version>2.13.4</dep.jackson.version>
     <!-- jersey and tika provide; converge on latest -->
     <dep.jakarta.xml.bind-api.version>2.3.3</dep.jakarta.xml.bind-api.version>
@@ -681,11 +682,19 @@
         <plugin>
           <groupId>net.revelc.code</groupId>
           <artifactId>impsort-maven-plugin</artifactId>
-          <version>1.6.2</version>
+          <version>${dep.impsort.version}</version>
           <configuration>
             <groups>java.,javax.,*</groups>
             <removeUnused>true</removeUnused>
           </configuration>
+          <!-- Remove dependencies block once impsort upgraded to 1.8.0 -->
+          <dependencies>
+            <dependency>
+              <groupId>org.codehaus.plexus</groupId>
+              <artifactId>plexus-utils</artifactId>
+              <version>3.5.1</version>
+            </dependency>
+          </dependencies>
           <executions>
             <execution>
               <id>sort-java-imports</id>
@@ -1382,7 +1391,7 @@
             <!-- Sort java imports -->
             <groupId>net.revelc.code</groupId>
             <artifactId>impsort-maven-plugin</artifactId>
-            <version>1.6.2</version>
+            <version>${dep.impsort.version}</version>
             <!--TODO update to latest once we move past JDK11 -->
             <configuration>
               <groups>emissary,*,java</groups>


### PR DESCRIPTION
I noticed GitHub actions were failing even on Java 8 builds with impsort related errors, looks like it's using a more recent version of Maven (3.9.0 I believe is where they remove the transparent dependency on plexus-utils).

[impsort 1.8.0](https://github.com/revelc/impsort-maven-plugin/pull/65) fixes the issue but requires JDK 11 which we're not ready to go to yet. This PR fixes the issue by explicitly requiring plexus-utils just for this plugin.

I've verified this locally with a Maven 4 alpha and JDK8, and the automatic build should verify this too.