### PR TITLE
Deprecate TikaFilePlace

### DIFF
--- a/src/main/java/emissary/id/TikaFilePlace.java
+++ b/src/main/java/emissary/id/TikaFilePlace.java
@@ -22,8 +22,10 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Perform file identification tests using the configured TIKA_SIGNATURE_FILE to drive the identification process
+ * @deprecated Perform file identification tests using the configured TIKA_SIGNATURE_FILE to drive the identification
+ *             process
  */
+@Deprecated
 public class TikaFilePlace extends emissary.id.IdPlace {
     private static final String DEFAULT_TIKA_SIGNATURE_FILE = "TikaMagic.xml";
     private static final String APPLICATION = "application";

--- a/src/test/java/emissary/id/TikaFilePlaceTest.java
+++ b/src/test/java/emissary/id/TikaFilePlaceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.io.IOException;
 import java.util.stream.Stream;
 
+@Deprecated
 class TikaFilePlaceTest extends IdentificationTest {
 
     public static Stream<? extends Arguments> data() {


### PR DESCRIPTION
Marks TikaFilePlas as deprecated. TikaFilePlace will be deleted in the Tika/POI update ticket, allowing tika to be removed as an emissary dependency.