### PR TITLE
Built out command to list Emissary Directories

### DIFF
--- a/src/main/java/emissary/Emissary.java
+++ b/src/main/java/emissary/Emissary.java
@@ -3,6 +3,7 @@ package emissary;
 import emissary.command.AgentsCommand;
 import emissary.command.Banner;
 import emissary.command.ConfigCommand;
+import emissary.command.DirectoryCommand;
 import emissary.command.EmissaryCommand;
 import emissary.command.EnvCommand;
 import emissary.command.FeedCommand;
@@ -56,7 +57,7 @@ public class Emissary {
         List<Class<? extends EmissaryCommand>> cmds =
                 Arrays.asList(ServerCommand.class, HelpCommand.class, WhatCommand.class, TopologyCommand.class, FeedCommand.class,
                         AgentsCommand.class, PoolCommand.class, VersionCommand.class, RunCommand.class, EnvCommand.class, StopCommand.class,
-                        PeersCommand.class, ConfigCommand.class);
+                        PeersCommand.class, ConfigCommand.class, DirectoryCommand.class);
         Map<String, EmissaryCommand> staticCopy = new HashMap<>();
         for (Class<? extends EmissaryCommand> clz : cmds) {
             EmissaryCommand cmd;

--- a/src/main/java/emissary/client/response/Directory.java
+++ b/src/main/java/emissary/client/response/Directory.java
@@ -15,8 +15,6 @@ public class Directory implements Comparable<Directory>, Serializable {
 
     private static final long serialVersionUID = 2428511052308449193L;
 
-    public static final long NOW = System.currentTimeMillis();
-
     private DirectoryEntry directoryEntry;
 
     @XmlElement(name = "entry")

--- a/src/main/java/emissary/client/response/Directory.java
+++ b/src/main/java/emissary/client/response/Directory.java
@@ -1,0 +1,64 @@
+package emissary.client.response;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.io.Serializable;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+@XmlAccessorType(XmlAccessType.NONE)
+public class Directory implements Comparable<Directory>, Serializable {
+
+    private static final long serialVersionUID = 2428511052308449193L;
+
+    @XmlElement(name = "dataId")
+    private String dataId;
+
+    @XmlElement(name = "entry")
+    private String entry;
+
+    public Directory() {}
+
+    public Directory(String dataId, String entry) {
+        this.dataId = dataId;
+        this.entry = entry;
+    }
+
+    public String getDataId() {
+        return dataId;
+    }
+
+    public void setDataId(String dataId) {
+        this.dataId = dataId;
+    }
+
+    public String getEntry() {
+        return entry;
+    }
+
+    public void setEntry(String entry) {
+        this.entry = entry;
+    }
+
+    @Override
+    public int compareTo(Directory o) {
+        return getEntry().compareTo(o.getEntry());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return getEntry();
+    }
+}

--- a/src/main/java/emissary/client/response/Directory.java
+++ b/src/main/java/emissary/client/response/Directory.java
@@ -1,5 +1,7 @@
 package emissary.client.response;
 
+import emissary.directory.DirectoryEntry;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -13,16 +15,57 @@ public class Directory implements Comparable<Directory>, Serializable {
 
     private static final long serialVersionUID = 2428511052308449193L;
 
-    @XmlElement(name = "dataId")
-    private String dataId;
+    public static final long NOW = System.currentTimeMillis();
+
+    private DirectoryEntry directoryEntry;
 
     @XmlElement(name = "entry")
     private String entry;
 
+    @XmlElement(name = "dataId")
+    private String dataId;
+
+    @XmlElement(name = "cost")
+    private int cost;
+
+    @XmlElement(name = "quality")
+    private int quality;
+
+    @XmlElement(name = "expense")
+    private int expense;
+
+    @XmlElement(name = "pathWeight")
+    private int pathWeight;
+
     public Directory() {}
 
-    public Directory(String dataId, String entry) {
-        this.dataId = dataId;
+    public Directory(DirectoryEntry directoryEntry) {
+        this.directoryEntry = directoryEntry;
+        setUpEntryInfo();
+    }
+
+    private void setUpEntryInfo() {
+        entry = directoryEntry.getKey();
+        dataId = directoryEntry.getDataID();
+        cost = directoryEntry.getCost();
+        quality = directoryEntry.getQuality();
+        expense = directoryEntry.getExpense();
+        pathWeight = directoryEntry.getPathWeight();
+    }
+
+    public DirectoryEntry getDirectoryEntry() {
+        return directoryEntry;
+    }
+
+    public void setDirectoryEntry(DirectoryEntry directoryEntry) {
+        this.directoryEntry = directoryEntry;
+    }
+
+    public String getEntry() {
+        return entry;
+    }
+
+    public void setEntry(String entry) {
         this.entry = entry;
     }
 
@@ -34,12 +77,36 @@ public class Directory implements Comparable<Directory>, Serializable {
         this.dataId = dataId;
     }
 
-    public String getEntry() {
-        return entry;
+    public int getCost() {
+        return cost;
     }
 
-    public void setEntry(String entry) {
-        this.entry = entry;
+    public void setCost(int cost) {
+        this.cost = cost;
+    }
+
+    public int getQuality() {
+        return quality;
+    }
+
+    public void setQuality(int quality) {
+        this.quality = quality;
+    }
+
+    public int getExpense() {
+        return expense;
+    }
+
+    public void setExpense(int expense) {
+        this.expense = expense;
+    }
+
+    public int getPathWeight() {
+        return pathWeight;
+    }
+
+    public void setPathWeight(int pathWeight) {
+        this.pathWeight = pathWeight;
     }
 
     @Override

--- a/src/main/java/emissary/client/response/DirectoryList.java
+++ b/src/main/java/emissary/client/response/DirectoryList.java
@@ -58,7 +58,7 @@ public class DirectoryList implements Serializable {
             sb.append("DirectoryPlace: ").append("\n");
             sb.append("  ").append(getDirectoryPlace()).append("\n").append("Entries: ");
             for (Directory entry : getEntries()) {
-                sb.append("\n  ").append(entry);
+                sb.append("\n  ").append(entry).append("$").append(entry.getExpense());
             }
             logger.info("{}", sb);
         }

--- a/src/main/java/emissary/client/response/DirectoryList.java
+++ b/src/main/java/emissary/client/response/DirectoryList.java
@@ -1,0 +1,66 @@
+package emissary.client.response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+
+@XmlAccessorType(XmlAccessType.NONE)
+public class DirectoryList implements Serializable {
+    private static final long serialVersionUID = -6660679929326876133L;
+
+    private static final Logger logger = LoggerFactory.getLogger(DirectoryList.class);
+
+    @XmlElement(name = "directoryPlace")
+    private String directoryPlace;
+
+    @XmlElement(name = "entries")
+    private SortedSet<Directory> entries;
+
+    public DirectoryList() {
+        entries = new TreeSet<>();
+    }
+
+    public DirectoryList(String directoryPlace, SortedSet<Directory> entries) {
+        this.directoryPlace = directoryPlace;
+        this.entries = entries;
+    }
+
+    public String getDirectoryPlace() {
+        return directoryPlace;
+    }
+
+    public void setDirectoryPlace(String directoryPlace) {
+        this.directoryPlace = directoryPlace;
+    }
+
+    public Set<Directory> getEntries() {
+        return entries;
+    }
+
+    public void setEntries(SortedSet<Directory> entries) {
+        this.entries = entries;
+    }
+
+    public void addEntries(Directory entry) {
+        this.entries.add(entry);
+    }
+
+    public void dumpToConsole() {
+        if (getDirectoryPlace() != null) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("DirectoryPlace: ").append("\n");
+            sb.append("  ").append(getDirectoryPlace()).append("\n").append("Entries: ");
+            for (Directory entry : getEntries()) {
+                sb.append("\n  ").append(entry);
+            }
+            logger.info("{}", sb);
+        }
+    }
+}

--- a/src/main/java/emissary/client/response/DirectoryResponseEntity.java
+++ b/src/main/java/emissary/client/response/DirectoryResponseEntity.java
@@ -1,0 +1,49 @@
+package emissary.client.response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "directories")
+@XmlAccessorType(XmlAccessType.NONE)
+public class DirectoryResponseEntity extends BaseResponseEntity {
+    private static final long serialVersionUID = 5686691885767273319L;
+
+    private static final Logger logger = LoggerFactory.getLogger(DirectoryResponseEntity.class);
+
+    @XmlElement(name = "local")
+    private DirectoryList local = new DirectoryList();
+
+    public DirectoryResponseEntity() {}
+
+    public DirectoryResponseEntity(DirectoryList local) {
+        this.local = local;
+    }
+
+    public DirectoryList getLocal() {
+        return local;
+    }
+
+    public void getLocal(DirectoryList local) {
+        this.local = local;
+    }
+
+    public void setLocal(DirectoryList local) {
+        this.local = local;
+    }
+
+    @Override
+    public void append(BaseEntity e) {
+        addErrors(e.getErrors());
+    }
+
+    @Override
+    public void dumpToConsole() {
+        getLocal().dumpToConsole();
+        logger.info("");
+    }
+}

--- a/src/main/java/emissary/command/DirectoryCommand.java
+++ b/src/main/java/emissary/command/DirectoryCommand.java
@@ -1,0 +1,36 @@
+package emissary.command;
+
+import emissary.client.EmissaryClient;
+import emissary.client.response.DirectoryResponseEntity;
+
+import com.beust.jcommander.Parameters;
+import org.apache.http.client.methods.HttpGet;
+
+import static emissary.server.api.Directories.DIRECTORIES_ENDPOINT;
+
+@Parameters(commandDescription = "List all of the active directories")
+public class DirectoryCommand extends MonitorCommand<DirectoryResponseEntity> {
+
+    public static String COMMAND_NAME = "directory";
+    public static final int DEFAULT_PORT = 8001;
+
+    @Override
+    public int getDefaultPort() {
+        return DEFAULT_PORT;
+    }
+
+    @Override
+    public String getCommandName() {
+        return COMMAND_NAME;
+    }
+
+    @Override
+    public DirectoryResponseEntity sendRequest(EmissaryClient client, String endpoint) {
+        return client.send(new HttpGet(endpoint)).getContent(DirectoryResponseEntity.class);
+    }
+
+    @Override
+    public String getTargetEndpoint() {
+        return DIRECTORIES_ENDPOINT;
+    }
+}

--- a/src/main/java/emissary/command/DirectoryCommand.java
+++ b/src/main/java/emissary/command/DirectoryCommand.java
@@ -11,7 +11,7 @@ import static emissary.server.api.Directories.DIRECTORIES_ENDPOINT;
 @Parameters(commandDescription = "List all of the active directories")
 public class DirectoryCommand extends MonitorCommand<DirectoryResponseEntity> {
 
-    public static String COMMAND_NAME = "directory";
+    public static final String COMMAND_NAME = "directory";
     public static final int DEFAULT_PORT = 8001;
 
     @Override

--- a/src/main/java/emissary/server/api/Directories.java
+++ b/src/main/java/emissary/server/api/Directories.java
@@ -1,0 +1,55 @@
+package emissary.server.api;
+
+import emissary.client.response.Directory;
+import emissary.client.response.DirectoryList;
+import emissary.client.response.DirectoryResponseEntity;
+import emissary.core.EmissaryException;
+import emissary.directory.DirectoryEntry;
+import emissary.directory.DirectoryPlace;
+import emissary.directory.IDirectoryPlace;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("")
+public class Directories {
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    public static final String DIRECTORIES_ENDPOINT = "api/directories";
+
+    @GET
+    @Path("/directories")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response directories() {
+        return Response.ok().entity(getDir()).build();
+    }
+
+    protected DirectoryResponseEntity getDir() {
+        DirectoryResponseEntity entity = new DirectoryResponseEntity();
+        try {
+            IDirectoryPlace dirPlace = DirectoryPlace.lookup();
+            DirectoryList entries = new DirectoryList();
+            entries.setDirectoryPlace(dirPlace.getKey());
+            List<DirectoryEntry> dirEntries = dirPlace.getEntries();
+
+            for (DirectoryEntry currentDir : dirEntries) {
+                entries.addEntries(new Directory(currentDir.getDataID(), currentDir.getKey()));
+            }
+
+            entity.setLocal(entries);
+            logger.debug("Returning Directory Entries: {}", entity.getLocal());
+        } catch (EmissaryException e) {
+            logger.error("Problem finding the directory in the namespace,", e);
+            entity.addError("Problem finding the directory in the namespace: " + e.getMessage());
+        }
+        return entity;
+    }
+
+}

--- a/src/main/java/emissary/server/api/Directories.java
+++ b/src/main/java/emissary/server/api/Directories.java
@@ -40,7 +40,7 @@ public class Directories {
             List<DirectoryEntry> dirEntries = dirPlace.getEntries();
 
             for (DirectoryEntry currentDir : dirEntries) {
-                entries.addEntries(new Directory(currentDir.getDataID(), currentDir.getKey()));
+                entries.addEntries(new Directory(currentDir));
             }
 
             entity.setLocal(entries);

--- a/src/test/java/emissary/server/api/EmissaryApiTest.java
+++ b/src/test/java/emissary/server/api/EmissaryApiTest.java
@@ -40,7 +40,11 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import javax.ws.rs.core.Response;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;


### PR DESCRIPTION
Built out a command to list all active Emissary directories entryKeys.
Also built out `api/directories`, creating a JSON object of Directory entry information.
Updated EmissaryApiTest for testing of directories api.