### PR TITLE
Remove 'overrideConfigCompilerVersion' from formatter configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -715,7 +715,6 @@
             <compilerTargetPlatform>${maven.compiler.target}</compilerTargetPlatform>
             <configFile>${eclipseFormatterStyle}</configFile>
             <lineEnding>LF</lineEnding>
-            <overrideConfigCompilerVersion>true</overrideConfigCompilerVersion>
             <skipCssFormatting>true</skipCssFormatting>
             <skipHtmlFormatting>true</skipHtmlFormatting>
             <skipJsFormatting>true</skipJsFormatting>


### PR DESCRIPTION
Removes the following warnings from the build:
```
[WARNING] Parameter 'overrideConfigCompilerVersion' is unknown for plugin 'formatter-maven-plugin:2.11.0:format (format-java-sources)'
[WARNING] Parameter 'overrideConfigCompilerVersion' is unknown for plugin 'formatter-maven-plugin:2.11.0:format (format-java-test-sources)'
[WARNING] Parameter 'overrideConfigCompilerVersion' is unknown for plugin 'formatter-maven-plugin:2.11.0:format (format-java-sources)'
[WARNING] Parameter 'overrideConfigCompilerVersion' is unknown for plugin 'formatter-maven-plugin:2.11.0:format (format-java-sources)'
```

I went back trying to find what version removed the parameter but can't find it. It was added as a parameter in plugin version 0.1.0: https://github.com/revelc/formatter-maven-plugin/blob/main/CHANGELOG.md#ver-010-2010-07-07

