### PR TITLE
exclude javax.servlet-api and rely on jakarta.servlet-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <dep.impsort.version>1.6.2</dep.impsort.version>
     <dep.jackson.version>2.13.4</dep.jackson.version>
     <dep.jakarta.activation-api.version>1.2.2</dep.jakarta.activation-api.version>
+    <dep.jakarta.servlet-api.version>4.0.3</dep.jakarta.servlet-api.version>
     <dep.jakarta.xml.bind-api.version>2.3.3</dep.jakarta.xml.bind-api.version>
     <dep.javax.annotation-api.version>1.3.2</dep.javax.annotation-api.version>
     <dep.jcommander.version>1.58</dep.jcommander.version>
@@ -178,6 +179,11 @@
         <version>${dep.jakarta.activation-api.version}</version>
       </dependency>
       <dependency>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>${dep.jakarta.servlet-api.version}</version>
+      </dependency>
+      <dependency>
         <groupId>jakarta.xml.bind</groupId>
         <artifactId>jakarta.xml.bind-api</artifactId>
         <version>${dep.jakarta.xml.bind-api.version}</version>
@@ -241,6 +247,12 @@
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
         <version>${dep.jetty.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
@@ -469,6 +481,10 @@
     <dependency>
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>net.logstash.logback</groupId>


### PR DESCRIPTION
manifested in the build as:
```
[WARNING] Javadoc Warnings
[WARNING] javadoc: warning - Multiple sources of package comments found for package "javax.servlet"
[WARNING] javadoc: warning - Multiple sources of package comments found for package "javax.servlet.http"
```
and using the new feature for  `mvn duplicate-finder:check` these packages conflicted in their resources between javax and jakarta.

The only conflict left is the RollManager.cfg