### PR TITLE
fix DateTimeFormatParser unchecked conversion build warning

### DIFF
--- a/src/main/java/emissary/util/DateTimeFormatParser.java
+++ b/src/main/java/emissary/util/DateTimeFormatParser.java
@@ -122,7 +122,7 @@ public class DateTimeFormatParser {
         if (StringUtils.isNotEmpty(dateString)) {
             String cleanedDateString = cleanDate(dateString);
 
-            List<Function<String, LocalDateTime>> methodList = new ArrayList();
+            List<Function<String, LocalDateTime>> methodList = new ArrayList<>();
             methodList.add(date -> tryParseWithDateTimeZoneFormats(date));
             methodList.add(date -> tryParseWithDateTimeOffsetFormats(date));
             methodList.add(date -> tryParseWithDateTimeFormats(date));


### PR DESCRIPTION
```
[WARNING] emissary/src/main/java/emissary/util/DateTimeFormatParser.java:[125,64] unchecked conversion
  required: java.util.List<java.util.function.Function<java.lang.String,java.time.LocalDateTime>>
  found:    java.util.ArrayList
  ```