### PR TITLE
475 updated unit test to not fail in docker

### DIFF
--- a/src/test/java/emissary/spi/ClassLocationVerificationProviderTest.java
+++ b/src/test/java/emissary/spi/ClassLocationVerificationProviderTest.java
@@ -11,7 +11,7 @@ class ClassLocationVerificationProviderTest extends UnitTest {
     @Test
     void testVerifyClassInWorkingDirectory() {
         String emissaryClassName = Emissary.class.getName();
-        boolean status = ClassLocationVerificationProvider.verify(emissaryClassName, "emissary");
+        boolean status = ClassLocationVerificationProvider.verify(emissaryClassName, "/classes/");
         Assertions.assertTrue(status);
 
         status = ClassLocationVerificationProvider.verify(emissaryClassName, "doesnotexist");


### PR DESCRIPTION
When building emissary in a docker container, the classLocPath variable set in ClassLocationVerificationProvider is set as /app/target/classes/ in the ClassLocationVerificationProvider unit tests. This breaks the testVerifyClassInWorkingDirectory unit test, as the unit test is written such that it expects that location path to have "emissary" as a substring. Re-write the tests to make sure that it works in both docker and non-docker builds.