### PR TITLE
exclude helm repo from super lint

### DIFF
--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -37,3 +37,4 @@ jobs:
           # VALIDATE_MARKDOWN: true
           VALIDATE_XML: true
           VALIDATE_YAML: true
+          FILTER_REGEX_EXCLUDE: .*contrib/helm.*


### PR DESCRIPTION
The helm templates are set up correctly but the super linter action does not view it as valid yaml. So excluding that directory for now. They have an outstanding feature request to add helm linting in a follow on version