### PR TITLE
Create logging PrintStream for StdOut/StdErr.

### DIFF
--- a/src/main/java/emissary/Emissary.java
+++ b/src/main/java/emissary/Emissary.java
@@ -17,6 +17,7 @@ import emissary.command.TopologyCommand;
 import emissary.command.VersionCommand;
 import emissary.command.WhatCommand;
 import emissary.util.GitRepositoryState;
+import emissary.util.io.LoggingPrintStream;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
@@ -29,13 +30,13 @@ import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -202,22 +203,9 @@ public class Emissary {
         // no need for sysout-over-slf4j anymore, which as need for any calls, like jni, which only
         // output to stdout/stderr Last none logback message
         LOG.trace("Redefining stdout so logback and capture the output");
-        System.setOut(new PrintStream(System.out) {
-            @Override
-            public void print(String s) {
-                LOG.info(s);
-            }
-        });
+        System.setOut(new LoggingPrintStream(System.out, "STDOUT", LOG, org.slf4j.event.Level.INFO, 30, TimeUnit.SECONDS));
 
         LOG.trace("Redefining stderr so logback and capture the output");
-        System.setErr(new PrintStream(System.err) {
-
-            @Override
-            public void print(String s) {
-                LOG.error(s);
-            }
-        });
+        System.setErr(new LoggingPrintStream(System.err, "STDERR", LOG, org.slf4j.event.Level.ERROR, 30, TimeUnit.SECONDS));
     }
-
-
 }

--- a/src/main/java/emissary/util/io/LoggingPrintStream.java
+++ b/src/main/java/emissary/util/io/LoggingPrintStream.java
@@ -1,0 +1,215 @@
+package emissary.util.io;
+
+import org.apache.commons.lang3.Validate;
+import org.slf4j.Logger;
+import org.slf4j.MDC;
+import org.slf4j.event.Level;
+
+import java.io.IOException;
+import java.io.LineNumberReader;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This class is designed to be put in place of StdOut and StdErr in order to log anything that is sent there.
+ */
+public class LoggingPrintStream extends PrintStream {
+    /**
+     * The prefix used for "throwable" messages.
+     */
+    public static final String THROWABLE_PREFIX = "Exception on ";
+    /**
+     * The string used to separate the stream name from the message for "normal" messages.
+     */
+    public static final String NORMAL_SEPARATOR = " : ";
+    /**
+     * The log string used to identify substitutions.
+     */
+    public static final String LOG_SUBSTITUTION = "{}";
+    /**
+     * The log format used for "throwable" messages.
+     */
+    public static final String THROWABLE_LOG_FORMAT = THROWABLE_PREFIX + LOG_SUBSTITUTION;
+    /**
+     * The log format used for "normal" messages.
+     */
+    public static final String NORMAL_LOG_FORMAT = LOG_SUBSTITUTION + NORMAL_SEPARATOR + LOG_SUBSTITUTION;
+    /**
+     * The name of the stream to be added to the log message.
+     */
+    private final String streamName;
+    /**
+     * The logger to be used for logging messages.
+     */
+    private final Logger logger;
+    /**
+     * The logging level to be used when logging messages.
+     */
+    private final Level level;
+    /**
+     * The time to wait for logging tasks to finish when closing.
+     */
+    private final long closeWaitTime;
+    /**
+     * The time unit to wait for logging tasks to finish when closing.
+     */
+    private final TimeUnit closeWaitTimeUnit;
+    /**
+     * Executor for executing logging statements.
+     */
+    private final ExecutorService executorService;
+    /**
+     * The number of lines to skip when a Throwable is received.
+     */
+    private int linesToSkip;
+
+    /**
+     * Constructs a custom PrintStream that logs anything it receives.
+     * 
+     * @param outputStream where the received data is to be written.
+     * @param streamName the name of the outputStream to be included in the log messages.
+     * @param logger that is to be used to log the messages.
+     * @param level the logging level to use for log statements.
+     * @param closeWaitTime the time to wait for logging tasks to finish when closing.
+     * @param closeWaitTimeUnit the time unit to use for the closeWaitTime.
+     */
+    public LoggingPrintStream(final OutputStream outputStream, final String streamName, final Logger logger, final Level level,
+            final long closeWaitTime, final TimeUnit closeWaitTimeUnit) {
+        super(outputStream);
+
+        Validate.notNull(streamName, "Required: streamName not null");
+        Validate.notNull(logger, "Required: logger not null");
+        Validate.notNull(level, "Required: level not null");
+        Validate.isTrue(closeWaitTime >= 0, "Required: closeWaitTime >= 0");
+        Validate.notNull(closeWaitTimeUnit, "Required: closeWaitTimeUnit not null");
+
+        this.streamName = streamName;
+        this.logger = logger;
+        this.level = level;
+        this.closeWaitTime = closeWaitTime;
+        this.closeWaitTimeUnit = closeWaitTimeUnit;
+        this.executorService = Executors.newSingleThreadExecutor(
+                runnable -> new Thread(runnable, "LoggingPrintStream_" + streamName));
+
+    }
+
+    /**
+     * Prints a string. If the argument is {@code null} then the string {@code "null"} is printed. Otherwise, the string's
+     * characters are converted into bytes according to the character encoding given to the constructor, or the platform's
+     * default character encoding if none specified. These bytes are written in exactly the manner of the
+     * {@link #write(int)} method.
+     *
+     * @param string The {@code String} to be printed
+     */
+    @Override
+    public void print(final String string) {
+        if (linesToSkip == 0) {
+            final Map<String, String> mdcContextMap = MDC.getCopyOfContextMap();
+
+            executorService.submit(() -> log(logger, mdcContextMap, level, NORMAL_LOG_FORMAT, streamName, string));
+        }
+
+        super.print(string);
+    }
+
+    /**
+     * Prints an Object and then terminate the line. This method calls at first String.valueOf(x) to get the printed
+     * object's string value, then behaves as though it invokes {@link #print(String)} and then {@link #println()}.
+     *
+     * @param object The {@code Object} to be printed.
+     */
+    @Override
+    public void println(final Object object) {
+        if (object instanceof Throwable) {
+            final Throwable throwable = (Throwable) object;
+
+            try (StringWriter stringWriter = new StringWriter();
+                    PrintWriter printWriter = new PrintWriter(stringWriter)) {
+                throwable.printStackTrace(printWriter);
+
+                final String throwableString = stringWriter.toString();
+
+                try (StringReader stringReader = new StringReader(throwableString);
+                        LineNumberReader lineNumberReader = new LineNumberReader(stringReader)) {
+                    lineNumberReader.skip(Long.MAX_VALUE);
+                    linesToSkip = lineNumberReader.getLineNumber();
+                }
+            } catch (IOException e) {
+                logger.error("This should never happen as the Readers/Writers are backed by Strings.");
+            }
+
+            final Map<String, String> mdcContextMap = MDC.getCopyOfContextMap();
+
+            executorService.submit(() -> log(logger, mdcContextMap, level, THROWABLE_LOG_FORMAT, streamName, throwable));
+        }
+
+        super.println(object);
+
+        if (linesToSkip > 0) {
+            linesToSkip--;
+        }
+    }
+
+    /**
+     * Closes the stream. This is done by flushing the stream and then closing the underlying output stream.
+     *
+     * @see java.io.OutputStream#close()
+     */
+    @Override
+    public void close() {
+        try {
+            if (!executorService.isShutdown()) {
+                executorService.shutdown();
+                executorService.awaitTermination(closeWaitTime, closeWaitTimeUnit);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        super.close();
+    }
+
+    /**
+     * Performs the actual logging of the message.
+     * 
+     * @param logger to use for logging the message.
+     * @param mdcContextMap to use for logging the message.
+     * @param level to use for logging the message.
+     * @param string the message.
+     * @param streamName the name of the stream.
+     * @param stringOrException the string or exception to log.
+     */
+    private static void log(final Logger logger, final Map<String, String> mdcContextMap, final Level level, final String string,
+            final String streamName, final Object stringOrException) {
+        if (mdcContextMap != null) {
+            MDC.setContextMap(mdcContextMap);
+        }
+
+        switch (level) {
+            case DEBUG:
+                logger.debug(string, streamName, stringOrException);
+                break;
+            case ERROR:
+                logger.error(string, streamName, stringOrException);
+                break;
+            case INFO:
+                logger.info(string, streamName, stringOrException);
+                break;
+            case TRACE:
+                logger.trace(string, streamName, stringOrException);
+                break;
+            case WARN:
+                logger.warn(string, streamName, stringOrException);
+                break;
+        }
+
+        MDC.clear();
+    }
+}

--- a/src/test/java/emissary/util/io/LoggingPrintStreamTest.java
+++ b/src/test/java/emissary/util/io/LoggingPrintStreamTest.java
@@ -1,0 +1,311 @@
+package emissary.util.io;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.read.ListAppender;
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.commons.lang3.Validate;
+import org.apache.log4j.MDC;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static emissary.util.io.LoggingPrintStream.NORMAL_SEPARATOR;
+import static emissary.util.io.LoggingPrintStream.THROWABLE_PREFIX;
+import static org.apache.commons.io.output.NullOutputStream.NULL_OUTPUT_STREAM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class LoggingPrintStreamTest {
+    private static final String LOG_MSG_1 = "Log message NUMBER 1";
+    private static final String LOG_MSG_2 = "Log message NUMBER 2";
+    private static final Object LOG_OBJ_1 = 1234567890;
+    private static final Exception EXCEPTION_CAUSE = new Exception("Test Exception 'cause'");
+    private static final Exception EXCEPTION_ONE = new Exception("Test Exception NUMBER 1", EXCEPTION_CAUSE);
+    private static final Exception EXCEPTION_TWO = new Exception("Test Exception NUMBER 2", EXCEPTION_CAUSE);
+
+    @Test
+    void testArguments() {
+        final Logger logger = (Logger) LoggerFactory.getLogger(LoggingPrintStream.class);
+        final org.slf4j.event.Level slf4jLevel = org.slf4j.event.Level.TRACE;
+
+        assertThrows(NullPointerException.class, () -> new LoggingPrintStream(null, "TEST", logger, slf4jLevel, 1, TimeUnit.SECONDS));
+        assertThrows(NullPointerException.class, () -> new LoggingPrintStream(NULL_OUTPUT_STREAM, null, logger, slf4jLevel, 1, TimeUnit.SECONDS));
+        assertThrows(NullPointerException.class, () -> new LoggingPrintStream(NULL_OUTPUT_STREAM, "TEST", null, slf4jLevel, 1, TimeUnit.SECONDS));
+        assertThrows(NullPointerException.class, () -> new LoggingPrintStream(NULL_OUTPUT_STREAM, "TEST", logger, null, 1, TimeUnit.SECONDS));
+        assertThrows(IllegalArgumentException.class,
+                () -> new LoggingPrintStream(NULL_OUTPUT_STREAM, "TEST", logger, slf4jLevel, -1, TimeUnit.SECONDS));
+        assertThrows(NullPointerException.class, () -> new LoggingPrintStream(NULL_OUTPUT_STREAM, "TEST", logger, slf4jLevel, 1, null));
+    }
+
+    @Test
+    void testClose() {
+        final Logger logger = (Logger) LoggerFactory.getLogger(LoggingPrintStream.class);
+        final org.slf4j.event.Level slf4jLevel = org.slf4j.event.Level.TRACE;
+
+        try (LoggingPrintStream loggingPrintStream = new LoggingPrintStream(NULL_OUTPUT_STREAM, "TEST", logger, slf4jLevel, 30, TimeUnit.SECONDS)) {
+            loggingPrintStream.close();
+
+            assertThrows(RejectedExecutionException.class, () -> loggingPrintStream.println(LOG_MSG_1));
+            assertThrows(RejectedExecutionException.class, () -> EXCEPTION_ONE.printStackTrace(loggingPrintStream));
+        }
+    }
+
+    @Test
+    void testLoggingLevel() throws Exception {
+        try (LogbackTester logbackTester = new LogbackTester(LoggingPrintStreamTest.class.getName());
+                LoggingPrintStream loggingPrintStreamDebug =
+                        new LoggingPrintStream(NULL_OUTPUT_STREAM, logbackTester.name + "_DEBUG", logbackTester.logger,
+                                org.slf4j.event.Level.DEBUG, 30, TimeUnit.SECONDS);
+                LoggingPrintStream loggingPrintStreamError =
+                        new LoggingPrintStream(NULL_OUTPUT_STREAM, logbackTester.name + "_ERROR", logbackTester.logger,
+                                org.slf4j.event.Level.ERROR, 30, TimeUnit.SECONDS);
+                LoggingPrintStream loggingPrintStreamInfo =
+                        new LoggingPrintStream(NULL_OUTPUT_STREAM, logbackTester.name + "_INFO", logbackTester.logger,
+                                org.slf4j.event.Level.INFO, 30, TimeUnit.SECONDS);
+                LoggingPrintStream loggingPrintStreamTrace =
+                        new LoggingPrintStream(NULL_OUTPUT_STREAM, logbackTester.name + "_TRACE", logbackTester.logger,
+                                org.slf4j.event.Level.TRACE, 30, TimeUnit.SECONDS);
+                LoggingPrintStream loggingPrintStreamWarn =
+                        new LoggingPrintStream(NULL_OUTPUT_STREAM, logbackTester.name + "_WARN", logbackTester.logger,
+                                org.slf4j.event.Level.WARN, 30, TimeUnit.SECONDS)) {
+            logbackTester.logger.setLevel(Level.ALL);
+
+            loggingPrintStreamDebug.print(LOG_MSG_1);
+            EXCEPTION_ONE.printStackTrace(loggingPrintStreamDebug);
+            loggingPrintStreamDebug.close();
+            loggingPrintStreamError.print(LOG_MSG_1);
+            EXCEPTION_ONE.printStackTrace(loggingPrintStreamError);
+            loggingPrintStreamError.close();
+            loggingPrintStreamInfo.print(LOG_MSG_1);
+            EXCEPTION_ONE.printStackTrace(loggingPrintStreamInfo);
+            loggingPrintStreamInfo.close();
+            loggingPrintStreamTrace.print(LOG_MSG_1);
+            EXCEPTION_ONE.printStackTrace(loggingPrintStreamTrace);
+            loggingPrintStreamTrace.close();
+            loggingPrintStreamWarn.print(LOG_MSG_1);
+            EXCEPTION_ONE.printStackTrace(loggingPrintStreamWarn);
+            loggingPrintStreamWarn.close();
+
+            final Level[] expectedLevels =
+                    {Level.DEBUG, Level.DEBUG, Level.ERROR, Level.ERROR, Level.INFO, Level.INFO, Level.TRACE, Level.TRACE, Level.WARN, Level.WARN};
+            final String[] expectedMessages =
+                    {logbackTester.name + "_DEBUG" + NORMAL_SEPARATOR + LOG_MSG_1,
+                            THROWABLE_PREFIX + logbackTester.name + "_DEBUG",
+                            logbackTester.name + "_ERROR" + NORMAL_SEPARATOR + LOG_MSG_1,
+                            THROWABLE_PREFIX + logbackTester.name + "_ERROR",
+                            logbackTester.name + "_INFO" + NORMAL_SEPARATOR + LOG_MSG_1,
+                            THROWABLE_PREFIX + logbackTester.name + "_INFO",
+                            logbackTester.name + "_TRACE" + NORMAL_SEPARATOR + LOG_MSG_1,
+                            THROWABLE_PREFIX + logbackTester.name + "_TRACE",
+                            logbackTester.name + "_WARN" + NORMAL_SEPARATOR + LOG_MSG_1,
+                            THROWABLE_PREFIX + logbackTester.name + "_WARN"};
+            final boolean[] expectedThrowables = {false, true, false, true, false, true, false, true, false, true};
+
+            logbackTester.checkLogList(expectedLevels, expectedMessages, expectedThrowables);
+        }
+    }
+
+    @Test
+    void testMdcContextMap() throws Exception {
+        final org.slf4j.event.Level slf4jLevel = org.slf4j.event.Level.INFO;
+        final Logger logger = (Logger) LoggerFactory.getLogger(LoggingPrintStreamTest.class.getName() + ".testMdcContextMap");
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                LoggingPrintStream loggingPrintStream =
+                        new LoggingPrintStream(NullOutputStream.NULL_OUTPUT_STREAM, "STDTEST", logger, slf4jLevel, 30, TimeUnit.SECONDS)) {
+            final ConsoleAppender<ILoggingEvent> consoleAppender = new ConsoleAppender<>();
+            final PatternLayoutEncoder patternLayoutEncoder = new PatternLayoutEncoder();
+
+            patternLayoutEncoder.setPattern("%5p %c - %X{MDC_KEY1} %X{MDC_KEY2} - %m%n");
+            patternLayoutEncoder.setContext(logger.getLoggerContext());
+            patternLayoutEncoder.start();
+
+            consoleAppender.setEncoder(patternLayoutEncoder);
+            consoleAppender.setContext(logger.getLoggerContext());
+            consoleAppender.start();
+            consoleAppender.setOutputStream(baos);
+
+            logger.addAppender(consoleAppender);
+            logger.setLevel(Level.INFO);
+            logger.setAdditive(false);
+
+            MDC.put("MDC_KEY1", "MDC_VALUE1");
+            MDC.put("MDC_KEY2", "MDC_VALUE2");
+
+            loggingPrintStream.println("MDC_TEST_MESSAGE");
+            loggingPrintStream.close();
+
+            logger.detachAndStopAllAppenders();
+
+            final String logMessage = baos.toString();
+
+            assertEquals(" INFO emissary.util.io.LoggingPrintStreamTest.testMdcContextMap - MDC_VALUE1 MDC_VALUE2 - STDTEST : MDC_TEST_MESSAGE\n",
+                    logMessage);
+        }
+    }
+
+    @Test
+    void testOutputStreamArgumentOne() throws Exception {
+        final org.slf4j.event.Level slf4jLevel = org.slf4j.event.Level.INFO;
+
+        try (LogbackTester logbackTester = new LogbackTester(LoggingPrintStreamTest.class.getName());
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                LoggingPrintStream loggingPrintStream =
+                        new LoggingPrintStream(baos, logbackTester.name, logbackTester.logger, slf4jLevel, 30, TimeUnit.SECONDS)) {
+            loggingPrintStream.println(LOG_MSG_1);
+            loggingPrintStream.close();
+
+            final String streamString = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+
+            assertEquals(LOG_MSG_1 + "\n", streamString, "OutputStream did not contain expected data");
+            logbackTester.checkLogList(new Level[] {Level.INFO}, new String[] {logbackTester.name + NORMAL_SEPARATOR + LOG_MSG_1},
+                    new boolean[] {false});
+        }
+    }
+
+    @Test
+    void testOutputStreamArgumentTwo() throws Exception {
+        final org.slf4j.event.Level slf4jLevel = org.slf4j.event.Level.INFO;
+
+        try (LogbackTester logbackTester = new LogbackTester(LoggingPrintStreamTest.class.getName());
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                LoggingPrintStream loggingPrintStream =
+                        new LoggingPrintStream(baos, logbackTester.name, logbackTester.logger, slf4jLevel, 30, TimeUnit.SECONDS);
+                StringWriter stringWriter = new StringWriter();
+                PrintWriter printWriter = new PrintWriter(stringWriter)) {
+            EXCEPTION_ONE.printStackTrace(loggingPrintStream);
+            EXCEPTION_ONE.printStackTrace(printWriter);
+            loggingPrintStream.close();
+
+            final String streamString = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+            final String expectedString = stringWriter.toString();
+
+            assertEquals(expectedString, streamString, "OutputStream did not contain expected data");
+            logbackTester.checkLogList(new Level[] {Level.INFO}, new String[] {THROWABLE_PREFIX + logbackTester.name}, new boolean[] {true});
+        }
+    }
+
+    @Test
+    void testSingleThread() throws Exception {
+        final org.slf4j.event.Level slf4jLevel = org.slf4j.event.Level.INFO;
+
+        try (LogbackTester logbackTester = new LogbackTester(LoggingPrintStreamTest.class.getName());
+                ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                PrintStream printStream = new PrintStream(byteArrayOutputStream);
+                LoggingPrintStream loggingPrintStream =
+                        new LoggingPrintStream(printStream, logbackTester.name, logbackTester.logger, slf4jLevel, 30, TimeUnit.SECONDS)) {
+            EXCEPTION_ONE.printStackTrace(loggingPrintStream);
+            loggingPrintStream.println(LOG_MSG_1);
+            EXCEPTION_TWO.printStackTrace(loggingPrintStream);
+            loggingPrintStream.println(LOG_OBJ_1);
+            loggingPrintStream.println(LOG_MSG_2);
+            loggingPrintStream.close();
+
+            final Level[] expectedLevels = {Level.INFO, Level.INFO, Level.INFO, Level.INFO, Level.INFO};
+            final String[] expectedMessages =
+                    {THROWABLE_PREFIX + logbackTester.name,
+                            logbackTester.name + NORMAL_SEPARATOR + LOG_MSG_1,
+                            THROWABLE_PREFIX + logbackTester.name,
+                            logbackTester.name + NORMAL_SEPARATOR + LOG_OBJ_1,
+                            logbackTester.name + NORMAL_SEPARATOR + LOG_MSG_2};
+            final boolean[] expectedThrowables = {true, false, true, false, false};
+
+            logbackTester.checkLogList(expectedLevels, expectedMessages, expectedThrowables);
+        }
+    }
+
+    @Test
+    void testMultiThread() throws Exception {
+        final org.slf4j.event.Level slf4jLevel = org.slf4j.event.Level.INFO;
+
+        try (LogbackTester logbackTester = new LogbackTester(LoggingPrintStreamTest.class.getName());
+                ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                PrintStream printStream = new PrintStream(byteArrayOutputStream);
+                LoggingPrintStream loggingPrintStream =
+                        new LoggingPrintStream(printStream, logbackTester.name, logbackTester.logger, slf4jLevel, 30, TimeUnit.SECONDS)) {
+            final int iterations = 25;
+            final int numberOfThreads = 5;
+
+            final ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+            for (int i = 0; i < numberOfThreads; i++) {
+                final String message = "Message from instance " + i;
+                final Exception exception = new Exception("Exception from instance " + i);
+
+                executorService.submit(() -> {
+                    for (int j = 0; j < iterations; j++) {
+                        loggingPrintStream.println(message);
+                        exception.printStackTrace(loggingPrintStream);
+                    }
+                });
+            }
+
+            executorService.shutdown();
+            executorService.awaitTermination(10, TimeUnit.SECONDS);
+
+            loggingPrintStream.close();
+
+            assertEquals(iterations * numberOfThreads * 2, logbackTester.appender.list.size(), "Wrong number of log messages!");
+        }
+    }
+
+    public static class LogbackTester implements Closeable {
+        private static final AtomicInteger INSTANCE = new AtomicInteger(0);
+
+        public final String name;
+        public final Logger logger;
+        public final ListAppender<ILoggingEvent> appender;
+
+        public LogbackTester(final String prefix) {
+            Validate.notNull(prefix, "Required: prefix != null");
+
+            name = prefix + "_" + INSTANCE.incrementAndGet();
+            logger = (Logger) LoggerFactory.getLogger(name);
+            appender = new ListAppender<>();
+
+            appender.setContext(logger.getLoggerContext());
+            appender.start();
+            logger.addAppender(appender);
+            logger.setAdditive(false);
+        }
+
+        public void checkLogList(final Level[] levels, final String[] messages, final boolean[] throwables) {
+            Validate.notNull(levels, "Required: levels != null");
+            Validate.notNull(messages, "Required: messages != null");
+            Validate.notNull(throwables, "Required: throwables != null");
+            Validate.isTrue(levels.length == messages.length, "Required: levels.length == messages.length");
+            Validate.isTrue(levels.length == throwables.length, "Required: levels.length == throwables.length");
+
+            assertEquals(levels.length, appender.list.size(), "Expected lengths do not match number of log messages");
+
+            for (int i = 0; i < appender.list.size(); i++) {
+                final ILoggingEvent item = appender.list.get(i);
+
+                assertEquals(levels[i], item.getLevel(), "Levels not equal for element " + i);
+                assertEquals(messages[i], item.getFormattedMessage(), "Messages not equal for element " + i);
+                assertEquals(throwables[i], item.getThrowableProxy() != null, "Throwables not equal for elmeent " + i);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            logger.detachAndStopAllAppenders();
+        }
+    }
+}


### PR DESCRIPTION
This PR creates a PrintStream with the following goals:
- Be able to use it for StdOut/StdErr.
- Allow only logging by allowing OutputStream to be null.
- Log Throwables as a single log message.