### PR TITLE
Only output version for version command and server startup

### DIFF
--- a/src/main/java/emissary/Emissary.java
+++ b/src/main/java/emissary/Emissary.java
@@ -110,7 +110,7 @@ public class Emissary {
             }
             EmissaryCommand cmd = commands.get(commandName);
             dumpBanner(cmd);
-            if (!Arrays.asList(args).contains(VersionCommand.COMMAND_NAME)) {
+            if (Arrays.asList(args).contains(ServerCommand.COMMAND_NAME)) {
                 dumpVersionInfo();
             }
             cmd.run(jc);


### PR DESCRIPTION
After some operational use, there is no need to have the version output at the execution of every command.
This change means the version is only output for the `version` command as one would expect and the `server` command since it has been useful to know what version is starting.