### PR TITLE
update to surefire 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <dep.junit.version>4.13.2</dep.junit.version>
     <dep.logback.version>1.2.11</dep.logback.version>
     <!-- seems to have an impact with java 11 integration, update with caution -->
-    <dep.maven-surefire-plugin.version>3.0.0-M3</dep.maven-surefire-plugin.version>
+    <dep.maven-surefire-plugin.version>3.1.0</dep.maven-surefire-plugin.version>
     <dep.mockito-junit.version>4.5.1</dep.mockito-junit.version>
     <dep.slf4j.version>1.7.36</dep.slf4j.version>
     <dep.spullara.mustache.compiler.version>0.9.10</dep.spullara.mustache.compiler.version>


### PR DESCRIPTION
This was just released. https://github.com/apache/maven-surefire/releases

Here is the junit diff from the update. This is on par with the M5 updates we've seen where the top level test appears to have "0 tests run" and the nested test counts for all of the annotated test methods (there are 6) as well as the answer file test.

```
< 7, Failures: 0, emissary.transform.HtmlEscapePlaceTest
---
> 0, Failures: 0, emissary.transform.HtmlEscapePlaceTest
> 7, Failures: 0, emissary.transform.HtmlEscapePlaceTest$HtmlEscapePlaceUnitTest
```