### PR TITLE
Add BUILD_TIMESTAMP property back in pom for version command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
   <ciManagement />
   <distributionManagement />
   <properties>
+    <BUILD_TIMESTAMP>${maven.build.timestamp}</BUILD_TIMESTAMP>
     <EMISSARY_VERSION>${project.version}</EMISSARY_VERSION>
     <argLine />
     <checkstyleFormatter>${project.basedir}/contrib/checkstyle.xml</checkstyleFormatter>


### PR DESCRIPTION
Fixes the build timestamp in version command:
```
sh emissary version
 ________  ________ _____ _____  ___  ________   __
|  ___|  \/  |_   _/  ___/  ___|/ _ \ | ___ \ \ / /
| |__ | .  . | | | \ `--.\ `--./ /_\ \| |_/ /\ V / 
|  __|| |\/| | | |  `--. \`--. \  _  ||    /  \ /  
| |___| |  | |_| |_/\__/ /\__/ / | | || |\ \  | |  
\____/\_|  |_/\___/\____/\____/\_| |_/\_| \_| \_/  

Emissary Version: 7.13.0 2023-05-08T23:40:32Z
```