### PR TITLE
remove isInUse check from HDMobileAgent toString()

### DIFF
--- a/src/main/java/emissary/core/HDMobileAgent.java
+++ b/src/main/java/emissary/core/HDMobileAgent.java
@@ -556,7 +556,7 @@ public class HDMobileAgent extends MobileAgent {
     public String toString() {
         if (isZombie()) {
             return "Closed";
-        } else if (!isInUse()) {
+        } else if (this.idle.get()) {
             return "Idle";
         }
 

--- a/src/main/java/emissary/core/MobileAgent.java
+++ b/src/main/java/emissary/core/MobileAgent.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
 /**
@@ -55,6 +56,9 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
 
     // What we carry around with us
     protected IBaseDataObject payload = null;
+
+    // Track if the MobileAgent is currently in use
+    protected AtomicBoolean idle = new AtomicBoolean(true);
 
     // Place we are at now
     protected transient IServiceProviderPlace arrivalPlace = null;
@@ -399,6 +403,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
         clear();
         setArrivalPlace(null);
         this.lastPlaceProcessed = null;
+        this.idle.set(true);
         AgentPool pool = null;
         try {
             pool = AgentPool.lookup();
@@ -696,6 +701,8 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
         if (dataObject != null && !(dataObject instanceof IBaseDataObject)) {
             throw new IllegalArgumentException("Illegal payload sent to MobileAgent, " + "cannot handle " + dataObject.getClass().getName());
         }
+
+        this.idle.set(false);
 
         setProcessFirstPlace(processAtFirstPlace);
 


### PR DESCRIPTION
This removes the `isInUse` method (which is synchronized) from the `toString` method of HDMobileAgent. They synchronization of this method was resulting in agent statuses containing 'null' as a lastPlaceVisisted value. This was seen after the addition of https://github.com/NationalSecurityAgency/emissary/commit/9cb7a9545ebd596a23f3b3ade5db663e7194f558.

Removing the call of any synchronized methods from `toString()` seems to be the right thing to do but we still need to maintain whether or not the agent is idle. Using an atomic boolean right when we start the `go()` call that persists until we return the agent to the pool should be comprehensive while the agent is "busy". The `isInUse()` check done today checks for empty `payloadList` and a null `arrivalPlace` which get cleared right before this new boolean in the `clear()` so if those combination of checks would have returned `false`, so would this one.

Since this only impacts `toString()`, it should only impact calls by the agents commands which use it.

Future work would be to migrate this to replace the `isInUse()` call.