### PR TITLE
add test for MobileAgent typeLookup and handle null Stage name

### DIFF
--- a/src/main/java/emissary/core/Stage.java
+++ b/src/main/java/emissary/core/Stage.java
@@ -60,7 +60,7 @@ enum Stage {
     public static Stage getByName(String name) {
         try {
             return Stage.valueOf(name);
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | NullPointerException e) {
             return null;
         }
     }

--- a/src/test/java/emissary/core/MobileAgentTest.java
+++ b/src/test/java/emissary/core/MobileAgentTest.java
@@ -40,6 +40,26 @@ class MobileAgentTest extends UnitTest {
         agent.recordHistory(place, d);
     }
 
+    @Test
+    void testTypeLookup() {
+        // invalid types
+        assertEquals(0, MobileAgent.typeLookup(null));
+        assertEquals(0, MobileAgent.typeLookup(""));
+        assertEquals(0, MobileAgent.typeLookup("UNDEFINED"));
+        assertEquals(0, MobileAgent.typeLookup("JUNK"));
+
+        // valid types
+        assertEquals(0, MobileAgent.typeLookup("STUDY"));
+        assertEquals(1, MobileAgent.typeLookup("ID"));
+        assertEquals(2, MobileAgent.typeLookup("COORDINATE"));
+        assertEquals(3, MobileAgent.typeLookup("PRETRANSFORM"));
+        assertEquals(4, MobileAgent.typeLookup("TRANSFORM"));
+        assertEquals(5, MobileAgent.typeLookup("POSTTRANSFORM"));
+        assertEquals(6, MobileAgent.typeLookup("ANALYZE"));
+        assertEquals(7, MobileAgent.typeLookup("VERIFY"));
+        assertEquals(8, MobileAgent.typeLookup("IO"));
+        assertEquals(9, MobileAgent.typeLookup("REVIEW"));
+    }
 
     @Test
     void testAddParrallelTrackingInfo() {

--- a/src/test/java/emissary/core/StageTest.java
+++ b/src/test/java/emissary/core/StageTest.java
@@ -41,6 +41,11 @@ class StageTest extends UnitTest {
     }
 
     @Test
+    void testGetByNameNull() {
+        assertNull(Stage.getByName(null));
+    }
+
+    @Test
     void testStageProgression() {
         List<Stage> list = Arrays.asList(Stage.values());
         Stage stage;


### PR DESCRIPTION
Adds a test for the MobileAgent method that interfaces with the Stage class to determine type values. 

During testing it was discovered that providing `Stage.getByName(null)` throws an NPE, so handle that scenario as well. 