### PR TITLE
Pass MDC entries down to Executrix child threads 

### DIFF
--- a/src/main/java/emissary/util/shell/Executrix.java
+++ b/src/main/java/emissary/util/shell/Executrix.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.io.BufferedOutputStream;
 import java.io.DataOutputStream;
@@ -829,6 +830,11 @@ public class Executrix {
                     stdErrThread = new ReadOutputBuffer(p.getErrorStream(), err, charset);
                 }
             }
+
+            // pass context to child threads so the info is available for any messages logged on those threads
+            stdOutThread.setContextMap(MDC.getCopyOfContextMap());
+            stdErrThread.setContextMap(MDC.getCopyOfContextMap());
+
             stdOutThread.start();
             stdErrThread.start();
             streamData(p, data);

--- a/src/main/java/emissary/util/shell/ProcessReader.java
+++ b/src/main/java/emissary/util/shell/ProcessReader.java
@@ -6,11 +6,51 @@
 
 package emissary.util.shell;
 
+import org.slf4j.MDC;
+
+import java.util.Map;
+
 /**
  *
  * @author ce
  * @version 1.0
  */
 public abstract class ProcessReader extends Thread {
+
+    private Map<String, String> contextMap;
+
     public abstract void finish();
+
+    /**
+     * Allows parent threads to pass state values retrieved through a call to {@link MDC#getCopyOfContextMap()}
+     * 
+     * @param contextMap Map of captured point-in-time state values
+     */
+    public void setContextMap(Map<String, String> contextMap) {
+        this.contextMap = contextMap;
+    }
+
+    /**
+     * Applies logger context to the current thread. This method should only be called from within the overridden
+     * {@link Thread#run()} method, since the context is backed by a {@link ThreadLocal ThreadLocal&lt;T&gt;} map.
+     */
+    protected final void applyLogContextMap() {
+        if (contextMap != null) {
+            MDC.setContextMap(contextMap);
+        }
+    }
+
+    /**
+     * Wrapper method to ensure that the {@link #applyLogContextMap()} method is always invoked before executing the core
+     * functionality of ProcessReader subclasses
+     */
+    public void run() {
+        applyLogContextMap();
+        runImpl();
+    }
+
+    /**
+     * Abstract method that subclasses should override to implement their core thread-specific functionality
+     */
+    abstract void runImpl();
 }

--- a/src/main/java/emissary/util/shell/ReadOutputBuffer.java
+++ b/src/main/java/emissary/util/shell/ReadOutputBuffer.java
@@ -99,7 +99,7 @@ public class ReadOutputBuffer extends ProcessReader {
     }
 
     @Override
-    public void run() {
+    void runImpl() {
         String aLine = "";
         this.finished = false;
         try {

--- a/src/main/java/emissary/util/shell/ReadOutputLogger.java
+++ b/src/main/java/emissary/util/shell/ReadOutputLogger.java
@@ -39,7 +39,7 @@ public class ReadOutputLogger extends ProcessReader {
     }
 
     @Override
-    public void run() {
+    void runImpl() {
         this.finished = false;
         try {
             String aLine;

--- a/src/test/java/emissary/util/shell/ProcessReaderTest.java
+++ b/src/test/java/emissary/util/shell/ProcessReaderTest.java
@@ -1,0 +1,131 @@
+package emissary.util.shell;
+
+import emissary.test.core.junit5.UnitTest;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.OutputStreamAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.io.ByteArrayOutputStream;
+
+import static emissary.log.MDCConstants.SERVICE_LOCATION;
+import static emissary.log.MDCConstants.SHORT_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ProcessReaderTest extends UnitTest {
+
+    static final String SOME_NAME = "some name";
+    static final String SOME_LOCATION = "some location";
+    static final String SOME_MESSAGE = "some message";
+    static final String NOT_SET = "[not set]";
+    static final String MSG_PATTERN = "SHORT_NAME: '%X{" + SHORT_NAME + "}' SERVICE_LOCATION: '%X{" + SERVICE_LOCATION + "}' - %m";
+    // pattern used to construct expected values using String.format(...)
+    static final String FORMAT_PATTERN = "SHORT_NAME: '%s' SERVICE_LOCATION: '%s' - %s";
+
+    static final Logger logger = (Logger) LoggerFactory.getLogger(DummyProcessReader.class);
+    OutputStreamAppender<ILoggingEvent> appender;
+    PatternLayoutEncoder encoder;
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        encoder = new PatternLayoutEncoder();
+        encoder.setPattern(MSG_PATTERN);
+        encoder.setContext(logger.getLoggerContext());
+        encoder.start();
+
+        appender = new OutputStreamAppender<>();
+        appender.setEncoder(encoder);
+        appender.setContext(logger.getLoggerContext());
+
+        logger.addAppender(appender);
+        logger.setLevel(Level.ALL);
+
+        MDC.put(SERVICE_LOCATION, SOME_LOCATION);
+        MDC.put(SHORT_NAME, SOME_NAME);
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        MDC.remove(SERVICE_LOCATION);
+        MDC.remove(SHORT_NAME);
+
+        if (encoder != null) {
+            encoder.stop();
+        }
+        if (appender != null) {
+            appender.stop();
+        }
+        logger.detachAndStopAllAppenders();
+    }
+
+    /**
+     * Used to validate that {@link MDC} values are properly passed down to child threads via the
+     * {@link ProcessReader#applyLogContextMap()}
+     */
+    @Test
+    void testFormattedLogMessageWithMDCTransfer() throws Exception {
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            appender.setOutputStream(outputStream);
+            appender.start();
+
+            DummyProcessReader objectUnderTest = new DummyProcessReader();
+            objectUnderTest.setContextMap(MDC.getCopyOfContextMap());
+            objectUnderTest.start();
+            objectUnderTest.join();
+
+            String expected = String.format(FORMAT_PATTERN, SOME_NAME, SOME_LOCATION, SOME_MESSAGE);
+            assertEquals(expected, outputStream.toString());
+        }
+    }
+
+    @Test
+    void testFormattedLogMessageWithoutMDCTransfer() throws Exception {
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            appender.setOutputStream(outputStream);
+            appender.start();
+
+            DummyProcessReader objectUnderTest = new DummyProcessReader();
+            // Skip the call to setContextMap()
+            // objectUnderTest.setContextMap(MDC.getCopyOfContextMap());
+            objectUnderTest.start();
+            objectUnderTest.join();
+
+            String expected = String.format(FORMAT_PATTERN, NOT_SET, NOT_SET, SOME_MESSAGE);
+            assertEquals(expected, outputStream.toString());
+        }
+    }
+
+    static class DummyProcessReader extends ProcessReader {
+        final Logger logger = (Logger) LoggerFactory.getLogger(DummyProcessReader.class);
+
+        @Override
+        public void finish() {
+            // nothing to do
+        }
+
+        @Override
+        void runImpl() {
+            // put default values in MDC map
+            MDC.put(SERVICE_LOCATION, NOT_SET);
+            MDC.put(SHORT_NAME, NOT_SET);
+
+            // override MDC values if info was passed from parent thread
+            applyLogContextMap();
+            logger.info(SOME_MESSAGE);
+        }
+    }
+}


### PR DESCRIPTION
Supports additional context capture in log entries