### PR TITLE
Consistently fail ExtractionTests if we did not create a meta/nometa tag correctly

### DIFF
--- a/src/main/java/emissary/core/MetadataDictionary.java
+++ b/src/main/java/emissary/core/MetadataDictionary.java
@@ -237,6 +237,9 @@ public class MetadataDictionary {
      * @return the new name as supplied by the first matching regexp or the original name if nothing matches
      */
     public String regex(final String m) {
+        if (m == null) {
+            return null;
+        }
         String r = this.regexCache.get(m);
         if (r != null) {
             this.logger.trace("Found cache match for {} --> {}", m, r);

--- a/src/test/java/emissary/core/MetadataDictionaryTest.java
+++ b/src/test/java/emissary/core/MetadataDictionaryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class MetadataDictionaryTest extends UnitTest {
@@ -91,6 +92,16 @@ public class MetadataDictionaryTest extends UnitTest {
             fail("Exception doing namespace lookup", ex);
         } finally {
             clearNamespace();
+        }
+    }
+
+    @Test
+    void testNullRegex() {
+        MetadataDictionary dict = getDict(true);
+        try {
+            assertNull(dict.regex(null), "regex() should return null if we pass it a null value.");
+        } catch (NullPointerException ex) {
+            fail("An exception was thrown instead of handling a null value gracefully", ex);
         }
     }
 

--- a/src/test/java/emissary/test/core/junit5/ExtractionTest.java
+++ b/src/test/java/emissary/test/core/junit5/ExtractionTest.java
@@ -226,14 +226,14 @@ public abstract class ExtractionTest extends UnitTest {
         // Check specified metadata
         for (Element meta : el.getChildren("meta")) {
             String key = meta.getChildTextTrim("name");
-            checkNullChildTag("meta", key);
+            checkForMissingNameElement("meta", key, tname);
             checkStringValue(meta, payload.getStringParameter(key), tname);
         }
 
         // Check specified nometa
         for (Element meta : el.getChildren("nometa")) {
             String key = meta.getChildTextTrim("name");
-            checkNullChildTag("nometa", key);
+            checkForMissingNameElement("nometa", key, tname);
             assertFalse(payload.hasParameter(key),
                     String.format("Metadata element '%s' in '%s' should not exist, but has value of '%s'", key, tname,
                             payload.getStringParameter(key)));
@@ -296,9 +296,9 @@ public abstract class ExtractionTest extends UnitTest {
         }
     }
 
-    private void checkNullChildTag(String parentTag, String key) {
+    private void checkForMissingNameElement(String parentTag, String key, String tname) {
         if (key == null) {
-            fail(String.format("The parent tag %s does not have a child name tag", parentTag));
+            fail(String.format("The element %s has a problem in %s: does not have a child name element", parentTag, tname));
         }
     }
 

--- a/src/test/java/emissary/test/core/junit5/ExtractionTest.java
+++ b/src/test/java/emissary/test/core/junit5/ExtractionTest.java
@@ -226,12 +226,14 @@ public abstract class ExtractionTest extends UnitTest {
         // Check specified metadata
         for (Element meta : el.getChildren("meta")) {
             String key = meta.getChildTextTrim("name");
+            checkNullChildTag("meta", key);
             checkStringValue(meta, payload.getStringParameter(key), tname);
         }
 
         // Check specified nometa
         for (Element meta : el.getChildren("nometa")) {
             String key = meta.getChildTextTrim("name");
+            checkNullChildTag("nometa", key);
             assertFalse(payload.hasParameter(key),
                     String.format("Metadata element '%s' in '%s' should not exist, but has value of '%s'", key, tname,
                             payload.getStringParameter(key)));
@@ -291,6 +293,12 @@ public abstract class ExtractionTest extends UnitTest {
                 assertEquals(0, Integer.parseInt(extractCountStr),
                         String.format("No extracted children in '%s' when expecting %s", tname, extractCountStr));
             }
+        }
+    }
+
+    private void checkNullChildTag(String parentTag, String key) {
+        if (key == null) {
+            fail(String.format("The parent tag %s does not have a child name tag", parentTag));
         }
     }
 

--- a/src/test/java/emissary/test/core/junit5/TestExtractionTest.java
+++ b/src/test/java/emissary/test/core/junit5/TestExtractionTest.java
@@ -1,5 +1,7 @@
 package emissary.test.core.junit5;
 
+import emissary.core.DataObjectFactory;
+import emissary.core.IBaseDataObject;
 import emissary.place.IServiceProviderPlace;
 
 import org.jdom2.Document;
@@ -7,6 +9,7 @@ import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 import org.jdom2.input.sax.XMLReaders;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -21,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class TestExtractionTest extends UnitTest {
 
     private final String RESOURCE_NAME = "/emissary/test/core/junit5/TestExtractionTest.xml";
+    private final String MISSING_TAGS_RESOURCE = "/emissary/test/core/junit5/MissingTags.xml";
 
     @Test
     void testCheckStringValueForCollection() throws JDOMException, IOException {
@@ -89,6 +93,22 @@ class TestExtractionTest extends UnitTest {
             fail("Attribute " + matchMode + " does not exist in data");
         }
         return data;
+    }
+
+    @Test
+    void testExtractionNoNameTags() throws JDOMException, IOException {
+        IBaseDataObject d = DataObjectFactory.getInstance();
+        WhyDoYouMakeMeDoThisExtractionTest test = new WhyDoYouMakeMeDoThisExtractionTest();
+
+        SAXBuilder builder = new SAXBuilder(XMLReaders.NONVALIDATING);
+        InputStream inputStream = TestExtractionTest.class.getResourceAsStream(MISSING_TAGS_RESOURCE);
+        Document doc = builder.build(inputStream);
+        Element answers = doc.getRootElement().getChild("answers");
+
+        // ensure that the test fails if the meta or nometa tags are not created correctly and a name tag is missing
+        Assertions.assertThrows(AssertionError.class, () -> {
+            test.checkAnswers(answers, d, null, MISSING_TAGS_RESOURCE);
+        }, "The test should fail if we did not create the nometa tag correctly");
     }
 
     public static class WhyDoYouMakeMeDoThisExtractionTest extends emissary.test.core.junit5.ExtractionTest {

--- a/src/test/resources/emissary/test/core/junit5/MissingTags.xml
+++ b/src/test/resources/emissary/test/core/junit5/MissingTags.xml
@@ -1,0 +1,5 @@
+<result>
+    <answers>
+        <nometa>FIELD</nometa>
+    </answers>
+</result>


### PR DESCRIPTION
Added a null check in MetadataDictionary to prevent future NPE's, and modified the ExtractionTest to consistently fail if we do not create the meta/nometa tags correctly. 