### PR TITLE
fix agentProcessHeavyDuty exception log

### DIFF
--- a/src/main/java/emissary/place/ServiceProviderPlace.java
+++ b/src/main/java/emissary/place/ServiceProviderPlace.java
@@ -572,7 +572,7 @@ public abstract class ServiceProviderPlace implements emissary.place.IServicePro
             rehash(payload);
             return l;
         } catch (Exception e) {
-            logger.error("Place.process threw: {}", e, e);
+            logger.error("Place.process threw:", e);
             throw e;
         }
     }


### PR DESCRIPTION
The format for this message is incorrect:
```
2023-06-02 15:41:07,946 localhost-8001 ERROR com.burrito.analyze.XmlPlace - PAGES.dat-att-3 XML.XML.ANALYZE.http://localhost:8001/XmlPlace - Place.process threw: {}
java.lang.ClassCastException: ...
```
It should look like:
```
2023-06-02 15:41:07,946 localhost-8001 ERROR com.burrito.analyze.XmlPlace - PAGES.dat-att-3 XML.XML.ANALYZE.http://localhost:8001/XmlPlace - Place.process threw:
java.lang.ClassCastException: ...
```