### PR TITLE
PayloadUtil: simple sonarlint clean-up

### DIFF
--- a/src/main/java/emissary/util/PayloadUtil.java
+++ b/src/main/java/emissary/util/PayloadUtil.java
@@ -242,7 +242,9 @@ public class PayloadUtil {
             root.addContent(views);
         }
 
-        logger.debug("Produced xml document for " + d.shortName());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Produced xml document for {}", d.shortName());
+        }
         return new Document(root);
     }
 
@@ -265,7 +267,9 @@ public class PayloadUtil {
         for (final IBaseDataObject d : list) {
             final Document doc = toXml(d);
             root.addContent(doc.detachRootElement());
-            logger.debug("Adding xml content for " + d.shortName() + " to document");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Adding xml content for {} to document", d.shortName());
+            }
         }
         return new Document(root);
     }


### PR DESCRIPTION
cleaned up logging statements in PayloadUtil. Sonarlint also complains about using JDOMUtil instead of AbstractJDOMUtil, but figured I wouldn't change that unless specified to do so