### PR TITLE
Disable push from the maven release plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -910,7 +910,7 @@
           <version>3.0.0</version>
           <configuration>
             <autoVersionSubmodules>true</autoVersionSubmodules>
-            <pushChanges>true</pushChanges>
+            <pushChanges>false</pushChanges>
             <goals>deploy</goals>
             <localCheckout>true</localCheckout>
             <releaseProfiles>basis,hotspot,dev</releaseProfiles>


### PR DESCRIPTION
This got me yesterday when experimenting with the plugin which led to commits being pushed during the maven build to the master branch.

We don't use the release plugin in our current workflow so disabling the push option should not cause any interruptions. 

I am also of the opinion that in the future if we have a release workflow that the actual git push step should be separate from the maven build