### PR TITLE
1676 - Allow '+' in IBDO Form name

### DIFF
--- a/src/main/java/emissary/core/BaseDataObject.java
+++ b/src/main/java/emissary/core/BaseDataObject.java
@@ -621,7 +621,7 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
             throw new IllegalArgumentException("caller attempted to push a null form value");
         } else if (!PayloadUtil.isValidForm(newForm)) {
             // If there is a key separator in the form, then throw an error log as this will cause issues in routing
-            logger.error("INVALID FORM: The form can only contain a-z, A-Z, 0-9, '-', '_', '()', '/'. Given form: {}", newForm);
+            logger.error("INVALID FORM: The form can only contain a-z, A-Z, 0-9, '-', '_', '()', '/', '+'. Given form: {}", newForm);
         }
 
         checkForAndLogDuplicates(newForm, "pushCurrentForm");

--- a/src/main/java/emissary/util/PayloadUtil.java
+++ b/src/main/java/emissary/util/PayloadUtil.java
@@ -28,7 +28,7 @@ public class PayloadUtil {
     public static final Logger logger = LoggerFactory.getLogger(PayloadUtil.class);
 
     private static final String LS = System.getProperty("line.separator");
-    private static final Pattern validFormRegex = Pattern.compile("^[\\w-)(/]+$");
+    private static final Pattern validFormRegex = Pattern.compile("^[\\w-)(/+]+$");
 
     protected static Map<String, String> historyPreference = new HashMap<>();
 
@@ -296,7 +296,7 @@ public class PayloadUtil {
     /**
      * Checks whether the form complies with form rules established by a regex
      *
-     * Approved forms can contain alpha-numerics, '-', or '_'
+     * Approved forms can contain alpha-numerics, '-', '_', '()', '/', '+'
      *
      * @param form The form to be tested
      * @return Whether the form is Emissary compliant

--- a/src/test/java/emissary/util/PayloadUtilTest.java
+++ b/src/test/java/emissary/util/PayloadUtilTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class PayloadUtilTest extends UnitTest {
 
     private static String timezone = "GMT";
-    private static final String validFormCharsString = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-)(/";
+    private static final String validFormCharsString = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-)(/+";
     private static final Set<Character> validFormChars = new HashSet<>();
 
     @BeforeAll
@@ -243,14 +243,15 @@ public class PayloadUtilTest extends UnitTest {
     void testIsValidForm() {
         // Check that all expected valid characters are valid
         String alphaLow = "abcdefghijklmnopqrstuvwxyz";
-        assertTrue(PayloadUtil.isValidForm(alphaLow), "Lower case alpha characters are not considered valid");
-        assertTrue(PayloadUtil.isValidForm(alphaLow.toUpperCase()), "Upper case alpha characters are not considered valid");
-        assertTrue(PayloadUtil.isValidForm("0123456789"), "Numeric characters are not considered valid");
-        assertTrue(PayloadUtil.isValidForm("-_"), "Dash and underscore aren't considered valid");
-        assertTrue(PayloadUtil.isValidForm("formName-(suffixInParens)"), "Parentheses aren't considered valid");
-        assertTrue(PayloadUtil.isValidForm("formName-(application/xml)"), "Slash aren't considered valid");
+        assertTrue(PayloadUtil.isValidForm(alphaLow), "Lower case alpha characters are valid");
+        assertTrue(PayloadUtil.isValidForm(alphaLow.toUpperCase()), "Upper case alpha characters are valid");
+        assertTrue(PayloadUtil.isValidForm("0123456789"), "Numeric characters are valid");
+        assertTrue(PayloadUtil.isValidForm("-_"), "Dash and underscore are valid");
+        assertTrue(PayloadUtil.isValidForm("formName-(suffixInParens)"), "Parentheses are valid");
+        assertTrue(PayloadUtil.isValidForm("formName-(application/xml)"), "Slash are valid");
         assertFalse(PayloadUtil.isValidForm("."), "Dot isn't considered valid");
         assertFalse(PayloadUtil.isValidForm(" "), "Space isn't considered valid");
+        assertTrue(PayloadUtil.isValidForm("+"), "Plus are valid");
 
         // Cycle through all characters and see how many are valid and that we have the expected number
         int validChars = 0;

--- a/src/test/java/emissary/util/PayloadUtilTest.java
+++ b/src/test/java/emissary/util/PayloadUtilTest.java
@@ -243,15 +243,15 @@ public class PayloadUtilTest extends UnitTest {
     void testIsValidForm() {
         // Check that all expected valid characters are valid
         String alphaLow = "abcdefghijklmnopqrstuvwxyz";
-        assertTrue(PayloadUtil.isValidForm(alphaLow), "Lower case alpha characters are valid");
-        assertTrue(PayloadUtil.isValidForm(alphaLow.toUpperCase()), "Upper case alpha characters are valid");
-        assertTrue(PayloadUtil.isValidForm("0123456789"), "Numeric characters are valid");
-        assertTrue(PayloadUtil.isValidForm("-_"), "Dash and underscore are valid");
-        assertTrue(PayloadUtil.isValidForm("formName-(suffixInParens)"), "Parentheses are valid");
-        assertTrue(PayloadUtil.isValidForm("formName-(application/xml)"), "Slash are valid");
-        assertFalse(PayloadUtil.isValidForm("."), "Dot isn't considered valid");
-        assertFalse(PayloadUtil.isValidForm(" "), "Space isn't considered valid");
-        assertTrue(PayloadUtil.isValidForm("+"), "Plus are valid");
+        assertTrue(PayloadUtil.isValidForm(alphaLow), "Lower case alpha characters are expected to be valid");
+        assertTrue(PayloadUtil.isValidForm(alphaLow.toUpperCase()), "Upper case alpha characters are expected to be valid");
+        assertTrue(PayloadUtil.isValidForm("0123456789"), "Numeric characters are expected to be valid");
+        assertTrue(PayloadUtil.isValidForm("-_"), "'-' and '_' are expected to be valid form characters");
+        assertTrue(PayloadUtil.isValidForm("formName-(suffixInParens)"), "Parentheses are expected to be valid form characters");
+        assertTrue(PayloadUtil.isValidForm("formName-(application/xml)"), "'/' is expected to be a valid form character");
+        assertFalse(PayloadUtil.isValidForm("."), "Dot should not be considered a valid form character");
+        assertFalse(PayloadUtil.isValidForm(" "), "Space should not be considered a valid form character");
+        assertTrue(PayloadUtil.isValidForm("+"), "'+' is expected to be a valid form character");
 
         // Cycle through all characters and see how many are valid and that we have the expected number
         int validChars = 0;


### PR DESCRIPTION
Added + to the regex that checks if valid form name and updated unit test. Also updated some comments.