### PR TITLE
Updated LoggingPrintStream so it won't block application shutdown (targets master)

### DIFF
--- a/src/main/java/emissary/util/io/LoggingPrintStream.java
+++ b/src/main/java/emissary/util/io/LoggingPrintStream.java
@@ -96,7 +96,12 @@ public class LoggingPrintStream extends PrintStream {
         this.closeWaitTime = closeWaitTime;
         this.closeWaitTimeUnit = closeWaitTimeUnit;
         this.executorService = Executors.newSingleThreadExecutor(
-                runnable -> new Thread(runnable, "LoggingPrintStream_" + streamName));
+                runnable -> {
+                    Thread t = new Thread(runnable, "LoggingPrintStream_" + streamName);
+                    // mark this as a daemon thread, so it won't block application shutdown
+                    t.setDaemon(true);
+                    return t;
+                });
 
     }
 


### PR DESCRIPTION
Couldn't think of a good unit test that isn't too clever or too intrusive.  Easiest way to verify the fix is to compare the result of the following steps on this branch vs. target branch:

1, Run `mvn clean package`
2. Run `./emissary agents`

On both branches, the `/.emissary agents` command will spit out the connection refused error message:
```
...
Setting emissary.node.name to localhost 
Setting emissary.node.port to 9001 
Setting emissary.node.scheme to http 
Mon Jul 03 16:04:58 GMT 2023
class org.apache.http.conn.HttpHostConnectException: Connect to localhost:9001 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused (Connection refused)
STDERR : class org.apache.http.conn.HttpHostConnectException: Connect to localhost:9001 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused (Connection refused)
``` 
On a fixed branch, the command will exit cleanly, but on the non-fixed branch the command will hang, and jstack will show a lingering "LoggingPrintStream_STDERR" thread:

```bash
[dev@devbox emissary (master $=)]$  jps -m | grep Emissary
49217 Emissary agents
[dev@devbox emissary (master $=)]$ jstack 49217 | grep -A15 LoggingPrintStream
"LoggingPrintStream_STDERR" #22 prio=5 os_prio=0 cpu=1.24ms elapsed=58.07s tid=0x00007f7254ca7800 nid=0xc06a waiting on condition  [0x00007f7173cfc000]
   java.lang.Thread.State: WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@11.0.19/Native Method)
	- parking to wait for  <0x00000004140517c0> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
	at java.util.concurrent.locks.LockSupport.park(java.base@11.0.19/LockSupport.java:194)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@11.0.19/AbstractQueuedSynchronizer.java:2081)
	at java.util.concurrent.LinkedBlockingQueue.take(java.base@11.0.19/LinkedBlockingQueue.java:433)
	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.19/ThreadPoolExecutor.java:1054)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.19/ThreadPoolExecutor.java:1114)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.19/ThreadPoolExecutor.java:628)
	at java.lang.Thread.run(java.base@11.0.19/Thread.java:829)
```
