### PR TITLE
Added null data check to DropOffPlace completion message setup

### DIFF
--- a/src/main/java/emissary/output/DropOffPlace.java
+++ b/src/main/java/emissary/output/DropOffPlace.java
@@ -246,7 +246,7 @@ public class DropOffPlace extends ServiceProviderPlace implements EmptyFormPlace
                 objectMetricsLog.info(appendEntries(outputObjectMetrics(tld, objectMetricsFields)), "Finished DropOff");
             }
 
-            if (outputCompletionPayloadSize) {
+            if (outputCompletionPayloadSize && tld.data() != null) {
                 logger.info(
                         "Finished DropOff for object {}, with external id: {}, with total processing time: {}ms, with filetype: {}, payload size: {} bytes",
                         tld.getInternalId(), this.dropOffUtil.getBestId(tld, tld), (new Date().getTime() - tld.getCreationTimestamp().getTime()),

--- a/src/main/java/emissary/output/DropOffPlace.java
+++ b/src/main/java/emissary/output/DropOffPlace.java
@@ -250,7 +250,7 @@ public class DropOffPlace extends ServiceProviderPlace implements EmptyFormPlace
                 logger.info(
                         "Finished DropOff for object {}, with external id: {}, with total processing time: {}ms, with filetype: {}, payload size: {} bytes",
                         tld.getInternalId(), this.dropOffUtil.getBestId(tld, tld), (new Date().getTime() - tld.getCreationTimestamp().getTime()),
-                        tld.getFileType(), tld.data().length);
+                        tld.getFileType(), tld.dataLength());
             } else {
                 logger.info("Finished DropOff for object {}, with external id: {}, with total processing time: {}ms, with filetype: {}",
                         tld.getInternalId(), this.dropOffUtil.getBestId(tld, tld), (new Date().getTime() - tld.getCreationTimestamp().getTime()),


### PR DESCRIPTION
Resolves a potential NullPointerException in `DropOffPlace.agentProcessHeavyDuty`.  (This NPE should never have been possible outside of unit tests anyway.)