### PR TITLE
Add 'CHECKSUM_CRC32' to the list of removed parameter keys.

### DIFF
--- a/src/main/java/emissary/kff/KffDataObjectHandler.java
+++ b/src/main/java/emissary/kff/KffDataObjectHandler.java
@@ -19,6 +19,7 @@ import javax.annotation.Nullable;
 public class KffDataObjectHandler {
     // Parameter names for data object param map
     public static final String KFF_PARAM_BASE = "CHECKSUM_";
+    public static final String KFF_PARAM_CRC32 = KFF_PARAM_BASE + "CRC32";
     public static final String KFF_PARAM_MD5 = KFF_PARAM_BASE + "MD5";
     public static final String KFF_PARAM_SHA1 = KFF_PARAM_BASE + "SHA-1";
     public static final String KFF_PARAM_SHA256 = KFF_PARAM_BASE + "SHA-256";
@@ -242,6 +243,7 @@ public class KffDataObjectHandler {
      * @param d the payload
      */
     public static void removeHash(IBaseDataObject d) {
+        d.deleteParameter(KFF_PARAM_CRC32);
         d.deleteParameter(KFF_PARAM_MD5);
         d.deleteParameter(KFF_PARAM_SHA1);
         d.deleteParameter(KFF_PARAM_SHA256);


### PR DESCRIPTION
The 'CHECKSUM_CRC32' parameter key is not removed when calling KffDataObjectHandler.hash(...). This means that if the payload is hashed, then the payload is changed and then the payload is hashed again, there will be two values for the 'CHECKSUM_CRC32' parameter key.