### PR TITLE
RegressionTest updates.

### DIFF
--- a/src/main/java/emissary/core/IBaseDataObjectXmlCodecs.java
+++ b/src/main/java/emissary/core/IBaseDataObjectXmlCodecs.java
@@ -1,0 +1,688 @@
+package emissary.core;
+
+import emissary.core.channels.InMemoryChannelFactory;
+import emissary.core.channels.SeekableByteChannelFactory;
+import emissary.core.channels.SeekableByteChannelHelper;
+import emissary.util.xml.AbstractJDOMUtil;
+
+import org.apache.commons.lang3.Validate;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.xml.XMLConstants;
+
+import static emissary.core.IBaseDataObjectXmlHelper.BIRTH_ORDER_ELEMENT_NAME;
+import static emissary.core.IBaseDataObjectXmlHelper.BROKEN_ELEMENT_NAME;
+import static emissary.core.IBaseDataObjectXmlHelper.NUM_CHILDREN_ELEMENT_NAME;
+import static emissary.core.IBaseDataObjectXmlHelper.NUM_SIBLINGS_ELEMENT_NAME;
+import static emissary.core.IBaseDataObjectXmlHelper.OUTPUTABLE_ELEMENT_NAME;
+import static emissary.core.IBaseDataObjectXmlHelper.PARAMETER_ELEMENT_NAME;
+import static emissary.core.IBaseDataObjectXmlHelper.PRIORITY_ELEMENT_NAME;
+import static emissary.core.IBaseDataObjectXmlHelper.PROCESSING_ERROR_ELEMENT_NAME;
+import static emissary.core.IBaseDataObjectXmlHelper.VALUE_ELEMENT_NAME;
+import static emissary.core.IBaseDataObjectXmlHelper.VIEW_ELEMENT_NAME;
+
+/**
+ * This class contains the interfaces and implementations used to convert an IBDO-&gt;XML and XML-&gt;IBDO.
+ */
+public final class IBaseDataObjectXmlCodecs {
+    /**
+     * Logger instance
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(IBaseDataObjectXmlCodecs.class);
+    /**
+     * The XML attribute name for Base64.
+     */
+    public static final String BASE64_ATTRIBUTE_NAME = "base64";
+    /**
+     * The XML attribute name for SHA256.
+     */
+    public static final String SHA256_ATTRIBUTE_NAME = "sha256";
+    /**
+     * New line string to use for normalised XML
+     */
+    public static final String BASE64_NEW_LINE_STRING = new String(new byte[] {'\n'});
+    /**
+     * Max width of Base64 char block.
+     */
+    public static final int BASE64_LINE_WIDTH = 76;
+    /**
+     * The Base64 encoder.
+     * 
+     * Uses same width as default, but overrides new line separator to use normalized XML separator.
+     * 
+     * See http://www.jdom.org/docs/apidocs/org/jdom2/output/Format.html#setLineSeparator(java.lang.String)
+     */
+    public static final Base64.Encoder BASE64_ENCODER = Base64.getMimeEncoder(BASE64_LINE_WIDTH, new byte[] {'\n'});
+    /**
+     * The Base64 decoder.
+     */
+    private static final Base64.Decoder BASE64_DECODER = Base64.getMimeDecoder();
+    /**
+     * The XML attribute name for Encoding.
+     */
+    public static final String ENCODING_ATTRIBUTE_NAME = "encoding";
+    /**
+     * The XML element name for Name.
+     */
+    public static final String NAME_ELEMENT_NAME = "name";
+    /**
+     * A map of element names of IBaseDataObject methods that get/set primitives and their default values.
+     */
+    public static final Map<String, Object> PRIMITVE_NAME_DEFAULT_MAP = Collections
+            .unmodifiableMap(new ConcurrentHashMap<>(Stream.of(
+                    new SimpleEntry<>(BIRTH_ORDER_ELEMENT_NAME, new BaseDataObject().getBirthOrder()),
+                    new SimpleEntry<>(BROKEN_ELEMENT_NAME, new BaseDataObject().isBroken()),
+                    new SimpleEntry<>(NUM_CHILDREN_ELEMENT_NAME, new BaseDataObject().getNumChildren()),
+                    new SimpleEntry<>(NUM_SIBLINGS_ELEMENT_NAME, new BaseDataObject().getNumSiblings()),
+                    new SimpleEntry<>(OUTPUTABLE_ELEMENT_NAME, new BaseDataObject().isOutputable()),
+                    new SimpleEntry<>(PRIORITY_ELEMENT_NAME, new BaseDataObject().getPriority()))
+                    .collect(Collectors.toMap(SimpleEntry::getKey, SimpleEntry::getValue))));
+    /**
+     * The XML namespace for "xml".
+     */
+    public static final Namespace XML_NAMESPACE = Namespace.getNamespace(XMLConstants.XML_NS_PREFIX,
+            XMLConstants.XML_NS_URI);
+
+    /**
+     * Interface for decoding an element value.
+     */
+    public interface ElementDecoder {
+        /**
+         * Decodes and XML element value and sets it on the specified IBDO method.
+         * 
+         * @param elements the list of elements to be decoded.
+         * @param ibdo the ibdo to set the values on.
+         * @param ibdoMethodName the ibdo method name to use to set the values.
+         * @throws Exception thrown if anything goes wrong.
+         */
+        void decode(List<Element> elements, IBaseDataObject ibdo, String ibdoMethodName) throws Exception;
+    }
+
+    /**
+     * Interface for encoding an element value.
+     */
+    public interface ElementEncoder<T> {
+        /**
+         * Encodes a list of values into an element that is attached to the parent element with the specified child element
+         * name.
+         * 
+         * @param values to be encoded.
+         * @param parentElement that the child element is to be attached to.
+         * @param childElementName the name of the child element.
+         */
+        void encode(List<T> values, Element parentElement, String childElementName);
+    }
+
+    /**
+     * Class that contains the element decoders.
+     */
+    public static class ElementDecoders {
+        /**
+         * Decoder for boolean elements.
+         */
+        public final ElementDecoder booleanDecoder;
+        /**
+         * Decoder for byte[] elements.
+         */
+        public final ElementDecoder byteArrayDecoder;
+        /**
+         * Decoder for integer elements.
+         */
+        public final ElementDecoder integerDecoder;
+        /**
+         * Decoder for SeekableByteChannel elements.
+         */
+        public final ElementDecoder seekableByteChannelFactoryDecoder;
+        /**
+         * Decoder for Map&lt;String,byte[]&gt; elements.
+         */
+        public final ElementDecoder stringByteArrayDecoder;
+        /**
+         * Decoder for String elements.
+         */
+        public final ElementDecoder stringDecoder;
+        /**
+         * Decoder for Map&lt;String,Collection&lt;Object&gt;&gt; elements.
+         */
+        public final ElementDecoder stringObjectDecoder;
+
+        /**
+         * Constructs a container for the XML element decoders.
+         * 
+         * @param booleanDecoder decoder for boolean elements
+         * @param byteArrayDecoder decoder for byte[] elements
+         * @param integerDecoder decoder for integer elements
+         * @param seekableByteChannelFactoryDecoder decoder for SeekableByteChannelElements.
+         * @param stringByteArrayDecoder decoder for Map&lt;String,byte[]&gt; elements
+         * @param stringDecoder decoder for String elements
+         * @param stringObjectDecoder decoder for Map&lt;String,Collection&lt;Object&gt;&gt; elements
+         */
+        public ElementDecoders(
+                final ElementDecoder booleanDecoder,
+                final ElementDecoder byteArrayDecoder,
+                final ElementDecoder integerDecoder,
+                final ElementDecoder seekableByteChannelFactoryDecoder,
+                final ElementDecoder stringByteArrayDecoder,
+                final ElementDecoder stringDecoder,
+                final ElementDecoder stringObjectDecoder) {
+            Validate.notNull(booleanDecoder, "Required: booleanDecoder not null!");
+            Validate.notNull(byteArrayDecoder, "Required: byteArrayDecoder not null!");
+            Validate.notNull(integerDecoder, "Required: integerDecoder not null!");
+            Validate.notNull(seekableByteChannelFactoryDecoder, "Required: seekableByteChannelFactoryDecoder not null!");
+            Validate.notNull(stringByteArrayDecoder, "Required: stringByteArrayDecoder not null!");
+            Validate.notNull(stringDecoder, "Required: stringDecoder not null!");
+            Validate.notNull(stringObjectDecoder, "Required: stringObjectDecoder not null!");
+
+            this.booleanDecoder = booleanDecoder;
+            this.byteArrayDecoder = byteArrayDecoder;
+            this.integerDecoder = integerDecoder;
+            this.seekableByteChannelFactoryDecoder = seekableByteChannelFactoryDecoder;
+            this.stringByteArrayDecoder = stringByteArrayDecoder;
+            this.stringDecoder = stringDecoder;
+            this.stringObjectDecoder = stringObjectDecoder;
+        }
+    }
+
+    /**
+     * Class that contains the element encoders.
+     */
+    public static class ElementEncoders {
+        /**
+         * Encoder for boolean elements.
+         */
+        public final ElementEncoder<Boolean> booleanEncoder;
+        /**
+         * Encoder for byte[] elements.
+         */
+        public final ElementEncoder<byte[]> byteArrayEncoder;
+        /**
+         * Encoder for integer elements.
+         */
+        public final ElementEncoder<Integer> integerEncoder;
+        /**
+         * Encoder for SeekableByteChannel elements.
+         */
+        public final ElementEncoder<SeekableByteChannelFactory> seekableByteChannelFactoryEncoder;
+        /**
+         * Encoder for Map&lt;String,byte[]&gt; elements.
+         */
+        public final ElementEncoder<Map<String, byte[]>> stringByteArrayEncoder;
+        /**
+         * Encoder for String elements.
+         */
+        public final ElementEncoder<String> stringEncoder;
+        /**
+         * Encoder for Map&lt;String, Collection&lt;Object&gt;&gt; elements.
+         */
+        public final ElementEncoder<Map<String, Collection<Object>>> stringObjectEncoder;
+
+        /**
+         * Constructs a container for the XML element encoders.
+         * 
+         * @param booleanEncoder encoder for boolean elements
+         * @param byteArrayEncoder encoder for byte[] elements
+         * @param integerEncoder encoder for integer elements
+         * @param seekableByteChannelFactoryEncoder encoder for SeekableByteChannel elements
+         * @param stringByteArrayEncoder encoder for Map&lt;String,byte[]&gt; elements
+         * @param stringEncoder encoder for String elements.
+         * @param stringObjectEncoder encoder for Map&lt;String, Collection&lt;Object&gt;&gt; elements
+         */
+        public ElementEncoders(
+                final ElementEncoder<Boolean> booleanEncoder,
+                final ElementEncoder<byte[]> byteArrayEncoder,
+                final ElementEncoder<Integer> integerEncoder,
+                final ElementEncoder<SeekableByteChannelFactory> seekableByteChannelFactoryEncoder,
+                final ElementEncoder<Map<String, byte[]>> stringByteArrayEncoder,
+                final ElementEncoder<String> stringEncoder,
+                final ElementEncoder<Map<String, Collection<Object>>> stringObjectEncoder) {
+            Validate.notNull(booleanEncoder, "Required: booleanEncoder not null!");
+            Validate.notNull(byteArrayEncoder, "Required: byteArrayEncoder not null!");
+            Validate.notNull(integerEncoder, "Required: integerEncoder not null!");
+            Validate.notNull(seekableByteChannelFactoryEncoder, "Required: seekableByteChannelFactoryEncoder not null!");
+            Validate.notNull(stringByteArrayEncoder, "Required: stringByteArrayEncoder not null!");
+            Validate.notNull(stringEncoder, "Required: stringEncoder not null!");
+            Validate.notNull(stringObjectEncoder, "Required: stringObjectEncoder not null!");
+
+            this.booleanEncoder = booleanEncoder;
+            this.byteArrayEncoder = byteArrayEncoder;
+            this.integerEncoder = integerEncoder;
+            this.seekableByteChannelFactoryEncoder = seekableByteChannelFactoryEncoder;
+            this.stringByteArrayEncoder = stringByteArrayEncoder;
+            this.stringEncoder = stringEncoder;
+            this.stringObjectEncoder = stringObjectEncoder;
+        }
+    }
+
+    /**
+     * Implementation of an XML element decoder that has a boolean value.
+     */
+    public static final ElementDecoder DEFAULT_BOOLEAN_DECODER = (elements, ibdo, ibdoMethodName) -> {
+        final Method method = IBaseDataObject.class.getDeclaredMethod(ibdoMethodName, boolean.class);
+
+        for (final Element element : elements) {
+            method.invoke(ibdo, Boolean.valueOf(element.getValue()));
+        }
+    };
+
+    /**
+     * Implementation of an XML element decoder that has a SeekableByteChannel value.
+     */
+    public static final ElementDecoder DEFAULT_SEEKABLE_BYTE_CHANNEL_FACTORY_DECODER = (elements, ibdo, ibdoMethodName) -> {
+        final Method method = IBaseDataObject.class.getDeclaredMethod(ibdoMethodName, SeekableByteChannelFactory.class);
+
+        for (final Element element : elements) {
+            final String elementValue = element.getValue();
+            final String encoding = element.getAttributeValue(ENCODING_ATTRIBUTE_NAME);
+
+            method.invoke(ibdo, InMemoryChannelFactory.create(extractBytes(encoding, elementValue)));
+        }
+    };
+
+    /**
+     * Implementation of an XML element decoder that has a byte array value.
+     */
+    public static final ElementDecoder DEFAULT_BYTE_ARRAY_DECODER = (elements, ibdo, ibdoMethodName) -> {
+        final Method method = IBaseDataObject.class.getDeclaredMethod(ibdoMethodName, byte[].class);
+
+        for (final Element element : elements) {
+            final String elementValue = element.getValue();
+            final String encoding = element.getAttributeValue(ENCODING_ATTRIBUTE_NAME);
+
+            method.invoke(ibdo, extractBytes(encoding, elementValue));
+        }
+    };
+
+    /**
+     * Implementation of an XML element decoder that has an integer value.
+     */
+    public static final ElementDecoder DEFAULT_INTEGER_DECODER = (elements, ibdo, ibdoMethodName) -> {
+        final Method method = IBaseDataObject.class.getDeclaredMethod(ibdoMethodName, int.class);
+
+        for (final Element element : elements) {
+            method.invoke(ibdo, Integer.decode(element.getValue()));
+        }
+    };
+
+    /**
+     * Implementation of an XML element decoder that has a string value.
+     */
+    public static final ElementDecoder DEFAULT_STRING_DECODER = (elements, ibdo, ibdoMethodName) -> {
+        final Method method = IBaseDataObject.class.getDeclaredMethod(ibdoMethodName, String.class);
+
+        for (final Element element : elements) {
+            final String elementValue = element.getValue();
+            final String encoding = element.getAttributeValue(ENCODING_ATTRIBUTE_NAME);
+
+            method.invoke(ibdo, new String(extractBytes(encoding, elementValue), StandardCharsets.UTF_8));
+        }
+    };
+
+    /**
+     * Implementation of an XML element decoder that has a mapped value where the key is a string and the value is a byte
+     * array.
+     */
+    public static final ElementDecoder DEFAULT_STRING_BYTE_ARRAY_DECODER = (elements, ibdo, ibdoMethodName) -> {
+        final Method method = IBaseDataObject.class.getDeclaredMethod(ibdoMethodName, String.class, byte[].class);
+
+        for (final Element element : elements) {
+            final Element nameElement = element.getChild(NAME_ELEMENT_NAME);
+            final String name = nameElement.getValue();
+            final String nameEncoding = nameElement.getAttributeValue(ENCODING_ATTRIBUTE_NAME);
+            final String nameDecoded = new String(extractBytes(nameEncoding, name), StandardCharsets.UTF_8);
+            final Element valueElement = element.getChild(VALUE_ELEMENT_NAME);
+            final String value = valueElement.getValue();
+            final String valueEncoding = valueElement.getAttributeValue(ENCODING_ATTRIBUTE_NAME);
+            final byte[] valueDecoded = extractBytes(valueEncoding, value);
+
+            method.invoke(ibdo, nameDecoded, valueDecoded);
+        }
+    };
+
+    /**
+     * Implementation of an XML element decoder that has a mapped value where the key is a string and the value is an
+     * object.
+     */
+    public static final ElementDecoder DEFAULT_STRING_OBJECT_DECODER = (elements, ibdo, ibdoMethodName) -> {
+        final Method method = IBaseDataObject.class.getDeclaredMethod(ibdoMethodName, String.class, Object.class);
+
+        for (final Element element : elements) {
+            final Element nameElement = element.getChild(NAME_ELEMENT_NAME);
+            final String name = nameElement.getValue();
+            final String nameEncoding = nameElement.getAttributeValue(ENCODING_ATTRIBUTE_NAME);
+            final String nameDecoded = new String(extractBytes(nameEncoding, name), StandardCharsets.UTF_8);
+            final Element valueElement = element.getChild(VALUE_ELEMENT_NAME);
+            final String value = valueElement.getValue();
+            final String valueEncoding = valueElement.getAttributeValue(ENCODING_ATTRIBUTE_NAME);
+            final String valueDecoded = new String(extractBytes(valueEncoding, value));
+
+            method.invoke(ibdo, nameDecoded, valueDecoded);
+        }
+    };
+
+    /**
+     * An implementation of an XML element encoder for SeekableByteChannel's that produces a base64 value.
+     */
+    public static final ElementEncoder<SeekableByteChannelFactory> DEFAULT_SEEKABLE_BYTE_CHANNEL_FACTORY_ENCODER =
+            new SeekableByteChannelFactoryEncoder();
+
+    private static class SeekableByteChannelFactoryEncoder implements ElementEncoder<SeekableByteChannelFactory> {
+        @Override
+        public void encode(final List<SeekableByteChannelFactory> values, final Element parentElement, final String childElementName) {
+            for (final SeekableByteChannelFactory value : values) {
+                if (value != null) {
+                    try {
+                        final byte[] bytes = SeekableByteChannelHelper.getByteArrayFromChannel(value,
+                                BaseDataObject.MAX_BYTE_ARRAY_SIZE);
+
+                        parentElement.addContent(preserve(protectedElementBase64(childElementName, bytes)));
+                    } catch (final IOException e) {
+                        LOGGER.error("Could not get bytes from SeekableByteChannel!", e);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * An implementation of an XML element encoder for SeekableByteChannel's that produces a SHA256 hash value.
+     */
+    public static final ElementEncoder<SeekableByteChannelFactory> SHA256_SEEKABLE_BYTE_CHANNEL_FACTORY_ENCODER =
+            new HashSeekableByteChannelFactoryEncoder();
+
+    private static class HashSeekableByteChannelFactoryEncoder implements ElementEncoder<SeekableByteChannelFactory> {
+        @Override
+        public void encode(final List<SeekableByteChannelFactory> values, final Element parentElement, final String childElementName) {
+            for (final SeekableByteChannelFactory value : values) {
+                if (value != null) {
+                    try {
+                        final byte[] bytes = SeekableByteChannelHelper.getByteArrayFromChannel(value,
+                                BaseDataObject.MAX_BYTE_ARRAY_SIZE);
+
+                        parentElement.addContent(preserve(protectedElementHash(childElementName, bytes)));
+                    } catch (final IOException e) {
+                        LOGGER.error("Could not get bytes from SeekableByteChannel!", e);
+                    }
+                }
+            }
+        }
+
+        private static Element protectedElementHash(final String name, final byte[] bytes) {
+            final Element element = new Element(name);
+
+            if (hasNonPrintableValues(bytes)) {
+                element.setAttribute(ENCODING_ATTRIBUTE_NAME, SHA256_ATTRIBUTE_NAME);
+                element.addContent(sha256Bytes(bytes));
+            } else {
+                element.addContent(new String(bytes, StandardCharsets.ISO_8859_1));
+            }
+
+            return element;
+        }
+    }
+
+    /**
+     * An implementation of an XML element encoder for integers.
+     */
+    public static final ElementEncoder<Integer> DEFAULT_INTEGER_ENCODER = new IntegerEncoder();
+
+    private static class IntegerEncoder implements ElementEncoder<Integer> {
+        @Override
+        public void encode(final List<Integer> values, final Element parentElement, final String childElementName) {
+            for (final int value : values) {
+                if (((Integer) PRIMITVE_NAME_DEFAULT_MAP.get(childElementName)) != value) {
+                    parentElement.addContent(AbstractJDOMUtil.simpleElement(childElementName, value));
+                }
+            }
+        }
+    }
+
+    /**
+     * An implementation of an XML element encoder for Strings.
+     */
+    public static final ElementEncoder<String> DEFAULT_STRING_ENCODER = new StringEncoder();
+
+    private static class StringEncoder implements ElementEncoder<String> {
+        @Override
+        public void encode(final List<String> values, final Element parentElement, final String childElementName) {
+            for (int i = values.size() - 1; i >= 0; i--) {
+                String value = values.get(i);
+
+                if (PROCESSING_ERROR_ELEMENT_NAME.equals(childElementName)) {
+                    value = value == null ? null : value.substring(0, value.length() - 1);
+                }
+
+                if (value != null) {
+                    parentElement.addContent(preserve(protectedElement(childElementName, value)));
+                }
+            }
+        }
+    }
+
+    /**
+     * An implementation of an XML element encoder for byte[].
+     */
+    public static final ElementEncoder<byte[]> DEFAULT_BYTE_ARRAY_ENCODER = new ByteArrayEncoder();
+
+    private static class ByteArrayEncoder implements ElementEncoder<byte[]> {
+        @Override
+        public void encode(final List<byte[]> values, final Element parentElement, final String childElementName) {
+            for (final byte[] value : values) {
+                if (value != null) {
+                    parentElement.addContent(preserve(protectedElementBase64(childElementName, value)));
+                }
+            }
+        }
+    }
+
+    /**
+     * An implementation of an XML element encoder for booleans.
+     */
+    public static final ElementEncoder<Boolean> DEFAULT_BOOLEAN_ENCODER = new BooleanEncoder();
+
+    private static class BooleanEncoder implements ElementEncoder<Boolean> {
+        @Override
+        public void encode(final List<Boolean> values, final Element parentElement, final String childElementName) {
+            for (final boolean value : values) {
+                if ((Boolean) PRIMITVE_NAME_DEFAULT_MAP.get(childElementName) != value) {
+                    parentElement.addContent(AbstractJDOMUtil.simpleElement(childElementName, value));
+                }
+            }
+        }
+    }
+
+    /**
+     * An implementation of an XML element encoder for Map&lt;String, Collection&lt;Object&gt;&gt;.
+     */
+    public static final ElementEncoder<Map<String, Collection<Object>>> DEFAULT_STRING_OBJECT_ENCODER = new StringObjectEncoder();
+
+    private static class StringObjectEncoder implements ElementEncoder<Map<String, Collection<Object>>> {
+        @Override
+        public void encode(final List<Map<String, Collection<Object>>> values, final Element parentElement, final String childElementName) {
+            for (final Map<String, Collection<Object>> value : values) {
+                for (final Entry<String, Collection<Object>> parameter : value.entrySet()) {
+                    for (final Object item : parameter.getValue()) {
+                        final Element metaElement = new Element(PARAMETER_ELEMENT_NAME);
+
+                        parentElement.addContent(metaElement);
+                        metaElement.addContent(preserve(protectedElement(NAME_ELEMENT_NAME, parameter.getKey())));
+                        metaElement.addContent(preserve(protectedElement(VALUE_ELEMENT_NAME, item.toString())));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * An implementation of an XML element encoder for Map&lt;String, byte[]&gt;.
+     */
+    public static final ElementEncoder<Map<String, byte[]>> DEFAULT_STRING_BYTE_ARRAY_ENCODER = new StringByteArrayEncoder();
+
+    private static class StringByteArrayEncoder implements ElementEncoder<Map<String, byte[]>> {
+        @Override
+        public void encode(final List<Map<String, byte[]>> values, final Element parentElement, final String childElementName) {
+            for (final Map<String, byte[]> value : values) {
+                for (final Entry<String, byte[]> view : value.entrySet()) {
+                    final Element metaElement = new Element(VIEW_ELEMENT_NAME);
+
+                    parentElement.addContent(metaElement);
+                    metaElement.addContent(preserve(protectedElement(NAME_ELEMENT_NAME, view.getKey())));
+                    metaElement.addContent(preserve(protectedElementBase64(VALUE_ELEMENT_NAME, view.getValue())));
+                }
+            }
+        }
+    }
+
+    /**
+     * The default set of XML element decoders.
+     */
+    public static final ElementDecoders DEFAULT_ELEMENT_DECODERS = new ElementDecoders(
+            DEFAULT_BOOLEAN_DECODER,
+            DEFAULT_BYTE_ARRAY_DECODER,
+            DEFAULT_INTEGER_DECODER,
+            DEFAULT_SEEKABLE_BYTE_CHANNEL_FACTORY_DECODER,
+            DEFAULT_STRING_BYTE_ARRAY_DECODER,
+            DEFAULT_STRING_DECODER,
+            DEFAULT_STRING_OBJECT_DECODER);
+
+    /**
+     * The default set of XML element encoders.
+     */
+    public static final ElementEncoders DEFAULT_ELEMENT_ENCODERS = new ElementEncoders(
+            DEFAULT_BOOLEAN_ENCODER,
+            DEFAULT_BYTE_ARRAY_ENCODER,
+            DEFAULT_INTEGER_ENCODER,
+            DEFAULT_SEEKABLE_BYTE_CHANNEL_FACTORY_ENCODER,
+            DEFAULT_STRING_BYTE_ARRAY_ENCODER,
+            DEFAULT_STRING_ENCODER,
+            DEFAULT_STRING_OBJECT_ENCODER);
+
+    /**
+     * The set of XML element encoders that will sha256 hash the specified element types.
+     */
+    public static final ElementEncoders SHA256_ELEMENT_ENCODERS = new ElementEncoders(
+            DEFAULT_BOOLEAN_ENCODER,
+            DEFAULT_BYTE_ARRAY_ENCODER,
+            DEFAULT_INTEGER_ENCODER,
+            SHA256_SEEKABLE_BYTE_CHANNEL_FACTORY_ENCODER,
+            DEFAULT_STRING_BYTE_ARRAY_ENCODER,
+            DEFAULT_STRING_ENCODER,
+            DEFAULT_STRING_OBJECT_ENCODER);
+
+    private IBaseDataObjectXmlCodecs() {}
+
+    /**
+     * Return UTF8 bytes from an XML value, decoding base64 if required
+     * 
+     * @param encoding e.g. 'base64', otherwise it returns the bytes as they are presented
+     * @param elementValue containing the data
+     * @return the data from elementValue, decoded from base64 if required
+     */
+    public static byte[] extractBytes(final String encoding, final String elementValue) {
+        if (BASE64_ATTRIBUTE_NAME.equalsIgnoreCase(encoding)) {
+            final String newElementValue = elementValue.replace("\n", "");
+            final byte[] bytes = newElementValue.getBytes(StandardCharsets.UTF_8);
+            return BASE64_DECODER.decode(bytes);
+        }
+
+        return elementValue.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static Element preserve(final Element element) {
+        element.setAttribute("space", "preserve", XML_NAMESPACE);
+
+        return element;
+    }
+
+    private static Element protectedElement(final String name, final String string) {
+        return protectedElementBase64(name, string.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Scans a byte array looking for non-printable values.
+     * 
+     * @param bytes the bytes to be scanned.
+     * @return whether or not there were non-printable values.
+     */
+    public static boolean hasNonPrintableValues(final byte[] bytes) {
+        boolean badCharacters = false;
+
+        for (byte aByte : bytes) {
+            if (aByte < 9 || aByte > 13 && aByte < 32) {
+                badCharacters = true;
+                break;
+            }
+        }
+
+        return badCharacters;
+    }
+
+    /**
+     * Creates a 'protected' element which can be encoded with base64 if it contains unsafe characters
+     * 
+     * See method source for specific definition of 'unsafe'.
+     * 
+     * @param name of the element
+     * @param bytes to wrap, if they contain unsafe characters
+     * @return the created element
+     */
+    private static Element protectedElementBase64(final String name, final byte[] bytes) {
+        final Element element = new Element(name);
+
+        if (hasNonPrintableValues(bytes)) {
+            String base64String = BASE64_NEW_LINE_STRING +
+                    BASE64_ENCODER.encodeToString(bytes) +
+                    BASE64_NEW_LINE_STRING;
+
+            element.setAttribute(ENCODING_ATTRIBUTE_NAME, BASE64_ATTRIBUTE_NAME);
+            element.addContent(base64String);
+        } else {
+            element.addContent(new String(bytes, StandardCharsets.ISO_8859_1));
+        }
+
+        return element;
+    }
+
+    /**
+     * Creates a hex string of a sha256 hash for a byte[].
+     * 
+     * @param bytes to be hashed
+     * @return the hex string of a sha256 hash of the bytes.
+     */
+    public static String sha256Bytes(final byte[] bytes) {
+        try {
+            final MessageDigest md = MessageDigest.getInstance("SHA-256");
+            final byte[] hash = md.digest(bytes);
+
+            final StringBuilder hexString = new StringBuilder(2 * hash.length);
+            for (byte b : hash) {
+                final String hex = Integer.toHexString(0xff & b);
+
+                if (hex.length() == 1) {
+                    hexString.append('0');
+                }
+                hexString.append(hex);
+            }
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/emissary/util/ByteUtil.java
+++ b/src/main/java/emissary/util/ByteUtil.java
@@ -1,5 +1,7 @@
 package emissary.util;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -271,6 +273,51 @@ public class ByteUtil {
             ret = new String(data, pos, data.length - pos);
         }
         return ret;
+    }
+
+    /**
+     * Scans a byte array looking for non-printable values.
+     * 
+     * @param bytes the bytes to be scanned.
+     * @return whether or not there were non-printable values.
+     */
+    public static boolean hasNonPrintableValues(final byte[] bytes) {
+        boolean badCharacters = false;
+
+        for (byte aByte : bytes) {
+            if (aByte < 9 || aByte > 13 && aByte < 32) {
+                badCharacters = true;
+                break;
+            }
+        }
+
+        return badCharacters;
+    }
+
+    /**
+     * Creates a hex string of a sha256 hash for a byte[].
+     * 
+     * @param bytes to be hashed
+     * @return the hex string of a sha256 hash of the bytes.
+     */
+    public static String sha256Bytes(final byte[] bytes) {
+        try {
+            final MessageDigest md = MessageDigest.getInstance("SHA-256");
+            final byte[] hash = md.digest(bytes);
+
+            final StringBuilder hexString = new StringBuilder(2 * hash.length);
+            for (byte b : hash) {
+                final String hex = Integer.toHexString(0xff & b);
+
+                if (hex.length() == 1) {
+                    hexString.append('0');
+                }
+                hexString.append(hex);
+            }
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e) {
+            return null;
+        }
     }
 
     /** This class is not meant to be instantiated. */

--- a/src/test/java/emissary/core/IBaseDataObjectHelperTest.java
+++ b/src/test/java/emissary/core/IBaseDataObjectHelperTest.java
@@ -3,6 +3,7 @@ package emissary.core;
 import emissary.core.channels.InMemoryChannelFactory;
 import emissary.kff.KffDataObjectHandler;
 import emissary.parser.SessionParser;
+import emissary.test.core.junit5.UnitTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 
-class IBaseDataObjectHelperTest {
+class IBaseDataObjectHelperTest extends UnitTest {
 
     private IBaseDataObject ibdo1;
     private IBaseDataObject ibdo2;
@@ -54,11 +55,11 @@ class IBaseDataObjectHelperTest {
         ibdo2 = new BaseDataObject();
     }
 
-    private void verifyClone(final String methodName, final IBaseDataObject origObj, final Boolean isSame, final Boolean isEquals,
+    private static void verifyClone(final String methodName, final IBaseDataObject origObj, final Boolean isSame, final Boolean isEquals,
             final Boolean switchWithFullClone) {
         try {
             final Method method = IBaseDataObject.class.getMethod(methodName);
-            final boolean isArrayType = method.getReturnType().getName().equals("[B");
+            final boolean isArrayType = "[B".equals(method.getReturnType().getName());
             final IBaseDataObject cloneFalseObj = IBaseDataObjectHelper.clone(origObj, false);
             final IBaseDataObject cloneTrueObj = IBaseDataObjectHelper.clone(origObj, true);
             verifyCloneAssertions(method, origObj, cloneFalseObj, isSame, isEquals);
@@ -76,8 +77,8 @@ class IBaseDataObjectHelperTest {
         }
     }
 
-    private void verifyCloneAssertions(final Method method, final Object obj1, final Object obj2, final Boolean isSame, final Boolean isEquals)
-            throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+    private static void verifyCloneAssertions(final Method method, final Object obj1, final Object obj2, final Boolean isSame, final Boolean isEquals)
+            throws IllegalAccessException, InvocationTargetException {
         final Object o1 = method.invoke(obj1);
         final Object o2 = method.invoke(obj2);
 
@@ -91,7 +92,7 @@ class IBaseDataObjectHelperTest {
 
         if (isEquals != null) {
             if (isEquals) {
-                if (method.getReturnType().getName().equals("[B")) {
+                if ("[B".equals(method.getReturnType().getName())) {
                     assertArrayEquals((byte[]) o1, (byte[]) o2);
                 } else {
                     assertEquals(o1, o2);
@@ -181,7 +182,7 @@ class IBaseDataObjectHelperTest {
     void testCloneInternalId() {
         verifyClone("getInternalId", ibdo1, IS_NOT_SAME, IS_NOT_EQUALS, EQUAL_AFTER_FULL_CLONE);
         // Now assert that if an exception occurs, the IDs will differ
-        try (final MockedStatic<IBaseDataObjectHelper> helper = Mockito.mockStatic(IBaseDataObjectHelper.class, Mockito.CALLS_REAL_METHODS)) {
+        try (MockedStatic<IBaseDataObjectHelper> helper = Mockito.mockStatic(IBaseDataObjectHelper.class, Mockito.CALLS_REAL_METHODS)) {
             helper.when(() -> IBaseDataObjectHelper.setPrivateFieldValue(any(), any(), any()))
                     .thenThrow(IllegalAccessException.class);
 
@@ -275,7 +276,7 @@ class IBaseDataObjectHelperTest {
         verifyClone("getTransactionId", ibdo1, DONT_CHECK, IS_NOT_EQUALS, EQUAL_AFTER_FULL_CLONE);
     }
 
-    private void checkThrowsNull(final Executable e) {
+    private static void checkThrowsNull(final Executable e) {
         assertThrows(NullPointerException.class, e);
     }
 

--- a/src/test/java/emissary/core/IBaseDataObjectXmlHelperTest.java
+++ b/src/test/java/emissary/core/IBaseDataObjectXmlHelperTest.java
@@ -5,6 +5,7 @@ import emissary.core.channels.InMemoryChannelFactory;
 import emissary.core.channels.SeekableByteChannelFactory;
 import emissary.kff.KffDataObjectHandler;
 import emissary.test.core.junit5.UnitTest;
+import emissary.util.ByteUtil;
 import emissary.util.PlaceComparisonHelper;
 
 import org.jdom2.Document;
@@ -146,7 +147,7 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
         final IBaseDataObject sha256ActualIbdo = ibdoFromXmlFromIbdo(expectedIbdo, expectedChildren, initialIbdo,
                 actualChildren, SHA256_ELEMENT_ENCODERS);
 
-        expectedIbdo.setData(IBaseDataObjectXmlCodecs.sha256Bytes(bytes).getBytes(StandardCharsets.ISO_8859_1));
+        expectedIbdo.setData(ByteUtil.sha256Bytes(bytes).getBytes(StandardCharsets.ISO_8859_1));
 
         final String sha256Diff = PlaceComparisonHelper.checkDifferences(expectedIbdo, sha256ActualIbdo, expectedChildren,
                 actualChildren, "testSha256Conversion", DiffCheckConfiguration.onlyCheckData());

--- a/src/test/java/emissary/core/IBaseDataObjectXmlHelperTest.java
+++ b/src/test/java/emissary/core/IBaseDataObjectXmlHelperTest.java
@@ -1,5 +1,6 @@
 package emissary.core;
 
+import emissary.core.IBaseDataObjectXmlCodecs.ElementEncoders;
 import emissary.core.channels.InMemoryChannelFactory;
 import emissary.core.channels.SeekableByteChannelFactory;
 import emissary.kff.KffDataObjectHandler;
@@ -7,14 +8,12 @@ import emissary.test.core.junit5.UnitTest;
 import emissary.util.PlaceComparisonHelper;
 
 import org.jdom2.Document;
-import org.jdom2.Element;
 import org.jdom2.input.SAXBuilder;
 import org.jdom2.input.sax.XMLReaders;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.StandardCharsets;
@@ -22,6 +21,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import static emissary.core.IBaseDataObjectXmlCodecs.DEFAULT_ELEMENT_DECODERS;
+import static emissary.core.IBaseDataObjectXmlCodecs.DEFAULT_ELEMENT_ENCODERS;
+import static emissary.core.IBaseDataObjectXmlCodecs.SHA256_ELEMENT_ENCODERS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -34,11 +36,18 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
         final List<IBaseDataObject> actualChildren = new ArrayList<>();
 
         final IBaseDataObject actualIbdo = ibdoFromXmlFromIbdo(expectedIbdo, expectedChildren, initialIbdo,
-                actualChildren);
+                actualChildren, DEFAULT_ELEMENT_ENCODERS);
         final String diff = PlaceComparisonHelper.checkDifferences(expectedIbdo, actualIbdo, expectedChildren,
                 actualChildren, "testParentIbdoNoFieldsChanged", DiffCheckConfiguration.onlyCheckData());
 
         assertNull(diff);
+
+        final IBaseDataObject sha256ActualIbdo = ibdoFromXmlFromIbdo(expectedIbdo, expectedChildren, initialIbdo,
+                actualChildren, SHA256_ELEMENT_ENCODERS);
+        final String sha256Diff = PlaceComparisonHelper.checkDifferences(expectedIbdo, sha256ActualIbdo, expectedChildren,
+                actualChildren, "testParentIbdoNoFieldsChangedSha256", DiffCheckConfiguration.onlyCheckData());
+
+        assertNull(sha256Diff);
     }
 
     @Test
@@ -76,11 +85,18 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
         expectedIbdo.addAlternateView("AlternateView2Key", "AlternateView2Value".getBytes(StandardCharsets.ISO_8859_1));
 
         final IBaseDataObject actualIbdo = ibdoFromXmlFromIbdo(expectedIbdo, expectedChildren, initialIbdo,
-                actualChildren);
+                actualChildren, DEFAULT_ELEMENT_ENCODERS);
         final String diff = PlaceComparisonHelper.checkDifferences(expectedIbdo, actualIbdo, expectedChildren,
                 actualChildren, "testParentIbdoAllFieldsChanged", DiffCheckConfiguration.onlyCheckData());
 
         assertNull(diff);
+
+        final IBaseDataObject sha256ActualIbdo = ibdoFromXmlFromIbdo(expectedIbdo, expectedChildren, initialIbdo,
+                actualChildren, SHA256_ELEMENT_ENCODERS);
+        final String sha256Diff = PlaceComparisonHelper.checkDifferences(expectedIbdo, sha256ActualIbdo, expectedChildren,
+                actualChildren, "testParentIbdoAllFieldsChangedSha256", DiffCheckConfiguration.onlyCheckData());
+
+        assertNull(sha256Diff);
     }
 
     @Test
@@ -89,8 +105,9 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
         final IBaseDataObject expectedIbdo = new BaseDataObject();
         final List<IBaseDataObject> expectedChildren = new ArrayList<>();
         final List<IBaseDataObject> actualChildren = new ArrayList<>();
+        final byte[] bytes = "\001Data".getBytes(StandardCharsets.ISO_8859_1);
 
-        expectedIbdo.setData("\001Data".getBytes(StandardCharsets.ISO_8859_1));
+        expectedIbdo.setData(bytes);
         expectedIbdo.setBirthOrder(5);
         expectedIbdo.setBroken("\001Broken1");
         expectedIbdo.setBroken("\001Broken2");
@@ -120,11 +137,21 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
                 "\200AlternateView2Value".getBytes(StandardCharsets.ISO_8859_1));
 
         final IBaseDataObject actualIbdo = ibdoFromXmlFromIbdo(expectedIbdo, expectedChildren, initialIbdo,
-                actualChildren);
+                actualChildren, DEFAULT_ELEMENT_ENCODERS);
         final String diff = PlaceComparisonHelper.checkDifferences(expectedIbdo, actualIbdo, expectedChildren,
                 actualChildren, "testBase64Conversion", DiffCheckConfiguration.onlyCheckData());
 
         assertNull(diff);
+
+        final IBaseDataObject sha256ActualIbdo = ibdoFromXmlFromIbdo(expectedIbdo, expectedChildren, initialIbdo,
+                actualChildren, SHA256_ELEMENT_ENCODERS);
+
+        expectedIbdo.setData(IBaseDataObjectXmlCodecs.sha256Bytes(bytes).getBytes(StandardCharsets.ISO_8859_1));
+
+        final String sha256Diff = PlaceComparisonHelper.checkDifferences(expectedIbdo, sha256ActualIbdo, expectedChildren,
+                actualChildren, "testSha256Conversion", DiffCheckConfiguration.onlyCheckData());
+
+        assertNull(sha256Diff);
     }
 
     @Test
@@ -151,9 +178,9 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
         expectedChildren.add(childIbdo2);
 
         final IBaseDataObject actualIbdo = ibdoFromXmlFromIbdo(expectedIbdo, expectedChildren, initialIbdo,
-                actualChildren);
+                actualChildren, DEFAULT_ELEMENT_ENCODERS);
         final String diff = PlaceComparisonHelper.checkDifferences(expectedIbdo, actualIbdo, expectedChildren,
-                actualChildren, "testBase64Conversion", DiffCheckConfiguration.onlyCheckData());
+                actualChildren, "testAttachmentsAndExtractedRecords", DiffCheckConfiguration.onlyCheckData());
 
         assertNull(diff);
     }
@@ -169,11 +196,18 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
         dataExceptionIbdo.setChannelFactory(new ExceptionChannelFactory());
 
         final IBaseDataObject actualIbdo = ibdoFromXmlFromIbdo(dataExceptionIbdo, expectedChildren, initialIbdo,
-                actualChildren);
+                actualChildren, DEFAULT_ELEMENT_ENCODERS);
         final String diff = PlaceComparisonHelper.checkDifferences(expectedIbdo, actualIbdo, expectedChildren,
                 actualChildren, "testBadChannelFactory", DiffCheckConfiguration.onlyCheckData());
 
         assertNull(diff);
+
+        final IBaseDataObject sha256ActualIbdo = ibdoFromXmlFromIbdo(dataExceptionIbdo, expectedChildren, initialIbdo,
+                actualChildren, SHA256_ELEMENT_ENCODERS);
+        final String sha256Diff = PlaceComparisonHelper.checkDifferences(expectedIbdo, sha256ActualIbdo, expectedChildren,
+                actualChildren, "testBadChannelFactory", DiffCheckConfiguration.onlyCheckData());
+
+        assertNull(sha256Diff);
     }
 
     @Test
@@ -186,40 +220,17 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
 
         priorityIbdo.setPriority(100);
 
-        final String xmlString = IBaseDataObjectXmlHelper.xmlFromIbdo(priorityIbdo, expectedChildren, initialIbdo);
+        final String xmlString = IBaseDataObjectXmlHelper.xmlFromIbdo(priorityIbdo, expectedChildren, initialIbdo, DEFAULT_ELEMENT_ENCODERS);
         final String newXmlString = xmlString.replace("100", "100A");
 
         final SAXBuilder builder = new SAXBuilder(XMLReaders.NONVALIDATING);
         final Document document = builder.build(new StringReader(newXmlString));
-        final IBaseDataObject actualIbdo = IBaseDataObjectXmlHelper.ibdoFromXml(document, actualChildren);
+        final IBaseDataObject actualIbdo = IBaseDataObjectXmlHelper.ibdoFromXml(document, actualChildren, DEFAULT_ELEMENT_DECODERS);
 
         final String diff = PlaceComparisonHelper.checkDifferences(expectedIbdo, actualIbdo, expectedChildren,
                 actualChildren, "testBadChannelFactory", DiffCheckConfiguration.onlyCheckData());
 
         assertNull(diff);
-    }
-
-    @Test
-    void testSetParameterOnIbdoException() throws Exception {
-        final Class<?> keyClass = null;
-        final Class<?> valueClass = int.class;
-        final IBaseDataObject ibdo = new BaseDataObject();
-        final String ibdoMethodName = "methodNotInIbdo";
-        final Object parameter = null;
-        final Element element = null;
-        final List<String> differences = new ArrayList<>();
-        final Method method = IBaseDataObjectXmlHelper.class.getDeclaredMethod("setParameterOnIbdo", Class.class,
-                Class.class, IBaseDataObject.class, String.class, Object.class, Element.class);
-
-        method.setAccessible(true);
-
-        method.invoke(IBaseDataObjectXmlHelper.class, keyClass, valueClass, ibdo, ibdoMethodName, parameter, element);
-
-        method.setAccessible(false);
-
-        IBaseDataObjectDiffHelper.diff(new BaseDataObject(), ibdo, differences, DiffCheckConfiguration.onlyCheckData());
-
-        assertEquals(0, differences.size());
     }
 
     @Test
@@ -254,14 +265,13 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
     }
 
     private static IBaseDataObject ibdoFromXmlFromIbdo(final IBaseDataObject ibdo, final List<IBaseDataObject> children,
-            final IBaseDataObject initialIbdo, final List<IBaseDataObject> outputChildren) throws Exception {
-        final String xmlString = IBaseDataObjectXmlHelper.xmlFromIbdo(ibdo, children, initialIbdo);
+            final IBaseDataObject initialIbdo, final List<IBaseDataObject> outputChildren, final ElementEncoders elementEncoders) throws Exception {
+        final String xmlString = IBaseDataObjectXmlHelper.xmlFromIbdo(ibdo, children, initialIbdo, elementEncoders);
 
         final SAXBuilder builder = new SAXBuilder(XMLReaders.NONVALIDATING);
         final Document document = builder.build(new StringReader(xmlString));
-        final IBaseDataObject ibdo2 = IBaseDataObjectXmlHelper.ibdoFromXml(document, outputChildren);
 
-        return ibdo2;
+        return IBaseDataObjectXmlHelper.ibdoFromXml(document, outputChildren, DEFAULT_ELEMENT_DECODERS);
     }
 
     private static class ExceptionChannelFactory implements SeekableByteChannelFactory {
@@ -279,12 +289,12 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
                 }
 
                 @Override
-                public int read(ByteBuffer dst) throws IOException {
+                public int read(final ByteBuffer dst) throws IOException {
                     throw new IOException("This SBC only throws Exceptions");
                 }
 
                 @Override
-                public int write(ByteBuffer src) throws IOException {
+                public int write(final ByteBuffer src) throws IOException {
                     throw new IOException("This SBC only throws Exceptions");
                 }
 
@@ -294,7 +304,7 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
                 }
 
                 @Override
-                public SeekableByteChannel position(long newPosition) throws IOException {
+                public SeekableByteChannel position(final long newPosition) throws IOException {
                     throw new IOException("This SBC only throws Exceptions");
                 }
 
@@ -304,10 +314,10 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
                 }
 
                 @Override
-                public SeekableByteChannel truncate(long size) throws IOException {
+                public SeekableByteChannel truncate(final long size) throws IOException {
                     throw new IOException("This SBC only throws Exceptions");
                 }
             };
         }
-    };
+    }
 }

--- a/src/test/java/emissary/test/core/junit5/RegressionTest.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTest.java
@@ -5,6 +5,7 @@ import emissary.core.IBaseDataObjectHelper;
 import emissary.core.IBaseDataObjectXmlCodecs;
 import emissary.core.IBaseDataObjectXmlCodecs.ElementDecoders;
 import emissary.core.IBaseDataObjectXmlCodecs.ElementEncoders;
+import emissary.util.ByteUtil;
 
 import com.google.errorprone.annotations.ForOverride;
 import org.jdom2.Document;
@@ -138,8 +139,12 @@ public abstract class RegressionTest extends ExtractionTest {
     @Override
     protected void checkAnswersPreHook(final Document answers, final IBaseDataObject payload, final List<IBaseDataObject> attachments,
             final String tname) {
-        if (payload.data() != null && IBaseDataObjectXmlCodecs.hasNonPrintableValues(payload.data())) {
-            final String hash = IBaseDataObjectXmlCodecs.sha256Bytes(payload.data());
+        if (!IBaseDataObjectXmlCodecs.SHA256_ELEMENT_ENCODERS.equals(getEncoders())) {
+            return;
+        }
+
+        if (payload.data() != null && ByteUtil.hasNonPrintableValues(payload.data())) {
+            final String hash = ByteUtil.sha256Bytes(payload.data());
 
             if (hash != null) {
                 payload.setData(hash.getBytes(StandardCharsets.UTF_8));
@@ -148,8 +153,8 @@ public abstract class RegressionTest extends ExtractionTest {
 
         if (payload.getExtractedRecords() != null) {
             for (final IBaseDataObject extractedRecord : payload.getExtractedRecords()) {
-                if (IBaseDataObjectXmlCodecs.hasNonPrintableValues(extractedRecord.data())) {
-                    final String hash = IBaseDataObjectXmlCodecs.sha256Bytes(extractedRecord.data());
+                if (ByteUtil.hasNonPrintableValues(extractedRecord.data())) {
+                    final String hash = ByteUtil.sha256Bytes(extractedRecord.data());
 
                     if (hash != null) {
                         extractedRecord.setData(hash.getBytes(StandardCharsets.UTF_8));
@@ -160,8 +165,8 @@ public abstract class RegressionTest extends ExtractionTest {
 
         if (attachments != null) {
             for (final IBaseDataObject attachment : attachments) {
-                if (IBaseDataObjectXmlCodecs.hasNonPrintableValues(attachment.data())) {
-                    final String hash = IBaseDataObjectXmlCodecs.sha256Bytes(attachment.data());
+                if (ByteUtil.hasNonPrintableValues(attachment.data())) {
+                    final String hash = ByteUtil.sha256Bytes(attachment.data());
 
                     if (hash != null) {
                         attachment.setData(hash.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
This PR accomplishes the following:
- RegressionTest basic behavior changed to sha256 hash IBDO non-printable data instead of base64'ing it.
- Refactor encoders and decoders into their own class so they can be easily changed.