### PR TITLE
error-prone :: remove unnecessary 'final'

### DIFF
--- a/src/main/java/emissary/core/DiffCheckConfiguration.java
+++ b/src/main/java/emissary/core/DiffCheckConfiguration.java
@@ -88,7 +88,7 @@ public class DiffCheckConfiguration {
      * 
      * @param enabled set of pre-configured options
      */
-    private DiffCheckConfiguration(final EnumSet<DiffCheckOptions> enabled) {
+    private DiffCheckConfiguration(EnumSet<DiffCheckOptions> enabled) {
         this.enabled = enabled;
     }
 
@@ -117,7 +117,7 @@ public class DiffCheckConfiguration {
          * @param options to enable explicitly
          * @return a new Configuration instance with the enabled options
          */
-        public DiffCheckConfiguration explicit(final DiffCheckOptions... options) {
+        public DiffCheckConfiguration explicit(DiffCheckOptions... options) {
             reset();
             building.addAll(Arrays.asList(options));
             return build();

--- a/src/main/java/emissary/core/EmissaryException.java
+++ b/src/main/java/emissary/core/EmissaryException.java
@@ -13,7 +13,7 @@ public class EmissaryException extends Exception {
      * 
      * @param message a string to go along with the exception
      */
-    public EmissaryException(final String message) {
+    public EmissaryException(String message) {
         super(message);
     }
 
@@ -23,7 +23,7 @@ public class EmissaryException extends Exception {
      * @param message a string to go along with the exception
      * @param cause the wrapped exception
      */
-    public EmissaryException(final String message, final Throwable cause) {
+    public EmissaryException(String message, Throwable cause) {
         super(message, cause);
     }
 
@@ -32,7 +32,7 @@ public class EmissaryException extends Exception {
      * 
      * @param cause the wrapped exception
      */
-    public EmissaryException(final Throwable cause) {
+    public EmissaryException(Throwable cause) {
         super("Exception: " + cause.getMessage(), cause);
     }
 }

--- a/src/main/java/emissary/core/IBaseDataObject.java
+++ b/src/main/java/emissary/core/IBaseDataObject.java
@@ -49,14 +49,14 @@ public interface IBaseDataObject {
      * @param offset the index of the first byte to use
      * @param length the number of bytes to use
      */
-    void setData(final byte[] newData, int offset, int length);
+    void setData(byte[] newData, int offset, int length);
 
     /**
      * Set the byte channel factory using whichever implementation is providing access to the data.
      * 
      * @param sbcf the new channel factory to set on this object
      */
-    void setChannelFactory(final SeekableByteChannelFactory sbcf);
+    void setChannelFactory(SeekableByteChannelFactory sbcf);
 
     /**
      * Returns the seekable byte channel factory containing a reference to the data

--- a/src/main/java/emissary/core/MobileAgent.java
+++ b/src/main/java/emissary/core/MobileAgent.java
@@ -95,7 +95,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      * @param threadGroup group we operate it
      * @param threadName symbolic name for this agent thread
      */
-    public MobileAgent(final ThreadGroup threadGroup, final String threadName) {
+    public MobileAgent(ThreadGroup threadGroup, String threadName) {
         logger.debug("Constructing agent {}", threadName);
         this.thread = new Thread(threadGroup, this, threadName);
         this.thread.setPriority(Thread.NORM_PRIORITY);
@@ -195,14 +195,14 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
     /**
      * Set the current place we should kick off with
      */
-    protected synchronized void setArrivalPlace(final IServiceProviderPlace p) {
+    protected synchronized void setArrivalPlace(IServiceProviderPlace p) {
         this.arrivalPlace = p;
     }
 
     /**
      * Set the payload
      */
-    protected synchronized void setPayload(final IBaseDataObject p) {
+    protected synchronized void setPayload(IBaseDataObject p) {
         this.payload = p;
     }
 
@@ -230,11 +230,11 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
         this.visitedPlaces.clear();
     }
 
-    protected void addParallelTrackingInfo(final String t) {
+    protected void addParallelTrackingInfo(String t) {
         this.visitedPlaces.add(t);
     }
 
-    protected boolean checkParallelTrackingFor(final String type) {
+    protected boolean checkParallelTrackingFor(String type) {
         return this.visitedPlaces.contains(type);
     }
 
@@ -251,12 +251,12 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      *
      * @param currentPlaceArg where we are now
      */
-    protected void agentControl(final IServiceProviderPlace currentPlaceArg) {
+    protected void agentControl(IServiceProviderPlace currentPlaceArg) {
         logger.debug("In agentControl {} for {}", currentPlaceArg, this.agentID);
         DirectoryEntry newEntry = currentPlaceArg.getDirectoryEntry();
 
         IServiceProviderPlace currentPlace = currentPlaceArg;
-        final IBaseDataObject mypayload = getPayload();
+        IBaseDataObject mypayload = getPayload();
         int loopCount = 0;
         boolean controlError = false;
 
@@ -337,7 +337,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      * @param place the place we are asking to work for us
      * @param payloadArg the data for the place to operate on
      */
-    protected void atPlace(final IServiceProviderPlace place, final IBaseDataObject payloadArg) {
+    protected void atPlace(IServiceProviderPlace place, IBaseDataObject payloadArg) {
         logger.debug("In atPlace {} with {}", place, payloadArg.shortName());
 
         try (TimedResource timer = resourceWatcherStart(place)) {
@@ -366,7 +366,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
         }
     }
 
-    protected final void checkInterrupt(final IServiceProviderPlace place) {
+    protected final void checkInterrupt(IServiceProviderPlace place) {
         if (Thread.interrupted()) {
             // this should NEVER happen. if it does, we've done something bad
             if (this.thread != Thread.currentThread()) {
@@ -383,7 +383,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
         }
     }
 
-    protected TimedResource resourceWatcherStart(final IServiceProviderPlace place) {
+    protected TimedResource resourceWatcherStart(IServiceProviderPlace place) {
         TimedResource tr = TimedResource.EMPTY;
         // CoordinationPlaces are tracked individually
         if (!(place instanceof CoordinationPlace)) {
@@ -420,7 +420,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      * @param payloadArg the current payload we care about
      * @return the SDE answer from the directory
      */
-    protected DirectoryEntry getNextKey(@Nullable final IServiceProviderPlace place, @Nullable final IBaseDataObject payloadArg) {
+    protected DirectoryEntry getNextKey(@Nullable IServiceProviderPlace place, @Nullable IBaseDataObject payloadArg) {
 
         logger.debug("start getNextKey");
 
@@ -458,7 +458,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
 
         // If we are in the error condition,
         // clean up and try for error drop off
-        final String curKey = payloadArg.currentForm();
+        String curKey = payloadArg.currentForm();
         if (ERROR_FORM.equals(curKey)) {
             if (payloadArg.currentFormSize() > 1 && ERROR_FORM.equals(payloadArg.currentFormAt(1))) {
                 logger.error("ERROR handling place produced an error, purging all current forms");
@@ -484,7 +484,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
         /* Get the last entry from the payload */
         DirectoryEntry lastEntry = payloadArg.getLastPlaceVisited();
 
-        final List<String> dataForms = payloadArg.getAllCurrentForms();
+        List<String> dataForms = payloadArg.getAllCurrentForms();
         logger.debug(">>> Current forms for {} are {}", payloadArg.shortName(), dataForms);
 
         /* Get the last service type from the last key */
@@ -511,7 +511,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
         DirectoryEntry curEntry = null;
         for (int curType = startType; curType < Stage.values().length; curType++) {
             // Search the form stack starting with the top.
-            final String stageName = Stage.getStageName(curType);
+            String stageName = Stage.getStageName(curType);
             for (String form : dataForms) {
 
                 // Test a full key form to see if it is the correct stage to be chosen
@@ -568,14 +568,14 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
     /**
      * Evaluate parallel attribute of specified type index
      */
-    protected boolean isParallelServiceType(final int typeSetPosition) {
+    protected boolean isParallelServiceType(int typeSetPosition) {
         return Stage.isParallelStage(typeSetPosition);
     }
 
     /**
      * Get index in typeSet for specified string, 0 if not found
      */
-    public static int typeLookup(final String s) {
+    public static int typeLookup(String s) {
         Stage stage = Stage.getByName(s);
         int idx = (stage == null) ? 0 : stage.ordinal();
         if (idx < 0) {
@@ -592,14 +592,13 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      * the first one will be returned to the caller. Caller knows to look on the internal queue for additional entries
      * before calling this method again.
      */
-    protected DirectoryEntry nextKeyFromDirectory(final String dataID, final IServiceProviderPlace place, final DirectoryEntry lastEntry,
-            final IBaseDataObject payloadArg) {
+    protected DirectoryEntry nextKeyFromDirectory(String dataID, IServiceProviderPlace place, DirectoryEntry lastEntry, IBaseDataObject payloadArg) {
 
         try {
             logger.debug("Trying nextKey for {} with last={}, atPlace={}", dataID, lastEntry, place);
 
             // Query the directory
-            final List<DirectoryEntry> entries = place.nextKeys(dataID, payloadArg, lastEntry);
+            List<DirectoryEntry> entries = place.nextKeys(dataID, payloadArg, lastEntry);
 
             // Add the entries returned to the queue
             if ((entries != null) && !entries.isEmpty()) {
@@ -627,9 +626,9 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      *
      * @param theID usually comes from the shortName of the payload
      */
-    protected void setAgentID(@Nullable final String theID) {
-        final long t = (System.currentTimeMillis() % 10000);
-        final String id = "Agent-" + t;
+    protected void setAgentID(@Nullable String theID) {
+        long t = (System.currentTimeMillis() % 10000);
+        String id = "Agent-" + t;
         this.agentID = id + "-" + ((theID != null) ? theID : "blah");
     }
 
@@ -642,7 +641,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      * @param arrivalPlaceArg the place we start at
      */
     @Override
-    public synchronized void go(final Object payloadArg, final IServiceProviderPlace arrivalPlaceArg) {
+    public synchronized void go(Object payloadArg, IServiceProviderPlace arrivalPlaceArg) {
         clear();
         go(payloadArg, arrivalPlaceArg, false);
     }
@@ -674,8 +673,8 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      * @param queuedItineraryItems transported itinerary items list of DirectoryEntry
      */
     @Override
-    public synchronized void arrive(final Object dataObject, final IServiceProviderPlace arrivalPlaceArg, final int moveErrorCount,
-            final List<DirectoryEntry> queuedItineraryItems) throws Exception {
+    public synchronized void arrive(Object dataObject, IServiceProviderPlace arrivalPlaceArg, int moveErrorCount,
+            List<DirectoryEntry> queuedItineraryItems) throws Exception {
 
         if (dataObject instanceof IBaseDataObject) {
             clear();
@@ -695,8 +694,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      * @param arrivalPlaceArg the place we start at
      * @param processAtFirstPlace true if we should call process on arrivalPlaceArg
      */
-    protected synchronized void go(@Nullable final Object dataObject, @Nullable final IServiceProviderPlace arrivalPlaceArg,
-            final boolean processAtFirstPlace) {
+    protected synchronized void go(@Nullable Object dataObject, @Nullable IServiceProviderPlace arrivalPlaceArg, boolean processAtFirstPlace) {
         // Check conditions
         if (dataObject != null && !(dataObject instanceof IBaseDataObject)) {
             throw new IllegalArgumentException("Illegal payload sent to MobileAgent, " + "cannot handle " + dataObject.getClass().getName());
@@ -710,7 +708,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
         // can handle the setting of their payload and still
         // be able to use this method
         if (dataObject != null) {
-            final IBaseDataObject d = (IBaseDataObject) dataObject;
+            IBaseDataObject d = (IBaseDataObject) dataObject;
             logger.debug("Setting payload {}", d.shortName());
             setPayload(d);
             setAgentID(d.shortName());
@@ -739,15 +737,15 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      *
      * @param payloadArg the dataobject to work on
      */
-    protected static void purgeNonFinalForms(final IBaseDataObject payloadArg) {
+    protected static void purgeNonFinalForms(IBaseDataObject payloadArg) {
         int i = 0;
         while (i < payloadArg.currentFormSize()) {
-            final String form = payloadArg.getAllCurrentForms().get(i);
+            String form = payloadArg.getAllCurrentForms().get(i);
             if (form.equals(ERROR_FORM)) {
                 i++;
                 continue;
             }
-            final String pseudoKey = payloadArg.currentFormAt(i) + ".SKIP.*.http://Previous_Error_Bypass$100";
+            String pseudoKey = payloadArg.currentFormAt(i) + ".SKIP.*.http://Previous_Error_Bypass$100";
 
             logger.debug("Removed {} because of ERROR.SKIP", payloadArg.currentFormAt(i));
             payloadArg.appendTransformHistory(pseudoKey);
@@ -760,10 +758,10 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      *
      * @param payloadArg the one we just finished with
      */
-    protected void logAgentCompletion(final IBaseDataObject payloadArg) {
+    protected void logAgentCompletion(IBaseDataObject payloadArg) {
         // Keep this at a nice high level, above the debug chatter
-        final Object isProbe = payloadArg.getParameter("DIRECTORY_PROBE");
-        final Logger dest = (isProbe == null) ? logger : probeLogger;
+        Object isProbe = payloadArg.getParameter("DIRECTORY_PROBE");
+        Logger dest = (isProbe == null) ? logger : probeLogger;
 
         if (dest.isInfoEnabled()) {
             dest.info(PayloadUtil.getPayloadDisplayString(payloadArg));
@@ -776,7 +774,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      * @param place where the processing is taking place
      * @param payloadArg the dataobject that is being processed
      */
-    protected void recordHistory(final IServiceProviderPlace place, final IBaseDataObject payloadArg) {
+    protected void recordHistory(IServiceProviderPlace place, IBaseDataObject payloadArg) {
         recordHistory(place.getDirectoryEntry(), payloadArg);
     }
 
@@ -786,11 +784,11 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      * @param placeEntry where the processing is taking place
      * @param payloadArg the dataobject that is being processed
      */
-    protected void recordHistory(final DirectoryEntry placeEntry, final IBaseDataObject payloadArg) {
+    protected void recordHistory(DirectoryEntry placeEntry, IBaseDataObject payloadArg) {
 
         String placeKey = null;
-        final String cf = payloadArg.currentForm();
-        final DirectoryEntry dnew = new DirectoryEntry(placeEntry);
+        String cf = payloadArg.currentForm();
+        DirectoryEntry dnew = new DirectoryEntry(placeEntry);
         if (!KeyManipulator.isKeyComplete(cf)) {
             // Splice this current form into the place key
             // for a proper representation of why we are here
@@ -800,7 +798,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
             // We already have a full key in the current form
             // just need to figure out the current cost
             if (!payloadArg.beforeStart()) {
-                final DirectoryEntry lpv = payloadArg.getLastPlaceVisited();
+                DirectoryEntry lpv = payloadArg.getLastPlaceVisited();
 
                 // Subtract one remote overhead if this represents a move
                 int exp = lpv.getExpense();
@@ -833,7 +831,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      *
      * @param arg the new value for processFirstPlace
      */
-    protected void setProcessFirstPlace(final boolean arg) {
+    protected void setProcessFirstPlace(boolean arg) {
         this.processFirstPlace = arg;
     }
 
@@ -877,7 +875,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      * @param value the maximum number of move failures
      */
     @Override
-    public void setMaxMoveErrors(final int value) {
+    public void setMaxMoveErrors(int value) {
         this.MAX_MOVE_ERRORS = value;
     }
 
@@ -895,7 +893,7 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
      * @param value the new maximum number of steps
      */
     @Override
-    public void setMaxItinerarySteps(final int value) {
+    public void setMaxItinerarySteps(int value) {
         this.MAX_ITINERARY_STEPS = value;
     }
 }

--- a/src/main/java/emissary/core/NamespaceException.java
+++ b/src/main/java/emissary/core/NamespaceException.java
@@ -21,7 +21,7 @@ public class NamespaceException extends emissary.core.EmissaryException {
      * 
      * @param s the message to go along with the exception
      */
-    public NamespaceException(final String s) {
+    public NamespaceException(String s) {
         super(s);
     }
 }

--- a/src/main/java/emissary/core/ResourceException.java
+++ b/src/main/java/emissary/core/ResourceException.java
@@ -15,7 +15,7 @@ public class ResourceException extends EmissaryException {
      * 
      * @param message a string to go along with the exception
      */
-    public ResourceException(final String message) {
+    public ResourceException(String message) {
         super(message);
     }
 
@@ -25,7 +25,7 @@ public class ResourceException extends EmissaryException {
      * @param message a string to go along with the exception
      * @param cause the wrapped exception
      */
-    public ResourceException(final String message, final Throwable cause) {
+    public ResourceException(String message, Throwable cause) {
         super(message, cause);
     }
 
@@ -34,7 +34,7 @@ public class ResourceException extends EmissaryException {
      * 
      * @param cause the wrapped exception
      */
-    public ResourceException(final Throwable cause) {
+    public ResourceException(Throwable cause) {
         super("Exception: " + cause.getMessage(), cause);
     }
 }

--- a/src/main/java/emissary/core/TimedResource.java
+++ b/src/main/java/emissary/core/TimedResource.java
@@ -39,7 +39,7 @@ public class TimedResource implements AutoCloseable {
         timerContext = null;
     }
 
-    public TimedResource(final IMobileAgent agent, final IServiceProviderPlace place, final long allowedDuration, final Timer timer) {
+    public TimedResource(IMobileAgent agent, IServiceProviderPlace place, long allowedDuration, Timer timer) {
         this.started = System.currentTimeMillis();
         this.agent = agent;
         this.payloadCount = agent.payloadCount();

--- a/src/main/java/emissary/core/TransformHistory.java
+++ b/src/main/java/emissary/core/TransformHistory.java
@@ -53,7 +53,7 @@ public class TransformHistory {
      * @see emissary.core.MobileAgent#agentControl
      * @param key the new value to append
      */
-    public void append(final String key) {
+    public void append(String key) {
         append(key, false);
     }
 
@@ -115,7 +115,7 @@ public class TransformHistory {
      */
     public String lastVisit() {
         List<String> historyList = get();
-        final int sz = historyList.size();
+        int sz = historyList.size();
         if (sz == 0) {
             return null;
         }
@@ -129,7 +129,7 @@ public class TransformHistory {
      */
     public String penultimateVisit() {
         List<String> historyList = get();
-        final int sz = historyList.size();
+        int sz = historyList.size();
         if (sz < 2) {
             return null;
         }
@@ -141,8 +141,8 @@ public class TransformHistory {
      *
      * @return true is place has been visited
      */
-    public boolean hasVisited(final String pattern) {
-        for (final String historyValue : get()) {
+    public boolean hasVisited(String pattern) {
+        for (String historyValue : get()) {
             if (KeyManipulator.gmatch(historyValue, pattern)) {
                 return true;
             }
@@ -160,14 +160,14 @@ public class TransformHistory {
         if (historyList.isEmpty()) {
             return true;
         }
-        final String s = historyList.get(historyList.size() - 1);
+        String s = historyList.get(historyList.size() - 1);
         return s.contains(IServiceProviderPlace.SPROUT_KEY);
     }
 
     @Override
     public String toString() {
-        final StringBuilder myOutput = new StringBuilder();
-        final String ls = System.getProperty("line.separator");
+        StringBuilder myOutput = new StringBuilder();
+        String ls = System.getProperty("line.separator");
         myOutput.append("transform history (").append(this.history.size()).append(") :").append(ls);
         history.forEach(x -> myOutput.append(x.toString()).append(ls));
         return myOutput.toString();

--- a/src/main/java/emissary/directory/DirectoryEntry.java
+++ b/src/main/java/emissary/directory/DirectoryEntry.java
@@ -109,7 +109,7 @@ public class DirectoryEntry implements Serializable {
      * @param cost from config file
      * @param quality from config file
      */
-    public DirectoryEntry(final String key, final String description, final int cost, final int quality) {
+    public DirectoryEntry(String key, String description, int cost, int quality) {
         if (logger.isDebugEnabled()) {
             logger.debug("Directory entry: {},{},{},\"{}\"", key, cost, quality, description);
         }
@@ -126,7 +126,7 @@ public class DirectoryEntry implements Serializable {
      * 
      * @param key the key to use
      */
-    public DirectoryEntry(final String key) {
+    public DirectoryEntry(String key) {
         setKey(key);
     }
 
@@ -140,8 +140,7 @@ public class DirectoryEntry implements Serializable {
      * @param description the description
      * @param expense the expense
      */
-    public DirectoryEntry(final String dataType, final String serviceName, final String serviceType, final String serviceLocation,
-            final String description, final int expense) {
+    public DirectoryEntry(String dataType, String serviceName, String serviceType, String serviceLocation, String description, int expense) {
         this.dataType = dataType;
         this.serviceName = serviceName;
         this.serviceType = serviceType;
@@ -162,8 +161,8 @@ public class DirectoryEntry implements Serializable {
      * @param cost the cost of the place
      * @param quality the quality of the place
      */
-    public DirectoryEntry(final String dataType, final String serviceName, final String serviceType, final String serviceLocation,
-            final String description, final int cost, final int quality) {
+    public DirectoryEntry(String dataType, String serviceName, String serviceType, String serviceLocation, String description, int cost,
+            int quality) {
         this.dataType = dataType;
         this.serviceName = serviceName;
         this.serviceType = serviceType;
@@ -184,8 +183,7 @@ public class DirectoryEntry implements Serializable {
      * @param serviceLocation the fourth part of the key
      * @param description the description
      */
-    public DirectoryEntry(final String dataType, final String serviceName, final String serviceType, final String serviceLocation,
-            final String description) {
+    public DirectoryEntry(String dataType, String serviceName, String serviceType, String serviceLocation, String description) {
         this(dataType, serviceName, serviceType, serviceLocation, description, 0, 0);
     }
 
@@ -194,7 +192,7 @@ public class DirectoryEntry implements Serializable {
      * 
      * @param that the entry to copy
      */
-    public DirectoryEntry(final DirectoryEntry that) {
+    public DirectoryEntry(DirectoryEntry that) {
         this(that, !PRESERVE_TIME);
     }
 
@@ -204,7 +202,7 @@ public class DirectoryEntry implements Serializable {
      * @param that the entry to copy
      * @param preserveTime copy the time value also when true
      */
-    DirectoryEntry(final DirectoryEntry that, final boolean preserveTime) {
+    DirectoryEntry(DirectoryEntry that, boolean preserveTime) {
         this.theKey = that.theKey;
         this.serviceType = that.serviceType;
         this.serviceName = that.serviceName;
@@ -234,9 +232,9 @@ public class DirectoryEntry implements Serializable {
      * 
      * @param expense the expense to use
      */
-    protected void setCQEFromExp(final int expense) {
+    protected void setCQEFromExp(int expense) {
         if (expense >= 100) {
-            final int invQual = expense % 100;
+            int invQual = expense % 100;
             this.theQuality = 100 - invQual;
             this.theCost = (expense - invQual) / 100;
         } else {
@@ -280,7 +278,7 @@ public class DirectoryEntry implements Serializable {
     /**
      * Set the quality associated with the entry and force the expese to be recalculated
      */
-    public void setQuality(final int quality) {
+    public void setQuality(int quality) {
         this.theQuality = quality;
         calculateExpense();
     }
@@ -297,7 +295,7 @@ public class DirectoryEntry implements Serializable {
      * 
      * @param cost the new cost
      */
-    public void setCost(final int cost) {
+    public void setCost(int cost) {
         this.theCost = cost;
         calculateExpense();
     }
@@ -307,7 +305,7 @@ public class DirectoryEntry implements Serializable {
      * 
      * @param costIncrement the increment to add
      */
-    public void addCost(final int costIncrement) {
+    public void addCost(int costIncrement) {
         this.theCost += costIncrement;
         calculateExpense();
     }
@@ -318,7 +316,7 @@ public class DirectoryEntry implements Serializable {
      * @see #buildKey
      * @param key the key
      */
-    protected void setKey(final String key) {
+    protected void setKey(String key) {
         this.theKey = KeyManipulator.removeExpense(key);
         this.serviceType = KeyManipulator.getServiceType(this.theKey);
         this.serviceName = KeyManipulator.getServiceName(this.theKey);
@@ -326,7 +324,7 @@ public class DirectoryEntry implements Serializable {
         this.dataID = this.dataType + KeyManipulator.DATAIDSEPARATOR + this.serviceType;
         this.serviceLocation = KeyManipulator.getServiceLocation(key);
         this.serviceHostURL = KeyManipulator.getServiceHostURL(key);
-        final int exp = KeyManipulator.getExpense(key, -1);
+        int exp = KeyManipulator.getExpense(key, -1);
         if (exp > -1) {
             setCQEFromExp(exp);
         }
@@ -349,7 +347,7 @@ public class DirectoryEntry implements Serializable {
      * 
      * @see #getPathWeight()
      */
-    public void setPathWeight(final int value) {
+    public void setPathWeight(int value) {
         this.pathWeight = value;
         if (this.pathWeight < 0) {
             this.pathWeight = 0;
@@ -364,7 +362,7 @@ public class DirectoryEntry implements Serializable {
      * @see #getPathWeight()
      * @param weightIncrement amount to add to weight
      */
-    public void addPathWeight(final int weightIncrement) {
+    public void addPathWeight(int weightIncrement) {
         this.pathWeight += weightIncrement;
         if (this.pathWeight < 0) {
             this.pathWeight = 0;
@@ -376,7 +374,7 @@ public class DirectoryEntry implements Serializable {
      * 
      * @param dataType the new data type
      */
-    public void setDataType(final String dataType) {
+    public void setDataType(String dataType) {
         this.dataType = dataType;
         buildKey();
     }
@@ -386,7 +384,7 @@ public class DirectoryEntry implements Serializable {
      * 
      * @param serviceLocation the new value
      */
-    public void setServiceLocation(final String serviceLocation) {
+    public void setServiceLocation(String serviceLocation) {
         this.serviceLocation = serviceLocation;
         this.serviceHostURL = serviceLocation.substring(0, serviceLocation.lastIndexOf(CLASSSEPARATOR) + 1);
         buildKey();
@@ -397,7 +395,7 @@ public class DirectoryEntry implements Serializable {
      * 
      * @param place the local reference
      */
-    protected void setLocalPlace(final IServiceProviderPlace place) {
+    protected void setLocalPlace(IServiceProviderPlace place) {
         this.localPlace = place;
     }
 
@@ -461,21 +459,21 @@ public class DirectoryEntry implements Serializable {
      * @param that the entry to test
      * @return true if this is better than that
      */
-    public boolean isBetterThan(final DirectoryEntry that) {
+    public boolean isBetterThan(DirectoryEntry that) {
         return this.theExpense < that.getExpense();
     }
 
     /**
      * test if the current dataEntry matches the passed key pattern.
      */
-    public boolean equals(final String pattern) {
+    public boolean equals(String pattern) {
         return equals(pattern.toCharArray());
     }
 
     /**
      * test if the current dataEntry matches the passed key pattern
      */
-    public boolean equals(final char[] pattern) {
+    public boolean equals(char[] pattern) {
         return KeyManipulator.gmatch(this.theKey.toCharArray(), pattern);
     }
 
@@ -484,7 +482,7 @@ public class DirectoryEntry implements Serializable {
      * test if the current dataEntry matches the passed key pattern specifically ignoring cost in the incoming pattern (if
      * any)
      */
-    public boolean equalsIgnoreCost(final String pattern) {
+    public boolean equalsIgnoreCost(String pattern) {
         return equals(KeyManipulator.removeExpense(pattern));
     }
 
@@ -498,7 +496,7 @@ public class DirectoryEntry implements Serializable {
     /**
      * Set a new service type
      */
-    public void setServiceType(final String serviceType) {
+    public void setServiceType(String serviceType) {
         this.serviceType = serviceType;
         buildKey();
     }
@@ -514,7 +512,7 @@ public class DirectoryEntry implements Serializable {
     /**
      * Set a new service name
      */
-    public void setServiceName(final String serviceName) {
+    public void setServiceName(String serviceName) {
         this.serviceName = serviceName;
         buildKey();
     }
@@ -539,7 +537,7 @@ public class DirectoryEntry implements Serializable {
      * @param cost the cost
      * @param quality the quality
      */
-    public static int calculateExpense(final int cost, final int quality) {
+    public static int calculateExpense(int cost, int quality) {
         return (cost * 100) + (100 - quality);
     }
 
@@ -578,8 +576,8 @@ public class DirectoryEntry implements Serializable {
      * 
      * @param proxyKey the replacement key
      */
-    public void proxyFor(final String proxyKey) {
-        final String newKey = KeyManipulator.makeProxyKey(this.theKey, proxyKey, this.theExpense);
+    public void proxyFor(String proxyKey) {
+        String newKey = KeyManipulator.makeProxyKey(this.theKey, proxyKey, this.theExpense);
         setKey(newKey);
     }
 
@@ -595,7 +593,7 @@ public class DirectoryEntry implements Serializable {
      * 
      * @param age the age to be preserved
      */
-    void preserveCopyAge(final long age) {
+    void preserveCopyAge(long age) {
         this.age = age;
     }
 
@@ -604,11 +602,11 @@ public class DirectoryEntry implements Serializable {
      * 
      * @param e a JDOM Element
      */
-    public static DirectoryEntry fromXML(final Element e) {
-        final String key = e.getChildTextTrim(KEY);
-        final String desc = e.getChildTextTrim(DESC);
-        final int cost = JDOMUtil.getChildIntValue(e, COST);
-        final int quality = JDOMUtil.getChildIntValue(e, QUALITY);
+    public static DirectoryEntry fromXML(Element e) {
+        String key = e.getChildTextTrim(KEY);
+        String desc = e.getChildTextTrim(DESC);
+        int cost = JDOMUtil.getChildIntValue(e, COST);
+        int quality = JDOMUtil.getChildIntValue(e, QUALITY);
         return new DirectoryEntry(key, desc, cost, quality);
     }
 
@@ -616,7 +614,7 @@ public class DirectoryEntry implements Serializable {
      * Turn this entry into an xml fragment
      */
     public Element getXML() {
-        final Element root = new Element(ENTRY);
+        Element root = new Element(ENTRY);
         root.addContent(JDOMUtil.simpleElement(KEY, this.theKey));
         root.addContent(JDOMUtil.simpleElement(DESC, this.description));
         root.addContent(JDOMUtil.simpleElement(COST, this.theCost));

--- a/src/main/java/emissary/directory/KeyManipulator.java
+++ b/src/main/java/emissary/directory/KeyManipulator.java
@@ -92,15 +92,15 @@ public class KeyManipulator implements Serializable {
      * @param serviceType the third part of the key
      * @param serviceLocation the fourth part of the key
      */
-    public static String makeKey(final String dataType, final String serviceName, final String serviceType, final String serviceLocation) {
+    public static String makeKey(String dataType, String serviceName, String serviceType, String serviceLocation) {
         return dataType + SEPARATOR + serviceName + SEPARATOR + serviceType + SEPARATOR + serviceLocation;
     }
 
     /**
      * Return the data type field from a dictionary formatted key.
      */
-    public static String getDataType(final String key) {
-        final int firstSeparator = key.indexOf(SEPARATOR);
+    public static String getDataType(String key) {
+        int firstSeparator = key.indexOf(SEPARATOR);
 
         if (firstSeparator >= 0) {
             return key.substring(0, firstSeparator);
@@ -108,12 +108,12 @@ public class KeyManipulator implements Serializable {
         return "";
     }
 
-    public static String getDataID(final String key) {
+    public static String getDataID(String key) {
         return getDataType(key) + DATAIDSEPARATOR + getServiceType(key);
     }
 
-    public static String getServiceTypeFromDataID(final String dataid) {
-        final int pos = dataid.indexOf(DATAIDSEPARATOR);
+    public static String getServiceTypeFromDataID(String dataid) {
+        int pos = dataid.indexOf(DATAIDSEPARATOR);
         if (pos > -1) {
             return dataid.substring(pos + DATAIDSEPARATOR.length());
         }
@@ -123,18 +123,18 @@ public class KeyManipulator implements Serializable {
     /**
      * Performs wildcard (? | *) string matching for dictionary key searches.
      */
-    public static boolean gmatch(final String s, final String p) {
+    public static boolean gmatch(String s, String p) {
         return gmatch2(s.toCharArray(), p.toCharArray(), 0, 0);
     }
 
     /**
      * Performs wildcard (? | *) character array matching for dictionary key searches.
      */
-    public static boolean gmatch(final char[] s, final char[] p) {
+    public static boolean gmatch(char[] s, char[] p) {
         return gmatch2(s, p, 0, 0);
     }
 
-    private static boolean gmatch2(final char[] s, final char[] p, final int spos, final int ppos) {
+    private static boolean gmatch2(char[] s, char[] p, int spos, int ppos) {
         // fastest interpreted version
         if (p.length == ppos) {
             return s.length == spos;
@@ -142,15 +142,15 @@ public class KeyManipulator implements Serializable {
         if (s.length == spos) {
             return false;
         }
-        final char scc = s[spos];
-        final char c = p[ppos];
+        char scc = s[spos];
+        char c = p[ppos];
         if (c == '?') {
             if (scc > 0) {
                 return gmatch2(s, p, spos + 1, ppos + 1);
             }
             return false;
         } else if (c == '*') {
-            final int ppos2 = ppos + 1;
+            int ppos2 = ppos + 1;
             if (p.length == ppos2) {
                 return true;
             }
@@ -176,7 +176,7 @@ public class KeyManipulator implements Serializable {
      *
      * @param key the key to check
      */
-    public static boolean isKeyComplete(final String key) {
+    public static boolean isKeyComplete(String key) {
         if (numTuplesInKey(key) < KeyManipulator.NUMTUPLES) {
             return false;
         }
@@ -189,9 +189,9 @@ public class KeyManipulator implements Serializable {
     /**
      * Return the number of tuples in the Key passed in
      */
-    public static int numTuplesInKey(final String key) {
+    public static int numTuplesInKey(String key) {
         int count = 0;
-        final byte[] keyBytes = key.getBytes();
+        byte[] keyBytes = key.getBytes();
 
         for (int i = 0; i < keyBytes.length; i++) {
             if (keyBytes[i] == KeyManipulator.SEPARATOR) {
@@ -213,16 +213,16 @@ public class KeyManipulator implements Serializable {
      * @param key the putative key
      * @return true if key is valid
      */
-    public static boolean isValid(@Nullable final String key) {
+    public static boolean isValid(@Nullable String key) {
         return (key != null) && (numTuplesInKey(key) == 4);
     }
 
     /**
      * Returns the class name from a dictionary formatted key
      */
-    public static String getServiceClassname(final String key) {
-        final String location = getServiceLocation(key);
-        final int sep = location.lastIndexOf(CLASSSEPARATOR);
+    public static String getServiceClassname(String key) {
+        String location = getServiceLocation(key);
+        int sep = location.lastIndexOf(CLASSSEPARATOR);
 
         if (sep >= 0) {
             return location.substring(sep + 1);
@@ -233,12 +233,12 @@ public class KeyManipulator implements Serializable {
     /**
      * Returns the hostname:port from a dictionary formatted key
      */
-    public static String getServiceHost(final String key) {
-        final String location = getServiceLocation(key);
-        final int ds = location.indexOf(doubleSlash);
+    public static String getServiceHost(String key) {
+        String location = getServiceLocation(key);
+        int ds = location.indexOf(doubleSlash);
 
         if (ds > -1) {
-            final int cs = location.indexOf(CLASSSEPARATOR, ds + 2);
+            int cs = location.indexOf(CLASSSEPARATOR, ds + 2);
 
             if (cs > -1) {
                 return location.substring(ds + 2, cs);
@@ -251,9 +251,9 @@ public class KeyManipulator implements Serializable {
     /**
      * Returns the protocol://hostname:port/ from a dictionary formatted key
      */
-    public static String getServiceHostURL(final String key) {
-        final String location = getServiceLocation(key);
-        final int ds = location.lastIndexOf(CLASSSEPARATOR);
+    public static String getServiceHostURL(String key) {
+        String location = getServiceLocation(key);
+        int ds = location.lastIndexOf(CLASSSEPARATOR);
 
         if (ds > -1) {
             return location.substring(0, ds + 1);
@@ -268,18 +268,18 @@ public class KeyManipulator implements Serializable {
      * @param k2 key for second place
      * @return true if local to each other
      */
-    public static boolean isLocalTo(final String k1, final String k2) {
+    public static boolean isLocalTo(String k1, String k2) {
         return getServiceHostURL(k1).equals(getServiceHostURL(k2));
     }
 
     /**
      * Returns the service location (host:port/className) field from a dictionary formatted key.
      */
-    public static String getServiceLocation(final String key) {
-        final int firstSeparator = key.indexOf(SEPARATOR);
-        final int secondSeparator = key.indexOf(SEPARATOR, firstSeparator + 1);
-        final int thirdSeparator = key.indexOf(SEPARATOR, secondSeparator + 1);
-        final int fourthSeparator = key.indexOf(DOLLAR, thirdSeparator + 1);
+    public static String getServiceLocation(String key) {
+        int firstSeparator = key.indexOf(SEPARATOR);
+        int secondSeparator = key.indexOf(SEPARATOR, firstSeparator + 1);
+        int thirdSeparator = key.indexOf(SEPARATOR, secondSeparator + 1);
+        int fourthSeparator = key.indexOf(DOLLAR, thirdSeparator + 1);
 
         if ((thirdSeparator >= 0)) {
             if (fourthSeparator > 0) {
@@ -293,12 +293,12 @@ public class KeyManipulator implements Serializable {
     /**
      * Return the expense of the service
      */
-    public static int getExpense(final String key) {
+    public static int getExpense(String key) {
         return getExpense(key, -1);
     }
 
-    public static int getExpense(final String key, final int dflt) {
-        final int pos = key.lastIndexOf(DOLLAR);
+    public static int getExpense(String key, int dflt) {
+        int pos = key.lastIndexOf(DOLLAR);
         int expense = dflt;
         try {
             expense = Integer.parseInt(key.substring(pos + 1));
@@ -311,7 +311,7 @@ public class KeyManipulator implements Serializable {
     /**
      * Add expense record onto a key
      */
-    public static String addExpense(final String key, final int expense) {
+    public static String addExpense(String key, int expense) {
         if (getExpense(key, -99) == expense) {
             return key;
         }
@@ -329,8 +329,8 @@ public class KeyManipulator implements Serializable {
      * @param key any key
      * @return the modified key
      */
-    public static String removeExpense(final String key) {
-        final int pos = key.indexOf(DOLLAR);
+    public static String removeExpense(String key) {
+        int pos = key.indexOf(DOLLAR);
         if (pos != -1) {
             return key.substring(0, pos);
         }
@@ -340,9 +340,9 @@ public class KeyManipulator implements Serializable {
     /**
      * Returns the service name field from a dictionary formatted key.
      */
-    public static String getServiceName(final String key) {
-        final int firstSeparator = key.indexOf(SEPARATOR);
-        final int secondSeparator = key.indexOf(SEPARATOR, firstSeparator + 1);
+    public static String getServiceName(String key) {
+        int firstSeparator = key.indexOf(SEPARATOR);
+        int secondSeparator = key.indexOf(SEPARATOR, firstSeparator + 1);
 
         if ((firstSeparator >= 0) && (secondSeparator >= 0)) {
             return key.substring(firstSeparator + 1, secondSeparator);
@@ -353,10 +353,10 @@ public class KeyManipulator implements Serializable {
     /**
      * Returns the service type field from a dictionary formatted key.
      */
-    public static String getServiceType(final String key) {
-        final int firstSeparator = key.indexOf(SEPARATOR);
-        final int secondSeparator = key.indexOf(SEPARATOR, firstSeparator + 1);
-        final int thirdSeparator = key.indexOf(SEPARATOR, secondSeparator + 1);
+    public static String getServiceType(String key) {
+        int firstSeparator = key.indexOf(SEPARATOR);
+        int secondSeparator = key.indexOf(SEPARATOR, firstSeparator + 1);
+        int thirdSeparator = key.indexOf(SEPARATOR, secondSeparator + 1);
 
         if ((secondSeparator >= 0) && (thirdSeparator >= 0)) {
             return key.substring(secondSeparator + 1, thirdSeparator);
@@ -371,7 +371,7 @@ public class KeyManipulator implements Serializable {
      * @param to the key we went to
      * @return the &quot;to&quot; key with remote overhead or as it was
      */
-    public static String addRemoteCostIfMoved(final String from, final String to) {
+    public static String addRemoteCostIfMoved(String from, String to) {
 
         // If no move, just return the "to" key
         if (getServiceHost(from).equals(getServiceHost(to))) {
@@ -391,11 +391,11 @@ public class KeyManipulator implements Serializable {
      * @return a key with the original data type, service type and service name and expense but the new place location from
      *         proxyKey
      */
-    public static String makeProxyKey(final String origKey, final String proxyKey, final int dfltExp) {
+    public static String makeProxyKey(String origKey, String proxyKey, int dfltExp) {
         if (isLocalTo(origKey, proxyKey) && dfltExp > -1) {
             return addExpense(origKey, getExpense(origKey, dfltExp));
         }
-        final int newExp = getExpense(origKey, dfltExp);
+        int newExp = getExpense(origKey, dfltExp);
         return getDataType(origKey) + SEPARATOR + getServiceName(origKey) + SEPARATOR + getServiceType(origKey) + SEPARATOR
                 + getServiceLocation(proxyKey) + (newExp > -1 ? (DOLLAR + newExp) : "");
     }
@@ -405,16 +405,16 @@ public class KeyManipulator implements Serializable {
      *
      * @param key the key of the place to find a directory for
      */
-    public static String getDefaultDirectoryKey(final String key) {
+    public static String getDefaultDirectoryKey(String key) {
         return WILDCARD_THREE + KeyManipulator.getServiceHostURL(key) + "DirectoryPlace";
     }
 
 
-    public static String getHostMatchKey(final String key) {
+    public static String getHostMatchKey(String key) {
         return WILDCARD_THREE + KeyManipulator.getServiceHostURL(key) + "*";
     }
 
-    public static void main(final String[] argv) {
+    public static void main(String[] argv) {
         String temp = "UNKNOWN.place.ID.tcp://host.domain.com:8001/thePlace$5050";
         String pat = "UNKNOWN.place.*";
 
@@ -434,14 +434,14 @@ public class KeyManipulator implements Serializable {
             System.out.println("ClassName  : " + getServiceClassname(temp));
             System.out.println("Expense    : " + getExpense(temp));
             System.out.println("Default Directory  : " + getDefaultDirectoryKey(temp));
-            final String hckey = getHostMatchKey(temp);
+            String hckey = getHostMatchKey(temp);
             System.out.println("Host match key : " + hckey + (gmatch(temp, hckey) ? " matches" : " does not match"));
         } else {
             System.out.println(" --- no match ---");
         }
     }
 
-    public static String makeSproutKey(final String placeKey) {
+    public static String makeSproutKey(String placeKey) {
         return "*.*." + IServiceProviderPlace.SPROUT_KEY + "." + getServiceLocation(placeKey) + DOLLAR + "0";
     }
 

--- a/src/main/java/emissary/id/WorkUnit.java
+++ b/src/main/java/emissary/id/WorkUnit.java
@@ -21,17 +21,17 @@ public class WorkUnit implements Serializable {
 
     public WorkUnit() {}
 
-    public WorkUnit(final String filename, final byte[] data) {
+    public WorkUnit(String filename, byte[] data) {
         setFilename(filename);
         setData(data);
     }
 
-    public WorkUnit(final String filename, final byte[] data, final String currentForm) {
+    public WorkUnit(String filename, byte[] data, String currentForm) {
         this(filename, data);
         setCurrentForm(currentForm);
     }
 
-    public WorkUnit(final String f, final byte[] hd, final byte[] data, final byte[] ft, final String currentForm) {
+    public WorkUnit(String f, byte[] hd, byte[] data, byte[] ft, String currentForm) {
         setFilename(f);
         setHeader(hd);
         setData(data);
@@ -53,7 +53,7 @@ public class WorkUnit implements Serializable {
      *
      * @param argFilename Value to assign to this.filename
      */
-    public void setFilename(final String argFilename) {
+    public void setFilename(String argFilename) {
         this.filename = argFilename;
     }
 
@@ -71,7 +71,7 @@ public class WorkUnit implements Serializable {
      *
      * @param argData Value to assign to this.data
      */
-    public void setData(final byte[] argData) {
+    public void setData(byte[] argData) {
         this.data = argData;
     }
 
@@ -89,7 +89,7 @@ public class WorkUnit implements Serializable {
      *
      * @param argCurrentForm Value to assign to this.currentForm
      */
-    public void setCurrentForm(final String argCurrentForm) {
+    public void setCurrentForm(String argCurrentForm) {
         this.currentForm = argCurrentForm;
     }
 
@@ -107,7 +107,7 @@ public class WorkUnit implements Serializable {
      *
      * @param argHeader Value to assign to this.header[]
      */
-    public void setHeader(final byte[] argHeader) {
+    public void setHeader(byte[] argHeader) {
         this.header = argHeader;
     }
 
@@ -125,28 +125,28 @@ public class WorkUnit implements Serializable {
      *
      * @param argFooter Value to assign to this.footer[]
      */
-    public void setFooter(final byte[] argFooter) {
+    public void setFooter(byte[] argFooter) {
         this.footer = argFooter;
     }
 
     /**
      * Add a parameter to control the work
      */
-    public void addParameter(final String key, final String value) {
+    public void addParameter(String key, String value) {
         this.params.put(key, value);
     }
 
     /**
      * Add a bunch of parameters to control the work
      */
-    public void addParameters(final Map<String, String> m) {
+    public void addParameters(Map<String, String> m) {
         this.params.putAll(m);
     }
 
     /**
      * Retrieve a parameter
      */
-    public String getParameter(final String key) {
+    public String getParameter(String key) {
         return this.params.get(key);
     }
 

--- a/src/main/java/emissary/util/DataUtil.java
+++ b/src/main/java/emissary/util/DataUtil.java
@@ -33,8 +33,8 @@ public class DataUtil {
      * @param d data object to have form pushed into
      * @param forms that are pushed into current forms if not already present
      */
-    public static void pushDedupedForms(final IBaseDataObject d, final Collection<String> forms) {
-        for (final String f : forms) {
+    public static void pushDedupedForms(IBaseDataObject d, Collection<String> forms) {
+        for (String f : forms) {
             pushDedupedForm(d, f);
         }
     }
@@ -45,7 +45,7 @@ public class DataUtil {
      * @param d data object to have form pushed into
      * @param form that are pushed into current forms if not already present
      */
-    public static void pushDedupedForm(final IBaseDataObject d, final String form) {
+    public static void pushDedupedForm(IBaseDataObject d, String form) {
         if (d.searchCurrentForm(form) == -1) {
             d.pushCurrentForm(form);
         }
@@ -57,15 +57,15 @@ public class DataUtil {
      * @param d the data object
      * @return true if d is not null and not empty
      */
-    public static boolean isNotEmpty(@Nullable final IBaseDataObject d) {
+    public static boolean isNotEmpty(@Nullable IBaseDataObject d) {
         return (d != null) && !isEmpty(d);
     }
 
     /**
      * Return true if the data slot is empty or just whitespace and/or control chars
      */
-    public static boolean isEmpty(final IBaseDataObject d) {
-        final byte[] data = d.data();
+    public static boolean isEmpty(IBaseDataObject d) {
+        byte[] data = d.data();
         return isEmpty(data);
     }
 
@@ -75,15 +75,15 @@ public class DataUtil {
      * @param data array to check
      * @return true if data is null or devoid of real characters
      */
-    public static boolean isEmpty(@Nullable final byte[] data) {
+    public static boolean isEmpty(@Nullable byte[] data) {
         return (data == null) || (data.length == 0);
     }
 
     /**
      * Return true if the data slot is empty or just one whitespace character
      */
-    public static boolean isEmpty(final WorkUnit u) {
-        final byte[] data = u.getData();
+    public static boolean isEmpty(WorkUnit u) {
+        byte[] data = u.getData();
         return isEmpty(data);
     }
 
@@ -92,7 +92,7 @@ public class DataUtil {
      * 
      * @param d the object to set as empty
      */
-    public static void setEmptySession(final IBaseDataObject d) {
+    public static void setEmptySession(IBaseDataObject d) {
         d.setCurrentForm(Form.EMPTY);
         d.setFileTypeIfEmpty(Form.EMPTY);
     }
@@ -100,8 +100,8 @@ public class DataUtil {
     /**
      * Escape a string so it is suitable for use in a CSV record
      */
-    public static String csvescape(final String field) {
-        final String SEP = ",";
+    public static String csvescape(String field) {
+        String SEP = ",";
         String s = field;
         if ((s != null) && (s.contains("\n") || s.contains("\r"))) {
             s = NL_REPL.matcher(s).replaceAll(" ");
@@ -122,7 +122,7 @@ public class DataUtil {
      * @return event date
      */
     @Deprecated
-    public static Calendar getEventDate(final IBaseDataObject payload) {
+    public static Calendar getEventDate(IBaseDataObject payload) {
         String evDate = payload.getStringParameter(EVENT_DATE);
         if (evDate == null) {
             evDate = payload.getStringParameter(FILE_DATE);
@@ -148,8 +148,8 @@ public class DataUtil {
      * @return specified time UTC calendar
      */
     @Deprecated
-    public static Calendar getCal(final Date eventDate) {
-        final Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+    public static Calendar getCal(Date eventDate) {
+        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         cal.setTime(eventDate);
         return cal;
     }
@@ -158,8 +158,8 @@ public class DataUtil {
      * Merge two maps with semicolon delimited lists as values
      */
     @Deprecated
-    public static void merge(final Map<String, String> info, final Map<String, String> recordInfo) {
-        for (final Map.Entry<String, String> entry : recordInfo.entrySet()) {
+    public static void merge(Map<String, String> info, Map<String, String> recordInfo) {
+        for (Map.Entry<String, String> entry : recordInfo.entrySet()) {
             addInfo(info, entry.getKey(), entry.getValue());
         }
     }
@@ -172,9 +172,9 @@ public class DataUtil {
      * @param value the newly arriving value
      */
     @Deprecated
-    public static void addInfo(final Map<String, String> info, final String key, final String value) {
+    public static void addInfo(Map<String, String> info, String key, String value) {
         if (info.containsKey(key)) {
-            final Set<String> existingValues = split(info.get(key));
+            Set<String> existingValues = split(info.get(key));
             existingValues.addAll(split(value));
             info.put(key, join(existingValues));
         } else {
@@ -191,9 +191,9 @@ public class DataUtil {
      * @return strings in list
      */
     @Deprecated
-    public static Set<String> split(final String values) {
-        final Set<String> valuesSet = new HashSet<>();
-        final String[] items = SEMICOLON_SPLIT.split(values);
+    public static Set<String> split(String values) {
+        Set<String> valuesSet = new HashSet<>();
+        String[] items = SEMICOLON_SPLIT.split(values);
         valuesSet.addAll(Arrays.asList(items));
         return valuesSet;
     }
@@ -206,8 +206,8 @@ public class DataUtil {
      * @param sort true if the output should be sorted
      */
     @Deprecated
-    public static String join(final Collection<String> values, final String delim, final boolean sort) {
-        final Collection<String> tojoin;
+    public static String join(Collection<String> values, String delim, boolean sort) {
+        Collection<String> tojoin;
         if (sort) {
             tojoin = new TreeSet<>();
             tojoin.addAll(values);
@@ -215,8 +215,8 @@ public class DataUtil {
             tojoin = values;
         }
 
-        final StringBuilder sb = new StringBuilder();
-        for (final String v : tojoin) {
+        StringBuilder sb = new StringBuilder();
+        for (String v : tojoin) {
             if (sb.length() > 0) {
                 sb.append(delim);
             }
@@ -232,7 +232,7 @@ public class DataUtil {
      * @param delim the string delimiter to use
      */
     @Deprecated
-    public static String join(final Collection<String> values, final String delim) {
+    public static String join(Collection<String> values, String delim) {
         return join(values, delim, true);
     }
 
@@ -242,7 +242,7 @@ public class DataUtil {
      * @param values the collection to join
      */
     @Deprecated
-    public static String join(final Collection<String> values) {
+    public static String join(Collection<String> values) {
         return join(values, IBaseDataObject.DEFAULT_PARAM_SEPARATOR, true);
     }
 
@@ -253,8 +253,8 @@ public class DataUtil {
      * @param map key-value pairs to merge
      */
     @Deprecated
-    public static void mergeMap(final IBaseDataObject parent, final Map<String, String> map) {
-        for (final Map.Entry<String, String> e : map.entrySet()) {
+    public static void mergeMap(IBaseDataObject parent, Map<String, String> map) {
+        for (Map.Entry<String, String> e : map.entrySet()) {
             mergeParameter(parent, e.getKey(), e.getValue());
         }
     }
@@ -268,12 +268,12 @@ public class DataUtil {
      * @param val String to append if not already in parents values
      */
     @Deprecated
-    public static void mergeParameter(final IBaseDataObject parent, final String key, final String val) {
+    public static void mergeParameter(IBaseDataObject parent, String key, String val) {
         String param;
         if (parent.hasParameter(key)) {
             param = parent.getStringParameter(key);
-            final Set<String> oldvals = split(param);
-            final Set<String> newvals = split(val);
+            Set<String> oldvals = split(param);
+            Set<String> newvals = split(val);
             newvals.addAll(oldvals);
             param = join(newvals);
         } else {
@@ -289,8 +289,8 @@ public class DataUtil {
      * @param target to copy to
      * @param keys array of metadata keys to copy
      */
-    public static void copyParams(final IBaseDataObject source, final IBaseDataObject target, final String[] keys) {
-        for (final String k : keys) {
+    public static void copyParams(IBaseDataObject source, IBaseDataObject target, String[] keys) {
+        for (String k : keys) {
             copyParam(source, target, k);
         }
     }
@@ -302,8 +302,8 @@ public class DataUtil {
      * @param target to copy to
      * @param keys collection of metadata keys to copy
      */
-    public static void copyParams(final IBaseDataObject source, final IBaseDataObject target, final Collection<String> keys) {
-        for (final String k : keys) {
+    public static void copyParams(IBaseDataObject source, IBaseDataObject target, Collection<String> keys) {
+        for (String k : keys) {
             copyParam(source, target, k);
         }
     }
@@ -315,8 +315,8 @@ public class DataUtil {
      * @param target to copy to
      * @param key metadata key to copy
      */
-    public static void copyParam(final IBaseDataObject source, final IBaseDataObject target, final String key) {
-        final Object value = source.getParameter(key);
+    public static void copyParam(IBaseDataObject source, IBaseDataObject target, String key) {
+        Object value = source.getParameter(key);
         if (value != null) {
             target.setParameter(key, value);
         }
@@ -328,7 +328,7 @@ public class DataUtil {
      * @param dataobj to be set
      * @param form added as current form and filetype for dataobj
      */
-    public static void setCurrentFormAndFiletype(final IBaseDataObject dataobj, final String form) {
+    public static void setCurrentFormAndFiletype(IBaseDataObject dataobj, String form) {
         dataobj.pushCurrentForm(form);
         dataobj.setFileType(form);
     }


### PR DESCRIPTION
Addresses:
[WARNING]
[UnnecessaryFinal] Since Java 8, it's been unnecessary to make local variables and parameters `final` for use in lambdas or anonymous classes. Marking them as `final` is weakly discouraged, as it adds a fair amount of noise for minimal benefit.
    (see https://errorprone.info/bugpattern/UnnecessaryFinal)