### PR TITLE
Migrate HttpClient from 4.x to 5.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
     <dep.errorprone.version>2.10.0</dep.errorprone.version>
     <dep.gson.version>2.8.9</dep.gson.version>
     <dep.guava.version>32.0.0-jre</dep.guava.version>
-    <dep.httpclient.version>4.5.13</dep.httpclient.version>
-    <dep.httpcore.version>4.4.15</dep.httpcore.version>
+    <dep.httpclient.version>5.2.1</dep.httpclient.version>
+    <dep.httpcore.version>5.2.1</dep.httpcore.version>
     <dep.impsort.version>1.6.2</dep.impsort.version>
     <dep.jackson.version>2.13.4</dep.jackson.version>
     <dep.jakarta.activation-api.version>1.2.2</dep.jakarta.activation-api.version>
@@ -243,13 +243,13 @@
         <version>${dep.commons-pool2.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
         <version>${dep.httpclient.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpcore</artifactId>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
         <version>${dep.httpcore.version}</version>
       </dependency>
       <dependency>
@@ -506,8 +506,8 @@
       <artifactId>commons-pool2</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
     </dependency>
     <dependency>
       <groupId>org.codehaus.janino</groupId>

--- a/src/main/java/emissary/client/EmissaryResponse.java
+++ b/src/main/java/emissary/client/EmissaryResponse.java
@@ -4,10 +4,10 @@ import emissary.client.response.BaseEntity;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpHeaders;
-import org.apache.http.HttpResponse;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.eclipse.jetty.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,10 +27,10 @@ public class EmissaryResponse {
     final Header[] headers;
     final ObjectMapper objectMapper = new ObjectMapper();
 
-    public EmissaryResponse(HttpResponse response) {
-        int tempStatus = response.getStatusLine().getStatusCode();
+    public EmissaryResponse(ClassicHttpResponse response) {
+        int tempStatus = response.getCode();
         String tempContent;
-        headers = response.getAllHeaders();
+        headers = response.getHeaders();
         Header[] contentHeaders = response.getHeaders(HttpHeaders.CONTENT_TYPE);
         if (contentHeaders.length > 0) {
             contentType = contentHeaders[0].getValue();

--- a/src/main/java/emissary/client/HTTPConnectionFactory.java
+++ b/src/main/java/emissary/client/HTTPConnectionFactory.java
@@ -5,19 +5,18 @@ import emissary.config.Configurator;
 import emissary.util.PkiUtil;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.http.ConnectionReuseStrategy;
-import org.apache.http.config.Registry;
-import org.apache.http.config.RegistryBuilder;
-import org.apache.http.conn.socket.ConnectionSocketFactory;
-import org.apache.http.conn.socket.PlainConnectionSocketFactory;
-import org.apache.http.conn.ssl.DefaultHostnameVerifier;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.impl.DefaultConnectionReuseStrategy;
-import org.apache.http.impl.NoConnectionReuseStrategy;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.ConnectionReuseStrategy;
+import org.apache.hc.core5.http.config.Registry;
+import org.apache.hc.core5.http.config.RegistryBuilder;
+import org.apache.hc.core5.http.impl.DefaultConnectionReuseStrategy;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
@@ -96,7 +95,8 @@ public class HTTPConnectionFactory {
             final Configurator cfg = config == null ? ConfigUtil.getConfigInfo(HTTPConnectionFactory.class) : config;
             // if someone doesn't want keep alives...
             if (!cfg.findBooleanEntry(CFG_HTTP_KEEPALIVE, DFLT_KEEPALIVE)) {
-                this.connReuseStrategy = NoConnectionReuseStrategy.INSTANCE;
+                this.connReuseStrategy = DefaultConnectionReuseStrategy.INSTANCE;
+                ;
             }
             this.maxConns = cfg.findIntEntry(CFG_HTTP_MAXCONNS, DFLT_MAXCONNS);
             this.userAgent = cfg.findStringEntry(CFG_HTTP_AGENT, DEFAULT_HTTP_AGENT);

--- a/src/main/java/emissary/client/HTTPConnectionFactory.java
+++ b/src/main/java/emissary/client/HTTPConnectionFactory.java
@@ -5,6 +5,7 @@ import emissary.config.Configurator;
 import emissary.util.PkiUtil;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.hc.client5.http.impl.DefaultClientConnectionReuseStrategy;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
@@ -16,7 +17,6 @@ import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.apache.hc.core5.http.ConnectionReuseStrategy;
 import org.apache.hc.core5.http.config.Registry;
 import org.apache.hc.core5.http.config.RegistryBuilder;
-import org.apache.hc.core5.http.impl.DefaultConnectionReuseStrategy;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
@@ -78,7 +78,7 @@ public class HTTPConnectionFactory {
 
     final PoolingHttpClientConnectionManager connMan;
 
-    private ConnectionReuseStrategy connReuseStrategy = DefaultConnectionReuseStrategy.INSTANCE;
+    private ConnectionReuseStrategy connReuseStrategy = DefaultClientConnectionReuseStrategy.INSTANCE;
 
     int maxConns = DFLT_MAXCONNS;
 
@@ -95,8 +95,7 @@ public class HTTPConnectionFactory {
             final Configurator cfg = config == null ? ConfigUtil.getConfigInfo(HTTPConnectionFactory.class) : config;
             // if someone doesn't want keep alives...
             if (!cfg.findBooleanEntry(CFG_HTTP_KEEPALIVE, DFLT_KEEPALIVE)) {
-                this.connReuseStrategy = DefaultConnectionReuseStrategy.INSTANCE;
-                ;
+                this.connReuseStrategy = (httpRequest, httpResponse, httpContext) -> false;
             }
             this.maxConns = cfg.findIntEntry(CFG_HTTP_MAXCONNS, DFLT_MAXCONNS);
             this.userAgent = cfg.findStringEntry(CFG_HTTP_AGENT, DEFAULT_HTTP_AGENT);

--- a/src/main/java/emissary/command/AgentsCommand.java
+++ b/src/main/java/emissary/command/AgentsCommand.java
@@ -3,7 +3,7 @@ package emissary.command;
 import emissary.client.EmissaryClient;
 import emissary.client.response.AgentsResponseEntity;
 
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import picocli.CommandLine.Command;
 
 import static emissary.server.api.Agents.AGENTS_ENDPOINT;

--- a/src/main/java/emissary/command/ConfigCommand.java
+++ b/src/main/java/emissary/command/ConfigCommand.java
@@ -5,7 +5,7 @@ import emissary.client.response.ConfigsResponseEntity;
 import emissary.server.api.Configs;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;

--- a/src/main/java/emissary/command/DirectoryCommand.java
+++ b/src/main/java/emissary/command/DirectoryCommand.java
@@ -3,7 +3,7 @@ package emissary.command;
 import emissary.client.EmissaryClient;
 import emissary.client.response.DirectoryResponseEntity;
 
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import picocli.CommandLine.Command;
 
 import static emissary.server.api.Directories.DIRECTORIES_ENDPOINT;

--- a/src/main/java/emissary/command/EnvCommand.java
+++ b/src/main/java/emissary/command/EnvCommand.java
@@ -4,7 +4,7 @@ import emissary.client.EmissaryClient;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;

--- a/src/main/java/emissary/command/HttpCommand.java
+++ b/src/main/java/emissary/command/HttpCommand.java
@@ -6,8 +6,8 @@ import emissary.command.converter.FileExistsConverter;
 import emissary.directory.EmissaryNode;
 
 import com.google.common.net.HostAndPort;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Option;

--- a/src/main/java/emissary/command/PoolCommand.java
+++ b/src/main/java/emissary/command/PoolCommand.java
@@ -3,7 +3,7 @@ package emissary.command;
 import emissary.client.EmissaryClient;
 import emissary.client.response.MapResponseEntity;
 
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import picocli.CommandLine.Command;
 
 import static emissary.server.api.Pool.POOL_ENDPOINT;

--- a/src/main/java/emissary/command/TopologyCommand.java
+++ b/src/main/java/emissary/command/TopologyCommand.java
@@ -3,7 +3,7 @@ package emissary.command;
 import emissary.client.EmissaryClient;
 import emissary.client.response.PeersResponseEntity;
 
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;

--- a/src/main/java/emissary/directory/HeartbeatManager.java
+++ b/src/main/java/emissary/directory/HeartbeatManager.java
@@ -6,10 +6,10 @@ import emissary.core.Namespace;
 import emissary.core.NamespaceException;
 import emissary.server.mvc.adapters.HeartbeatAdapter;
 
-import org.apache.http.NameValuePair;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.message.BasicNameValuePair;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/emissary/pickup/WorkSpace.java
+++ b/src/main/java/emissary/pickup/WorkSpace.java
@@ -19,7 +19,7 @@ import emissary.server.mvc.adapters.WorkSpaceAdapter;
 import emissary.util.Version;
 import emissary.util.io.FileFind;
 
-import org.apache.http.HttpStatus;
+import org.apache.hc.core5.http.HttpStatus;
 import org.eclipse.jetty.server.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/emissary/server/EmissaryServer.java
+++ b/src/main/java/emissary/server/EmissaryServer.java
@@ -24,7 +24,7 @@ import emissary.spi.SPILoader;
 
 import ch.qos.logback.classic.ViewStatusMessagesServlet;
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;

--- a/src/main/java/emissary/server/api/Agents.java
+++ b/src/main/java/emissary/server/api/Agents.java
@@ -12,7 +12,7 @@ import emissary.directory.EmissaryNode;
 import emissary.pool.MobileAgentFactory;
 import emissary.server.EmissaryServer;
 
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/emissary/server/api/Peers.java
+++ b/src/main/java/emissary/server/api/Peers.java
@@ -5,7 +5,7 @@ import emissary.client.response.PeerList;
 import emissary.client.response.PeersResponseEntity;
 import emissary.core.EmissaryException;
 
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/emissary/server/api/Places.java
+++ b/src/main/java/emissary/server/api/Places.java
@@ -8,7 +8,7 @@ import emissary.core.Namespace;
 import emissary.directory.EmissaryNode;
 import emissary.server.EmissaryServer;
 
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/emissary/server/api/Pool.java
+++ b/src/main/java/emissary/server/api/Pool.java
@@ -10,7 +10,7 @@ import emissary.pool.AgentPool;
 import emissary.pool.MobileAgentFactory;
 import emissary.server.EmissaryServer;
 
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/emissary/server/api/Version.java
+++ b/src/main/java/emissary/server/api/Version.java
@@ -8,7 +8,7 @@ import emissary.core.NamespaceException;
 import emissary.directory.EmissaryNode;
 import emissary.server.EmissaryServer;
 
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/emissary/server/mvc/adapters/DirectoryAdapter.java
+++ b/src/main/java/emissary/server/mvc/adapters/DirectoryAdapter.java
@@ -12,14 +12,13 @@ import emissary.directory.IRemoteDirectory;
 import emissary.directory.KeyManipulator;
 import emissary.log.MDCConstants;
 
-import org.apache.http.HttpStatus;
-import org.apache.http.HttpVersion;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.entity.EntityBuilder;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.message.BasicHttpResponse;
-import org.apache.http.message.BasicNameValuePair;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.entity.EntityBuilder;
+import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -85,7 +84,7 @@ public class DirectoryAdapter extends EmissaryClient {
      */
     public EmissaryResponse outboundAddPlaces(final String parentDirectory, final List<DirectoryEntry> entryList, final boolean propagating) {
         if (disableAddPlaces) {
-            BasicHttpResponse response = new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "Not accepting remote add places");
+            BasicClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_OK, "Not accepting remote add places");
             response.setEntity(EntityBuilder.create().setText("").setContentEncoding(MediaType.TEXT_PLAIN).build());
             return new EmissaryResponse(response);
         } else {

--- a/src/main/java/emissary/server/mvc/adapters/WorkSpaceAdapter.java
+++ b/src/main/java/emissary/server/mvc/adapters/WorkSpaceAdapter.java
@@ -5,12 +5,13 @@ import emissary.client.EmissaryResponse;
 import emissary.directory.KeyManipulator;
 import emissary.pickup.WorkBundle;
 
-import org.apache.http.HttpStatus;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.message.BasicNameValuePair;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
+import org.apache.hc.core5.util.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +47,8 @@ public class WorkSpaceAdapter extends EmissaryClient {
         nvps.add(new BasicNameValuePair(SPACE_NAME, space));
         method.setEntity(new UrlEncodedFormEntity(nvps, StandardCharsets.UTF_8));
         // set a timeout in case a node is unresponsive
-        method.setConfig(RequestConfig.custom().setConnectTimeout(60000).setSocketTimeout(60000).build());
+        method.setConfig(RequestConfig.custom().setConnectTimeout(Timeout.ofMilliseconds(60000)).setConnectionKeepAlive(Timeout.ofMilliseconds(60000))
+                .build());
 
         return send(method);
     }

--- a/src/main/java/emissary/server/mvc/adapters/WorkSpaceAdapter.java
+++ b/src/main/java/emissary/server/mvc/adapters/WorkSpaceAdapter.java
@@ -6,12 +6,10 @@ import emissary.directory.KeyManipulator;
 import emissary.pickup.WorkBundle;
 
 import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
-import org.apache.hc.core5.util.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,9 +44,8 @@ public class WorkSpaceAdapter extends EmissaryClient {
         nvps.add(new BasicNameValuePair(CLIENT_NAME, place));
         nvps.add(new BasicNameValuePair(SPACE_NAME, space));
         method.setEntity(new UrlEncodedFormEntity(nvps, StandardCharsets.UTF_8));
-        // set a timeout in case a node is unresponsive
-        method.setConfig(RequestConfig.custom().setConnectTimeout(Timeout.ofMilliseconds(60000)).setConnectionKeepAlive(Timeout.ofMilliseconds(60000))
-                .build());
+
+        // {@link EmissaryClient#client} is configured with connection and socket timeout
 
         return send(method);
     }

--- a/src/test/java/emissary/client/EmissaryClientTest.java
+++ b/src/test/java/emissary/client/EmissaryClientTest.java
@@ -3,7 +3,8 @@ package emissary.client;
 import emissary.config.ConfigUtil;
 import emissary.test.core.junit5.UnitTest;
 
-import org.apache.http.client.config.RequestConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.core5.util.Timeout;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,9 +35,9 @@ class EmissaryClientTest extends UnitTest {
             EmissaryClient.configure();
             EmissaryClient client = new EmissaryClient();
             RequestConfig requestConfig = client.getRequestConfig();
-            assertEquals(EmissaryClient.DEFAULT_CONNECTION_TIMEOUT, requestConfig.getConnectTimeout());
-            assertEquals(EmissaryClient.DEFAULT_CONNECTION_MANAGER_TIMEOUT, requestConfig.getConnectionRequestTimeout());
-            assertEquals(EmissaryClient.DEFAULT_SO_TIMEOUT, requestConfig.getSocketTimeout());
+            assertEquals(Timeout.ofMilliseconds(EmissaryClient.DEFAULT_CONNECTION_TIMEOUT), requestConfig.getConnectTimeout());
+            assertEquals(Timeout.ofMicroseconds(EmissaryClient.DEFAULT_CONNECTION_MANAGER_TIMEOUT), requestConfig.getConnectionRequestTimeout());
+            assertEquals(Timeout.ofMilliseconds(EmissaryClient.DEFAULT_SO_TIMEOUT), requestConfig.getResponseTimeout());
         } catch (IOException e) {
             logger.error("Problem moving {}", origCfg.toAbsolutePath(), e);
         } finally {
@@ -60,9 +61,9 @@ class EmissaryClientTest extends UnitTest {
         RequestConfig requestConfig = client.getRequestConfig();
         // asserted values are copied from src/main/resource/emissary/client/EmissaryClient.cfg, which is packaged
         // with the jar
-        assertEquals(TimeUnit.MINUTES.toMillis(10), requestConfig.getConnectTimeout());
-        assertEquals(TimeUnit.MINUTES.toMillis(5), requestConfig.getConnectionRequestTimeout());
-        assertEquals(TimeUnit.SECONDS.toMillis(90), requestConfig.getSocketTimeout());
+        assertEquals(Timeout.ofMilliseconds(TimeUnit.MINUTES.toMillis(10)), requestConfig.getConnectTimeout());
+        assertEquals(Timeout.ofMicroseconds(TimeUnit.MINUTES.toMillis(5)), requestConfig.getConnectionRequestTimeout());
+        assertEquals(Timeout.ofMilliseconds(TimeUnit.SECONDS.toMillis(90)), requestConfig.getResponseTimeout());
     }
 
     @Test
@@ -81,9 +82,9 @@ class EmissaryClientTest extends UnitTest {
             EmissaryClient.configure();
             EmissaryClient client = new EmissaryClient();
             RequestConfig requestConfig = client.getRequestConfig();
-            assertEquals(newConnectionTimeout, requestConfig.getConnectTimeout());
-            assertEquals(newConnectionManagerTimeout, requestConfig.getConnectionRequestTimeout());
-            assertEquals(newSocketTimeout, requestConfig.getSocketTimeout());
+            assertEquals(Timeout.ofMilliseconds(newConnectionTimeout), requestConfig.getConnectTimeout());
+            assertEquals(Timeout.ofMicroseconds(newConnectionManagerTimeout), requestConfig.getConnectionRequestTimeout());
+            assertEquals(Timeout.ofMilliseconds(newSocketTimeout), requestConfig.getResponseTimeout());
         } catch (IOException e) {
             logger.error("Problem with {}", cfgFile.toAbsolutePath(), e);
         } finally {
@@ -99,13 +100,13 @@ class EmissaryClientTest extends UnitTest {
         RequestConfig requestConfig = client.getRequestConfig();
         // initial value from config file on classpath
         int valueInCfgOnClasspath = (int) TimeUnit.MINUTES.toMillis(10);
-        assertEquals(valueInCfgOnClasspath, requestConfig.getConnectTimeout());
+        assertEquals(Timeout.ofMilliseconds(valueInCfgOnClasspath), requestConfig.getConnectTimeout());
         int newTimeout = (int) TimeUnit.MINUTES.toMillis(3);
         client.setConnectionTimeout(newTimeout);
         // did it get reset?
-        assertEquals(newTimeout, client.getRequestConfig().getConnectTimeout());
+        assertEquals(Timeout.ofMilliseconds(newTimeout), client.getRequestConfig().getConnectTimeout());
         // ensure it didn't override config for new instances
-        assertEquals(valueInCfgOnClasspath, new EmissaryClient().getRequestConfig().getConnectTimeout());
+        assertEquals(Timeout.ofMilliseconds(valueInCfgOnClasspath), new EmissaryClient().getRequestConfig().getConnectTimeout());
     }
 
 }

--- a/src/test/java/emissary/client/EmissaryClientTest.java
+++ b/src/test/java/emissary/client/EmissaryClientTest.java
@@ -3,6 +3,7 @@ package emissary.client;
 import emissary.config.ConfigUtil;
 import emissary.test.core.junit5.UnitTest;
 
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.core5.util.Timeout;
 import org.junit.jupiter.api.Test;
@@ -35,9 +36,10 @@ class EmissaryClientTest extends UnitTest {
             EmissaryClient.configure();
             EmissaryClient client = new EmissaryClient();
             RequestConfig requestConfig = client.getRequestConfig();
-            assertEquals(Timeout.ofMilliseconds(EmissaryClient.DEFAULT_CONNECTION_TIMEOUT), requestConfig.getConnectTimeout());
-            assertEquals(Timeout.ofMicroseconds(EmissaryClient.DEFAULT_CONNECTION_MANAGER_TIMEOUT), requestConfig.getConnectionRequestTimeout());
-            assertEquals(Timeout.ofMilliseconds(EmissaryClient.DEFAULT_SO_TIMEOUT), requestConfig.getResponseTimeout());
+            ConnectionConfig connectionConfig = client.getConnectionConfig();
+            assertEquals(Timeout.ofMilliseconds(EmissaryClient.DEFAULT_CONNECTION_TIMEOUT), connectionConfig.getConnectTimeout());
+            assertEquals(Timeout.ofMilliseconds(EmissaryClient.DEFAULT_CONNECTION_MANAGER_TIMEOUT), requestConfig.getConnectionRequestTimeout());
+            assertEquals(Timeout.ofMilliseconds(EmissaryClient.DEFAULT_SO_TIMEOUT), connectionConfig.getSocketTimeout());
         } catch (IOException e) {
             logger.error("Problem moving {}", origCfg.toAbsolutePath(), e);
         } finally {
@@ -59,11 +61,12 @@ class EmissaryClientTest extends UnitTest {
         EmissaryClient.configure();
         EmissaryClient client = new EmissaryClient();
         RequestConfig requestConfig = client.getRequestConfig();
+        ConnectionConfig connectionConfig = client.getConnectionConfig();
         // asserted values are copied from src/main/resource/emissary/client/EmissaryClient.cfg, which is packaged
         // with the jar
-        assertEquals(Timeout.ofMilliseconds(TimeUnit.MINUTES.toMillis(10)), requestConfig.getConnectTimeout());
-        assertEquals(Timeout.ofMicroseconds(TimeUnit.MINUTES.toMillis(5)), requestConfig.getConnectionRequestTimeout());
-        assertEquals(Timeout.ofMilliseconds(TimeUnit.SECONDS.toMillis(90)), requestConfig.getResponseTimeout());
+        assertEquals(Timeout.ofMilliseconds(TimeUnit.MINUTES.toMillis(10)), connectionConfig.getConnectTimeout());
+        assertEquals(Timeout.ofMilliseconds(TimeUnit.MINUTES.toMillis(5)), requestConfig.getConnectionRequestTimeout());
+        assertEquals(Timeout.ofMilliseconds(TimeUnit.SECONDS.toMillis(90)), connectionConfig.getSocketTimeout());
     }
 
     @Test
@@ -82,9 +85,10 @@ class EmissaryClientTest extends UnitTest {
             EmissaryClient.configure();
             EmissaryClient client = new EmissaryClient();
             RequestConfig requestConfig = client.getRequestConfig();
-            assertEquals(Timeout.ofMilliseconds(newConnectionTimeout), requestConfig.getConnectTimeout());
-            assertEquals(Timeout.ofMicroseconds(newConnectionManagerTimeout), requestConfig.getConnectionRequestTimeout());
-            assertEquals(Timeout.ofMilliseconds(newSocketTimeout), requestConfig.getResponseTimeout());
+            ConnectionConfig connectionConfig = client.getConnectionConfig();
+            assertEquals(Timeout.ofMilliseconds(newConnectionTimeout), connectionConfig.getConnectTimeout());
+            assertEquals(Timeout.ofMilliseconds(newConnectionManagerTimeout), requestConfig.getConnectionRequestTimeout());
+            assertEquals(Timeout.ofMilliseconds(newSocketTimeout), connectionConfig.getSocketTimeout());
         } catch (IOException e) {
             logger.error("Problem with {}", cfgFile.toAbsolutePath(), e);
         } finally {
@@ -98,15 +102,16 @@ class EmissaryClientTest extends UnitTest {
         EmissaryClient.configure();
         EmissaryClient client = new EmissaryClient();
         RequestConfig requestConfig = client.getRequestConfig();
+        ConnectionConfig connectionConfig = client.getConnectionConfig();
         // initial value from config file on classpath
         int valueInCfgOnClasspath = (int) TimeUnit.MINUTES.toMillis(10);
-        assertEquals(Timeout.ofMilliseconds(valueInCfgOnClasspath), requestConfig.getConnectTimeout());
+        assertEquals(Timeout.ofMilliseconds(valueInCfgOnClasspath), connectionConfig.getConnectTimeout());
         int newTimeout = (int) TimeUnit.MINUTES.toMillis(3);
         client.setConnectionTimeout(newTimeout);
         // did it get reset?
-        assertEquals(Timeout.ofMilliseconds(newTimeout), client.getRequestConfig().getConnectTimeout());
+        assertEquals(Timeout.ofMilliseconds(newTimeout), client.getConnectionConfig().getConnectTimeout());
         // ensure it didn't override config for new instances
-        assertEquals(Timeout.ofMilliseconds(valueInCfgOnClasspath), new EmissaryClient().getRequestConfig().getConnectTimeout());
+        assertEquals(Timeout.ofMilliseconds(valueInCfgOnClasspath), new EmissaryClient().getConnectionConfig().getConnectTimeout());
     }
 
 }

--- a/src/test/java/emissary/core/FTestMovingAgent.java
+++ b/src/test/java/emissary/core/FTestMovingAgent.java
@@ -11,8 +11,8 @@ import emissary.pool.MobileAgentFactory;
 import emissary.test.core.junit5.FunctionalTest;
 import emissary.util.Version;
 
-import org.apache.http.HttpStatus;
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/emissary/directory/HeartbeatManagerTest.java
+++ b/src/test/java/emissary/directory/HeartbeatManagerTest.java
@@ -5,16 +5,15 @@ import emissary.client.EmissaryResponse;
 import emissary.test.core.junit5.UnitTest;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpHeaders;
-import org.apache.http.NoHttpResponseException;
-import org.apache.http.StatusLine;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.message.BasicHeader;
-import org.apache.http.protocol.HttpContext;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.NoHttpResponseException;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -66,11 +65,9 @@ class HeartbeatManagerTest extends UnitTest {
         CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
         CloseableHttpResponse mockResponse = mock(CloseableHttpResponse.class);
         HttpEntity mockHttpEntity = mock(HttpEntity.class);
-        StatusLine mockStatusLine = mock(StatusLine.class);
 
         when(mockClient.execute(any(HttpUriRequest.class), any(HttpContext.class))).thenReturn(mockResponse);
-        when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
-        when(mockStatusLine.getStatusCode()).thenReturn(401);
+        when(mockResponse.getCode()).thenReturn(401);
         when(mockResponse.getEntity()).thenReturn(mockHttpEntity);
         String responseString = "Unauthorized heartbeat man";
         when(mockHttpEntity.getContent()).thenReturn(IOUtils.toInputStream(responseString, StandardCharsets.UTF_8));

--- a/src/test/java/emissary/server/EmissaryServerIT.java
+++ b/src/test/java/emissary/server/EmissaryServerIT.java
@@ -6,7 +6,7 @@ import emissary.command.ServerCommand;
 import emissary.test.core.junit5.UnitTest;
 import emissary.util.Version;
 
-import org.apache.http.client.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
`< before change`
`> after change`
```
46,48c46,48
< [INFO] +- org.apache.httpcomponents:httpclient:jar:4.5.13:compile
< [INFO] |  +- org.apache.httpcomponents:httpcore:jar:4.4.15:compile
< [INFO] |  \- commons-logging:commons-logging:jar:1.2:compile
---
> [INFO] +- org.apache.httpcomponents.client5:httpclient5:jar:5.2.1:compile
> [INFO] |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.2.1:compile
> [INFO] |  \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.2:compile

```