### PR TITLE
Add new Filename Generator with date, node, and filter

### DIFF
--- a/src/main/java/emissary/output/io/DateFilterFilenameGenerator.java
+++ b/src/main/java/emissary/output/io/DateFilterFilenameGenerator.java
@@ -5,20 +5,24 @@ import emissary.util.io.FileNameGenerator;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
+/**
+ * Creates a Filename Generator that contains a timestamp (julian day), uuid, node name/host, and filter name. Example
+ * filename with a filter param of json is: 20232231650_7959b045-d895-4b34-bed2-8800b5071dcd_localhost_json
+ */
 public class DateFilterFilenameGenerator implements FileNameGenerator {
 
-    protected static final SimpleDateFormat DATE_PATTERN = new SimpleDateFormat("yyyyDDDHHmm");
+    protected static final DateTimeFormatter DATE_PATTERN = DateTimeFormatter.ofPattern("yyyyDDDHHmm");
     public static final char DELIMITER = '_';
     public static final char DASH = '-';
     private final String filterNamePart;
     private static final String NODE_NAME = System.getProperty(EmissaryNode.NODE_NAME_PROPERTY);
 
     /**
-     * Create a file name generator that contains date,
+     * Create a file name generator that contains date, uuid, node name, filter extension.
      * 
      * @param filterName filter name used to create file extension
      */
@@ -40,7 +44,7 @@ public class DateFilterFilenameGenerator implements FileNameGenerator {
     }
 
     private static String now() {
-        return DATE_PATTERN.format(new Date());
+        return DATE_PATTERN.format(LocalDateTime.now());
     }
 
 }

--- a/src/main/java/emissary/output/io/DateFilterFilenameGenerator.java
+++ b/src/main/java/emissary/output/io/DateFilterFilenameGenerator.java
@@ -1,0 +1,46 @@
+package emissary.output.io;
+
+import emissary.directory.EmissaryNode;
+import emissary.util.io.FileNameGenerator;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.UUID;
+
+public class DateFilterFilenameGenerator implements FileNameGenerator {
+
+    protected static final SimpleDateFormat DATE_PATTERN = new SimpleDateFormat("yyyyDDDHHmm");
+    public static final char DELIMITER = '_';
+    public static final char DASH = '-';
+    private final String filterNamePart;
+    private static final String NODE_NAME = System.getProperty(EmissaryNode.NODE_NAME_PROPERTY);
+
+    /**
+     * Create a file name generator that contains date,
+     * 
+     * @param filterName filter name used to create file extension
+     */
+    public DateFilterFilenameGenerator(String filterName) {
+        this.filterNamePart = (StringUtils.isNotBlank(filterName) ? DELIMITER + filterName.replace(DELIMITER, DASH) : StringUtils.EMPTY);
+    }
+
+    /**
+     *
+     * @return the next unique filename from this generator
+     */
+    @Override
+    public String nextFileName() {
+        return createFileName(filterNamePart);
+    }
+
+    public static String createFileName(String extension) {
+        return String.format("%s%s%s%s%s%s", now(), DELIMITER, UUID.randomUUID(), DELIMITER, NODE_NAME, extension);
+    }
+
+    private static String now() {
+        return DATE_PATTERN.format(new Date());
+    }
+
+}

--- a/src/test/java/emissary/output/io/DateFilterFilenameGeneratorTest.java
+++ b/src/test/java/emissary/output/io/DateFilterFilenameGeneratorTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DateFilterFilenameGeneratorTest extends UnitTest {
+class DateFilterFilenameGeneratorTest extends UnitTest {
 
     private static final String FAKE_FILTER = "fakeFilter";
     private static final String FAKE_FILTER_DASH = "fake-filter";

--- a/src/test/java/emissary/output/io/DateFilterFilenameGeneratorTest.java
+++ b/src/test/java/emissary/output/io/DateFilterFilenameGeneratorTest.java
@@ -1,0 +1,68 @@
+package emissary.output.io;
+
+import emissary.directory.EmissaryNode;
+import emissary.test.core.UnitTest;
+import emissary.util.io.FileNameGenerator;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DateFilterFilenameGeneratorTest extends UnitTest {
+
+    private static final String FAKE_FILTER = "fakeFilter";
+    private static final String FAKE_FILTER_DASH = "fake-filter";
+    private static final String FAKE_FILTER_UNDERSCORE = "fake_filter";
+
+    @Test
+    void testDateFilterFilenameGenerator() {
+        FileNameGenerator fileNameGenerator = new DateFilterFilenameGenerator(FAKE_FILTER);
+
+        String filename1 = fileNameGenerator.nextFileName();
+        String filename2 = fileNameGenerator.nextFileName();
+        String[] filename1Parts = filename1.split(String.valueOf(DateFilterFilenameGenerator.DELIMITER));
+
+        // Test Uniqueness
+        assertNotEquals(filename1, filename2);
+
+        // Test that filename starts with date (11 digits)
+        assertTrue(NumberUtils.isDigits(filename1Parts[0]));
+        assertEquals(11, filename1Parts[0].length());
+
+        // Test that uuid is valid
+        assertEquals(UUID.fromString(filename1Parts[1]).toString(), filename1Parts[1]);
+
+        // Test that filename has 4 parts and filter name is present at the end
+        assertEquals(4, filename1Parts.length);
+        assertEquals(FAKE_FILTER, filename1Parts[filename1Parts.length - 1]);
+    }
+
+    @Test
+    void testFilterDelimiterReplacement() {
+        FileNameGenerator fileNameGenerator = new DateFilterFilenameGenerator(FAKE_FILTER_UNDERSCORE);
+        String filename = fileNameGenerator.nextFileName();
+        String[] filenameParts = filename.split(String.valueOf(DateFilterFilenameGenerator.DELIMITER));
+
+        assertNotEquals(FAKE_FILTER_UNDERSCORE, filenameParts[3]);
+        assertEquals(FAKE_FILTER_DASH, filenameParts[3]);
+    }
+
+    @Test
+    void testEmptyFilter() {
+        FileNameGenerator fileNameGenerator = new DateFilterFilenameGenerator(StringUtils.EMPTY);
+        String filename = fileNameGenerator.nextFileName();
+        String[] filenameParts = filename.split(String.valueOf(DateFilterFilenameGenerator.DELIMITER));
+
+        // Only expect 3 parts now and that node name is the last element
+        assertEquals(3, filenameParts.length);
+        assertEquals(System.getProperty(EmissaryNode.NODE_NAME_PROPERTY), filenameParts[filenameParts.length - 1]);
+    }
+
+
+}


### PR DESCRIPTION
This is similar to https://github.com/NationalSecurityAgency/emissary/blob/master/src/main/java/emissary/output/io/DateStampFilenameGenerator.java

But instead of trying to update that class to what we need figured I would create a new one. I can deprecate the old one if we want. Or just leave it alone