### PR TITLE
Identify invalid IBDO data/array modifications.

### DIFF
--- a/src/main/config/emissary.core.SafeUsageChecker.cfg
+++ b/src/main/config/emissary.core.SafeUsageChecker.cfg
@@ -1,0 +1,1 @@
+ENABLED = TRUE

--- a/src/main/java/emissary/core/IBaseDataObject.java
+++ b/src/main/java/emissary/core/IBaseDataObject.java
@@ -27,6 +27,14 @@ public interface IBaseDataObject {
     String DEFAULT_PARAM_SEPARATOR = ";";
 
     /**
+     * Checks to see if payload byte arrays visible to external classes have any changes not explicitly saved via a call to
+     * the {@link IBaseDataObject#setData(byte[]) setData(byte[])}, {@link IBaseDataObject#setData(byte[], int, int)
+     * setData(byte[], int, int)}, or {@link IBaseDataObject#setChannelFactory(SeekableByteChannelFactory)
+     * setChannelFactory(SeekableByteChannelFactory)} method.
+     */
+    void checkForUnsafeDataChanges();
+
+    /**
      * Return the data as a byte array. If using a channel to the data, calling this method will only return up to
      * Integer.MAX_VALUE bytes of the original data.
      * 

--- a/src/main/java/emissary/core/SafeUsageChecker.java
+++ b/src/main/java/emissary/core/SafeUsageChecker.java
@@ -1,0 +1,105 @@
+package emissary.core;
+
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+import emissary.core.channels.SeekableByteChannelFactory;
+import emissary.util.ByteUtil;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility for validating that Places safely interact with IBDO payloads in byte array form. Specifically, this class
+ * helps with validating that changes to a IBDO's payload are followed by a call to the
+ * {@link IBaseDataObject#setData(byte[]) setData(byte[])}, {@link IBaseDataObject#setData(byte[], int, int)
+ * setData(byte[], int, int)}, or {@link IBaseDataObject#setChannelFactory(SeekableByteChannelFactory)
+ * setChannelFactory(SeekableByteChannelFactory)} method.
+ */
+public class SafeUsageChecker {
+    protected static final Logger LOGGER = LoggerFactory.getLogger(SafeUsageChecker.class);
+
+    public static final String ENABLED_KEY = "ENABLED";
+    public static final boolean ENABLED_FROM_CONFIGURATION;
+    public static final String UNSAFE_MODIFICATION_DETECTED = "Detected unsafe changes to IBDO byte array contents";
+
+    // to minimize I/O, we only want to read the config file once regardless of the number of instances created
+    static {
+        boolean enabledFromConfiguration = false;
+
+        try {
+            Configurator configurator = ConfigUtil.getConfigInfo(SafeUsageChecker.class);
+
+            enabledFromConfiguration = configurator.findBooleanEntry(ENABLED_KEY, enabledFromConfiguration);
+        } catch (IOException e) {
+            LOGGER.warn("Could not get configuration!", e);
+        }
+
+        ENABLED_FROM_CONFIGURATION = enabledFromConfiguration;
+    }
+
+    /**
+     * Cache that records each {@literal byte[]} reference made available to IBDO clients, along with a sha256 hash of the
+     * array contents. Used for determining whether the clients modify the array contents without explicitly pushing those
+     * changes back to the IBDO
+     */
+    private final Map<byte[], String> cache = new HashMap<>();
+    public final boolean enabled;
+
+    public SafeUsageChecker() {
+        enabled = ENABLED_FROM_CONFIGURATION;
+    }
+
+    public SafeUsageChecker(Configurator configurator) {
+        enabled = configurator.findBooleanEntry(ENABLED_KEY, ENABLED_FROM_CONFIGURATION);
+    }
+
+    /**
+     * Resets the snapshot cache
+     */
+    public void reset() {
+        if (enabled) {
+            cache.clear();
+        }
+    }
+
+    /**
+     * Stores a new integrity snapshot
+     * 
+     * @param bytes byte[] for which a snapshot should be captured
+     */
+    public void recordSnapshot(final byte[] bytes) {
+        if (enabled) {
+            cache.put(bytes, ByteUtil.sha256Bytes(bytes));
+        }
+    }
+
+
+    /**
+     * Resets the cache and stores a new integrity snapshot
+     * 
+     * @param bytes byte[] for which a snapshot should be captured
+     */
+    public void resetCacheThenRecordSnapshot(final byte[] bytes) {
+        if (enabled) {
+            reset();
+            recordSnapshot(bytes);
+        }
+    }
+
+    /**
+     * Uses the snapshot cache to determine whether any of the byte arrays have unsaved changes
+     */
+    public void checkForUnsafeDataChanges() {
+        if (enabled) {
+            boolean isUnsafe = cache.entrySet().stream().anyMatch(e -> !ByteUtil.sha256Bytes(e.getKey()).equals(e.getValue()));
+            if (isUnsafe) {
+                LOGGER.warn(UNSAFE_MODIFICATION_DETECTED);
+            }
+            reset();
+        }
+    }
+}

--- a/src/main/java/emissary/place/ServiceProviderPlace.java
+++ b/src/main/java/emissary/place/ServiceProviderPlace.java
@@ -581,6 +581,7 @@ public abstract class ServiceProviderPlace implements emissary.place.IServicePro
         MDC.put(MDCConstants.SERVICE_LOCATION, this.getKey());
         try {
             List<IBaseDataObject> l = processHeavyDuty(payload);
+            payload.checkForUnsafeDataChanges();
             rehash(payload);
             return l;
         } catch (Exception e) {

--- a/src/test/java/emissary/core/SafeUsageCheckerTest.java
+++ b/src/test/java/emissary/core/SafeUsageCheckerTest.java
@@ -1,0 +1,56 @@
+package emissary.core;
+
+import emissary.config.ServiceConfigGuide;
+import emissary.test.core.junit5.LogbackTester;
+import emissary.test.core.junit5.UnitTest;
+
+import ch.qos.logback.classic.Level;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SafeUsageCheckerTest extends UnitTest {
+    @Test
+    void testDifferentConfigs() {
+        assertTrue(SafeUsageChecker.ENABLED_FROM_CONFIGURATION, "Enabled from config file should be true");
+
+        final ServiceConfigGuide scg = new ServiceConfigGuide();
+
+        scg.addEntry(SafeUsageChecker.ENABLED_KEY, Boolean.toString(false));
+
+        assertFalse(new SafeUsageChecker(scg).enabled, "Enabled should be false!");
+
+        scg.removeAllEntries(SafeUsageChecker.ENABLED_KEY);
+        scg.addEntry(SafeUsageChecker.ENABLED_KEY, Boolean.toString(true));
+
+        assertTrue(new SafeUsageChecker(scg).enabled, "Enabled should be true!");
+    }
+
+    @Test
+    void testDisabled() throws IOException {
+        final ServiceConfigGuide scg = new ServiceConfigGuide();
+
+        scg.addEntry(SafeUsageChecker.ENABLED_KEY, Boolean.toString(false));
+
+        final SafeUsageChecker suc = new SafeUsageChecker(scg);
+        final byte[] bytes0 = new byte[10];
+        final byte[] bytes1 = new byte[10];
+
+        suc.reset();
+        suc.resetCacheThenRecordSnapshot(bytes0);
+        suc.recordSnapshot(bytes1);
+
+        Arrays.fill(bytes0, (byte) 10);
+        Arrays.fill(bytes1, (byte) 20);
+
+        try (LogbackTester logbackTester = new LogbackTester(SafeUsageChecker.class.getName())) {
+            suc.checkForUnsafeDataChanges();
+
+            logbackTester.checkLogList(new Level[0], new String[0], new boolean[0]);
+        }
+    }
+}

--- a/src/test/java/emissary/test/core/junit5/LogbackTester.java
+++ b/src/test/java/emissary/test/core/junit5/LogbackTester.java
@@ -1,0 +1,55 @@
+package emissary.test.core.junit5;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.apache.commons.lang3.Validate;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LogbackTester implements Closeable {
+    public final String name;
+    public final Logger logger;
+    public final ListAppender<ILoggingEvent> appender;
+
+    public LogbackTester(final String name) {
+        Validate.notNull(name, "Required: name != null");
+
+        this.name = name;
+        logger = (Logger) LoggerFactory.getLogger(name);
+        appender = new ListAppender<>();
+
+        appender.setContext(logger.getLoggerContext());
+        appender.start();
+        logger.addAppender(appender);
+        logger.setAdditive(false);
+    }
+
+    public void checkLogList(final Level[] levels, final String[] messages, final boolean[] throwables) {
+        Validate.notNull(levels, "Required: levels != null");
+        Validate.notNull(messages, "Required: messages != null");
+        Validate.notNull(throwables, "Required: throwables != null");
+        Validate.isTrue(levels.length == messages.length, "Required: levels.length == messages.length");
+        Validate.isTrue(levels.length == throwables.length, "Required: levels.length == throwables.length");
+
+        assertEquals(levels.length, appender.list.size(), "Expected lengths do not match number of log messages");
+
+        for (int i = 0; i < appender.list.size(); i++) {
+            final ILoggingEvent item = appender.list.get(i);
+
+            assertEquals(levels[i], item.getLevel(), "Levels not equal for element " + i);
+            assertEquals(messages[i], item.getFormattedMessage(), "Messages not equal for element " + i);
+            assertEquals(throwables[i], item.getThrowableProxy() != null, "Throwables not equal for elmeent " + i);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        logger.detachAndStopAllAppenders();
+    }
+}


### PR DESCRIPTION
This PR identifies invalid modifications to the IBDO data/array. This pertains only to IBDO data returned as a byte array since data returned as a ChannelFactory is immutable. An invalid modification is when a byte array is returned, the elements are modified and IBDO.setData(...)/IBDO.setChannelFactory(...) is NOT called. The problem occurs when the IBDO data is backed by a channel factory, a byte array is created and returned from the ChannelFactory, the byte array is modified and then the place competes with the byte array being garbage collected without the modifications being given back to the IBDO.