### PR TITLE
Removing * import from UnixFilePlace

### DIFF
--- a/src/main/java/emissary/id/UnixFilePlace.java
+++ b/src/main/java/emissary/id/UnixFilePlace.java
@@ -6,7 +6,11 @@ import emissary.util.UnixFile;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Accesses emissary.util.UnixFile to perform file identification tests using emissary.util.UnixFile


### PR DESCRIPTION
On another PR that I was checking, saw the UnixFilePlace had a * import.