### PR TITLE
Removing pathWeight from all of Emissary

### DIFF
--- a/src/main/java/emissary/client/response/Directory.java
+++ b/src/main/java/emissary/client/response/Directory.java
@@ -32,9 +32,6 @@ public class Directory implements Comparable<Directory>, Serializable {
     @XmlElement(name = "expense")
     private int expense;
 
-    @XmlElement(name = "pathWeight")
-    private int pathWeight;
-
     public Directory() {}
 
     public Directory(DirectoryEntry directoryEntry) {
@@ -48,7 +45,6 @@ public class Directory implements Comparable<Directory>, Serializable {
         cost = directoryEntry.getCost();
         quality = directoryEntry.getQuality();
         expense = directoryEntry.getExpense();
-        pathWeight = directoryEntry.getPathWeight();
     }
 
     public DirectoryEntry getDirectoryEntry() {
@@ -97,14 +93,6 @@ public class Directory implements Comparable<Directory>, Serializable {
 
     public void setExpense(int expense) {
         this.expense = expense;
-    }
-
-    public int getPathWeight() {
-        return pathWeight;
-    }
-
-    public void setPathWeight(int pathWeight) {
-        this.pathWeight = pathWeight;
     }
 
     @Override

--- a/src/main/java/emissary/directory/DirectoryEntry.java
+++ b/src/main/java/emissary/directory/DirectoryEntry.java
@@ -40,13 +40,6 @@ public class DirectoryEntry implements Serializable {
      */
     protected int theExpense = 0;
 
-    /**
-     * Nominal starting path weight. Making it lower makes the entry less likely to be selected from a group with equal
-     * expense. Making it higher makes it more likely to be selected from a group with equal expense. Between entries with
-     * different expense values there is no effect.
-     */
-    protected transient int pathWeight = 500;
-
     /** Protection against repeated namespace lookups for this entry */
     protected transient boolean lookupAttempted = false;
 
@@ -215,7 +208,6 @@ public class DirectoryEntry implements Serializable {
         this.theQuality = that.theQuality;
         this.theCost = that.theCost;
         this.calculateExpense();
-        this.pathWeight = that.pathWeight;
         this.description = that.description;
         if (preserveTime) {
             this.age = that.age;
@@ -329,45 +321,6 @@ public class DirectoryEntry implements Serializable {
         final int exp = KeyManipulator.getExpense(key, -1);
         if (exp > -1) {
             setCQEFromExp(exp);
-        }
-    }
-
-    /**
-     * Get the path weight of moving to a place Nominal starting path weight is 500. Making it lower makes the entry less
-     * likely to be selected from a group with equal expense. Making it higher makes it more likely to be selected from a
-     * group with equal expense. Between entries with different expense values there is no effect. The value is not allowed
-     * to go below zero.
-     * 
-     * @return the current path weight value
-     */
-    public int getPathWeight() {
-        return this.pathWeight;
-    }
-
-    /**
-     * Set the path weight of moving to a place
-     * 
-     * @see #getPathWeight()
-     */
-    public void setPathWeight(final int value) {
-        this.pathWeight = value;
-        if (this.pathWeight < 0) {
-            this.pathWeight = 0;
-        }
-    }
-
-
-    /**
-     * Add to the path weight. The increment can be negative to remove weight. The path weight is not allowed to go below
-     * zero.
-     * 
-     * @see #getPathWeight()
-     * @param weightIncrement amount to add to weight
-     */
-    public void addPathWeight(final int weightIncrement) {
-        this.pathWeight += weightIncrement;
-        if (this.pathWeight < 0) {
-            this.pathWeight = 0;
         }
     }
 

--- a/src/main/java/emissary/directory/DirectoryPlace.java
+++ b/src/main/java/emissary/directory/DirectoryPlace.java
@@ -820,13 +820,10 @@ public class DirectoryPlace extends ServiceProviderPlace implements IRemoteDirec
             logger.debug("Permanent failure of remote {}", key);
             count += removePlaces(Collections.singletonList(hmKey));
         } else {
-            // Change the weight of the paths for all places matching the
+            // Change the cost for all places matching the
             // failed directory. This has the effect of causing them
             // not to be chosen as much.
             final List<DirectoryEntry> list = this.entryMap.collectAllMatching(hmKey);
-            for (final DirectoryEntry e : list) {
-                e.addPathWeight(-20);
-            }
             this.observerManager.placeCostChangeEntries(list);
         }
 

--- a/src/main/java/emissary/server/mvc/DumpDirectoryAction.java
+++ b/src/main/java/emissary/server/mvc/DumpDirectoryAction.java
@@ -143,7 +143,6 @@ public class DumpDirectoryAction {
         final int cost;
         final int quality;
         final int expense;
-        final int pathWeight;
         final String age;
 
         public DirectoryEntryInfo(String stripe, DirectoryEntry entry, long now) {
@@ -152,7 +151,6 @@ public class DumpDirectoryAction {
             this.cost = entry.getCost();
             this.quality = entry.getQuality();
             this.expense = entry.getExpense();
-            this.pathWeight = entry.getPathWeight();
             long ago = now - entry.getAge();
             long hh = ago / 3600000;
             long mm = (ago % 3600000) / 60000;

--- a/src/main/resources/templates/dump_directory.mustache
+++ b/src/main/resources/templates/dump_directory.mustache
@@ -20,7 +20,6 @@
               <th>Cost</th>
               <th>Quality</th>
               <th title="Computed from Cost and quality">Expense</th>
-              <th title="Path Weight">PW</th>
               <th title="HH:MM:SS">Age</th>
           </tr>
        </thead>
@@ -33,7 +32,6 @@
             <td class="num">{{cost}}</td>
             <td class="num">{{quality}}</td>
             <td class="num">{{expense}}</td>
-            <td class="num">{{pathWeight}}</td>
             <td class="num">{{age}}</td>
           </tr>
          {{/entrylist}}

--- a/src/test/java/emissary/directory/DirectoryEntryTest.java
+++ b/src/test/java/emissary/directory/DirectoryEntryTest.java
@@ -86,16 +86,6 @@ class DirectoryEntryTest extends UnitTest {
         final int newExp = DirectoryEntry.calculateExpense(cost + 100, quality);
         assertEquals(newExp, this.d.getExpense(), "Expense computation on cost increment");
         assertTrue(this.d.toString().contains("$" + newExp), "Correct expense in key");
-
-        final int origWeight = this.d.getPathWeight();
-        this.d.addPathWeight(100);
-        assertEquals(100 + origWeight, this.d.getPathWeight(), "Path weight incrememented");
-
-        this.d.addPathWeight(-100000);
-        assertEquals(0, this.d.getPathWeight(), "Path weight cannot be negative");
-
-        this.d.setPathWeight(-1);
-        assertEquals(0, this.d.getPathWeight(), "Path weight cannot be negative");
     }
 
     @Test
@@ -156,7 +146,6 @@ class DirectoryEntryTest extends UnitTest {
         assertEquals(this.d.getDescription(), copy.getDescription(), "Copied desc");
         assertEquals(this.d.toString(), copy.toString(), "Copied tostring");
         assertEquals(this.d.getFullKey(), copy.getFullKey(), "Full key");
-        assertEquals(this.d.getPathWeight(), copy.getPathWeight(), "Copied path weight");
     }
 
     @Test

--- a/src/test/java/emissary/server/api/EmissaryApiTest.java
+++ b/src/test/java/emissary/server/api/EmissaryApiTest.java
@@ -266,7 +266,6 @@ class EmissaryApiTest extends EndpointTestBase {
                 foundCost.add(entry.getCost());
                 assertEquals(50, entry.getQuality(), "Quality is expected to be 50 for all entries.");
                 foundExpense.add(entry.getExpense());
-                assertEquals(500, entry.getPathWeight(), "PathWeight is expected to be 500 for all entries.");
             });
             assertEquals(expEntryKeys, foundEntryKeys);
             assertEquals(expDataIds, foundDataIds);


### PR DESCRIPTION
Remove pathWeight instances from code, as well as updating API to no longer show PW in Directories tab.