### PR TITLE
revert super-linter reference

### DIFF
--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v5.2.1
+        uses: github/super-linter/slim@v4.10.0
         env:
           LOG_LEVEL: NOTICE
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
super-linter was migrated from the github namespace, but has not yet received a certified status in the marketplace