### PR TITLE
fix object metrics log configuration

### DIFF
--- a/src/main/config/logback.xml
+++ b/src/main/config/logback.xml
@@ -21,7 +21,7 @@
   </appender>
 
   <!-- Enable output metrics logging by creating an environment variable of "LogObjectMetrics=true" -->
-  <if condition='${LogObjectMetrics} == true'>
+  <if condition="&quot;${LogObjectMetrics}&quot;.equals(&quot;true&quot;)">
     <then>
       <appender name="OBJECT-METRICS" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
@@ -29,7 +29,6 @@
           <includeMdc>false</includeMdc>
           <fieldNames>
             <version>[ignore]</version>
-            <logValue>[ignore]</logValue>
             <logger>[ignore]</logger>
             <thread>[ignore]</thread>
             <levelValue>[ignore]</levelValue>


### PR DESCRIPTION
- resolves issue when `LogObjectMetrics` is not set or null, so the conditional check fails with an error
- removes unknown field for `logLevel` assuming this is the proper list/documentation https://javadoc.io/static/net.logstash.logback/logstash-logback-encoder/4.6/index.html?net/logstash/logback/encoder/LogstashEncoder.html