### PR TITLE
Fix IBaseDataObjectXmlCodec bug.

### DIFF
--- a/src/main/java/emissary/core/IBaseDataObjectDiffHelper.java
+++ b/src/main/java/emissary/core/IBaseDataObjectDiffHelper.java
@@ -11,6 +11,7 @@ import java.nio.channels.Channels;
 import java.nio.channels.SeekableByteChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -58,7 +59,7 @@ public class IBaseDataObjectDiffHelper {
 
         diff(ibdo1.getFontEncoding(), ibdo2.getFontEncoding(), "fontEncoding", differences);
         // TreeMap automatically sorts parameters by key
-        diff(new TreeMap<>(ibdo1.getParameters()), new TreeMap<>(ibdo2.getParameters()), "parameters", differences);
+        diff(convertMap(ibdo1.getParameters()), convertMap(ibdo2.getParameters()), "parameters", differences);
         diff(ibdo1.getNumChildren(), ibdo2.getNumChildren(), "numChildren", differences);
         diff(ibdo1.getNumSiblings(), ibdo2.getNumSiblings(), "numSiblings", differences);
         diff(ibdo1.getBirthOrder(), ibdo2.getBirthOrder(), "birthOrder", differences);
@@ -223,5 +224,27 @@ public class IBaseDataObjectDiffHelper {
                 !map1.entrySet().stream().allMatch(e -> Arrays.equals(e.getValue(), map2.get(e.getKey())))) {
             differences.add(identifier + ARE_NOT_EQUAL);
         }
+    }
+
+    /**
+     * This method converts the IBDO parameter map of Object values to a map of String values for better comparison.
+     * 
+     * @param map IBDO parameter map
+     * @return a map that has only Strings as it values.
+     */
+    public static Map<String, Collection<String>> convertMap(final Map<String, Collection<Object>> map) {
+        Map<String, Collection<String>> newMap = new TreeMap<>();
+
+        for (Map.Entry<String, Collection<Object>> e : map.entrySet()) {
+            final List<String> list = new ArrayList<>();
+
+            for (Object o : e.getValue()) {
+                list.add(o.toString());
+            }
+
+            newMap.put(e.getKey(), list);
+        }
+
+        return newMap;
     }
 }

--- a/src/main/java/emissary/core/IBaseDataObjectXmlCodecs.java
+++ b/src/main/java/emissary/core/IBaseDataObjectXmlCodecs.java
@@ -431,7 +431,7 @@ public final class IBaseDataObjectXmlCodecs {
      * object.
      */
     public static final ElementDecoder DEFAULT_STRING_OBJECT_DECODER = (elements, ibdo, ibdoMethodName) -> {
-        final Method method = getIbdoMethod(ibdoMethodName, String.class, Object.class);
+        final Method method = getIbdoMethod(ibdoMethodName, String.class, CharSequence.class);
 
         for (final Element element : elements) {
             final Element nameElement = element.getChild(NAME);

--- a/src/main/java/emissary/core/constants/IbdoMethodNames.java
+++ b/src/main/java/emissary/core/constants/IbdoMethodNames.java
@@ -60,7 +60,7 @@ public final class IbdoMethodNames {
     /**
      * The IBaseDataObject set method name for Parameter.
      */
-    public static final String SET_PARAMETER = "putParameter";
+    public static final String SET_PARAMETER = "appendParameter";
     /**
      * The IBaseDataObject set method name for Priority.
      */

--- a/src/test/java/emissary/core/IBaseDataObjectXmlHelperTest.java
+++ b/src/test/java/emissary/core/IBaseDataObjectXmlHelperTest.java
@@ -19,6 +19,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
@@ -81,7 +82,8 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
         expectedIbdo.setTransactionId("TransactionId");
         expectedIbdo.setWorkBundleId("WorkBundleId");
         expectedIbdo.putParameter("Parameter1Key", "Parameter1Value");
-        expectedIbdo.putParameter("Parameter2Key", "Parameter2Value");
+        expectedIbdo.putParameter("Parameter2Key", Arrays.asList("Parameter2Value1", "Parameter2Value2"));
+        expectedIbdo.putParameter("Parameter3Key", Arrays.asList(10L, 20L));
         expectedIbdo.addAlternateView("AlternateView1Key", "AlternateView1Value".getBytes(StandardCharsets.ISO_8859_1));
         expectedIbdo.addAlternateView("AlternateView2Key", "AlternateView2Value".getBytes(StandardCharsets.ISO_8859_1));
 


### PR DESCRIPTION
IBaseDataObjectXmlCodec does not currently handle multiple parameter values for a single key correctly when converting XML -> IBDO.