### PR TITLE
KffFile cleanup

### DIFF
--- a/src/main/java/emissary/kff/KffFile.java
+++ b/src/main/java/emissary/kff/KffFile.java
@@ -177,9 +177,9 @@ public class KffFile implements KffFilter {
                     return true;
                 }
             }
-        } catch (IOException e) {
-            logger.warn("Exception reading KffFile: {}", e.getMessage());
-            return false;
+        }
+        catch (IOException e) {
+            logger.warn("Exception reading KffFile", e);
         }
 
         // not found

--- a/src/main/java/emissary/kff/KffFile.java
+++ b/src/main/java/emissary/kff/KffFile.java
@@ -177,8 +177,7 @@ public class KffFile implements KffFilter {
                     return true;
                 }
             }
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             logger.warn("Exception reading KffFile", e);
         }
 

--- a/src/test/java/emissary/kff/KffFileTest.java
+++ b/src/test/java/emissary/kff/KffFileTest.java
@@ -114,7 +114,7 @@ class KffFileTest extends UnitTest {
 
         List<KffFileCheckTask> callables = createCallableTasksForParallelExecution(testInputs);
 
-        logger.info("testing {} invocations, with {} that should return true", callables.size(), numberOfKffEntriesInTestFile);
+        logger.debug("testing {} invocations, with {} that should return true", callables.size(), numberOfKffEntriesInTestFile);
 
         ExecutorService executorService = null;
         try {
@@ -272,7 +272,7 @@ class KffFileTest extends UnitTest {
         public Boolean call() throws Exception {
             boolean actual = kffFile.check("ignored param", csr);
             // increase this log level to view stream of executions and results
-            LOGGER.info("expected {}, got {}", expectedResult, actual);
+            LOGGER.debug("expected {}, got {}", expectedResult, actual);
             return expectedResult.equals(actual);
         }
     }


### PR DESCRIPTION
Getting better insight into the cause of any caught `IOException` while searching the KffFile 