### PR TITLE
Modified KffDataObjectHandler.hash(..) method so it explicitly replaces IBDO params it generates.

### DIFF
--- a/src/main/java/emissary/core/BaseDataObject.java
+++ b/src/main/java/emissary/core/BaseDataObject.java
@@ -884,6 +884,13 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
             }
 
             final Object value = entry.getValue();
+
+            if ((policy == MergePolicy.DROP_EXISTING)) {
+                // store the provided value for this key, discarding any previously-stored value
+                setParameter(name, value);
+                continue;
+            }
+
             if (value instanceof Iterable) {
                 for (final Object v : (Iterable<?>) value) {
                     if (policy == MergePolicy.KEEP_ALL || policy == MergePolicy.KEEP_EXISTING) {

--- a/src/main/java/emissary/core/IBaseDataObject.java
+++ b/src/main/java/emissary/core/IBaseDataObject.java
@@ -18,7 +18,7 @@ public interface IBaseDataObject {
      * Define the merge policy values for parameter handling
      */
     enum MergePolicy {
-        DISTINCT, KEEP_EXISTING, KEEP_ALL
+        DISTINCT, KEEP_EXISTING, KEEP_ALL, DROP_EXISTING
     }
 
     /**

--- a/src/main/java/emissary/kff/KffDataObjectHandler.java
+++ b/src/main/java/emissary/kff/KffDataObjectHandler.java
@@ -1,6 +1,7 @@
 package emissary.kff;
 
 import emissary.core.IBaseDataObject;
+import emissary.core.IBaseDataObject.MergePolicy;
 import emissary.core.channels.SeekableByteChannelFactory;
 
 import org.slf4j.Logger;
@@ -193,9 +194,9 @@ public class KffDataObjectHandler {
 
         // Compute and add the hashes
         if (useSbc && d.getChannelSize() > 0) {
-            d.putParameters(hashData(d.getChannelFactory(), d.shortName(), ""));
+            d.putParameters(hashData(d.getChannelFactory(), d.shortName(), ""), MergePolicy.DROP_EXISTING);
         } else if (!useSbc && d.dataLength() > 0) {
-            d.putParameters(hashData(d.data(), d.shortName()));
+            d.putParameters(hashData(d.data(), d.shortName()), MergePolicy.DROP_EXISTING);
         } else {
             return;
         }

--- a/src/test/java/emissary/kff/KffDataObjectHandlerTest.java
+++ b/src/test/java/emissary/kff/KffDataObjectHandlerTest.java
@@ -94,15 +94,36 @@ class KffDataObjectHandlerTest extends UnitTest {
         kff = new KffDataObjectHandler(true, true, true);
         payload.setParameter(KffDataObjectHandler.KFF_PARAM_KNOWN_FILTER_NAME, "test.filter");
         kff.hash(payload);
-        assertEquals("test.filter", payload.getStringParameter(KffDataObjectHandler.KFF_PARAM_BASE + "FILTERED_BY"));
+        assertEquals("test.filter", payload.getStringParameter(KffDataObjectHandler.KFF_PARAM_KNOWN_FILTER_NAME));
         assertTrue(KffDataObjectHandler.hashPresent(payload));
         assertEquals(DATA_MD5, payload.getStringParameter(KffDataObjectHandler.KFF_PARAM_MD5));
-        assertEquals(DATA_CRC32, payload.getStringParameter(KffDataObjectHandler.KFF_PARAM_BASE + "CRC32"));
+        assertEquals(DATA_CRC32, payload.getStringParameter(KffDataObjectHandler.KFF_PARAM_CRC32));
         assertEquals(DATA_SSDEEP, payload.getStringParameter(KffDataObjectHandler.KFF_PARAM_SSDEEP));
         assertEquals(DATA_SHA1, payload.getStringParameter(KffDataObjectHandler.KFF_PARAM_SHA1));
         assertEquals(DATA_SHA256, payload.getStringParameter(KffDataObjectHandler.KFF_PARAM_SHA256));
         assertEquals(KffDataObjectHandler.KFF_DUPE_CURRENT_FORM, payload.getFileType());
         assertArrayEquals(new byte[0], payload.data());
+    }
+
+    @Test
+    void testHashMethodCalledTwice() {
+        // don't truncate known data or the second call will be made with an empty payload
+        kff = new KffDataObjectHandler(KffDataObjectHandler.KEEP_KNOWN_DATA, true, true);
+        payload.setParameter(KffDataObjectHandler.KFF_PARAM_KNOWN_FILTER_NAME, "test.filter");
+        kff.hash(payload);
+
+        // hash again, to see the effect on the hash-related params.
+        // none of the parameters should have a duplicated value
+
+        kff.hash(payload);
+        assertEquals("test.filter", payload.getStringParameter(KffDataObjectHandler.KFF_PARAM_KNOWN_FILTER_NAME));
+        assertTrue(KffDataObjectHandler.hashPresent(payload));
+        assertEquals(DATA_MD5, payload.getStringParameter(KffDataObjectHandler.KFF_PARAM_MD5));
+        assertEquals(DATA_CRC32, payload.getStringParameter(KffDataObjectHandler.KFF_PARAM_CRC32));
+        assertEquals(DATA_SSDEEP, payload.getStringParameter(KffDataObjectHandler.KFF_PARAM_SSDEEP));
+        assertEquals(DATA_SHA1, payload.getStringParameter(KffDataObjectHandler.KFF_PARAM_SHA1));
+        assertEquals(DATA_SHA256, payload.getStringParameter(KffDataObjectHandler.KFF_PARAM_SHA256));
+        assertEquals(KffDataObjectHandler.KFF_DUPE_CURRENT_FORM, payload.getFileType());
     }
 
     @Test


### PR DESCRIPTION
A given object should have only one value for each type of hash we compute.  With this change, the last one computed wins.  Need to make sure that's the behavior we want. 

Honestly, we should _probably_ instead modify the behavior so that the `hash` method hashes a given payload at-most one time (so the computed hashes represent the data in its original form), with any subsequent calls being no-op'ed. 