### PR TITLE
Using FILE_ABSOLUTEPATH and Original-Filename to populate FILEXT

### DIFF
--- a/src/main/java/emissary/core/constants/Parameters.java
+++ b/src/main/java/emissary/core/constants/Parameters.java
@@ -11,6 +11,7 @@ public class Parameters {
     public static final String INPUT_FILENAME = "INPUT_FILENAME";
     public static final String ORIGINAL_FILENAME = "Original-Filename";
     public static final String SUMMARY = "SUMMARY";
+    public static final String FILE_ABSOLUTEPATH = "FILE_ABSOLUTEPATH";
 
     // Common parameter prefixes
 

--- a/src/main/java/emissary/core/constants/Parameters.java
+++ b/src/main/java/emissary/core/constants/Parameters.java
@@ -5,13 +5,14 @@ public class Parameters {
     // Common parameters
     public static final String DOCUMENT_TITLE = "DocumentTitle";
     public static final String EVENT_DATE = "EventDate";
+    public static final String FILEXT = "FILEXT";
+    public static final String FILE_ABSOLUTEPATH = "FILE_ABSOLUTEPATH";
     public static final String FILE_DATE = "FILE_DATE";
     public static final String FILE_NAME = "FILE_NAME";
     public static final String INPUT_FILEDATE = "INPUT_FILEDATE";
     public static final String INPUT_FILENAME = "INPUT_FILENAME";
     public static final String ORIGINAL_FILENAME = "Original-Filename";
     public static final String SUMMARY = "SUMMARY";
-    public static final String FILE_ABSOLUTEPATH = "FILE_ABSOLUTEPATH";
 
     // Common parameter prefixes
 

--- a/src/main/java/emissary/output/DropOffUtil.java
+++ b/src/main/java/emissary/output/DropOffUtil.java
@@ -85,8 +85,6 @@ public class DropOffUtil {
     private static final String DEFAULT_EVENT_DATE_TO_NOW = "DEFAULT_EVENT_DATE_TO_NOW";
     protected boolean defaultEventDateToNow = true;
 
-    private static List<String> defaultFilenameFields;
-
     /**
      * Create with the default configuration
      */
@@ -151,14 +149,6 @@ public class DropOffUtil {
                 this.maxFilextLen = Integer.MAX_VALUE;
             }
 
-            defaultFilenameFields = new ArrayList<>();
-            List<String> configuredFilenameFields = actualConfigG.findEntries("FILENAME_FIELDS");
-            if (!configuredFilenameFields.isEmpty()) {
-                defaultFilenameFields.addAll(configuredFilenameFields);
-            } else {
-                defaultFilenameFields.add(ORIGINAL_FILENAME);
-                defaultFilenameFields.add(FILE_ABSOLUTEPATH);
-            }
         } else {
             logger.debug("Configuration is null for DropOffUtil, using defaults");
             this.executrix = new Executrix();
@@ -1019,17 +1009,29 @@ public class DropOffUtil {
     }
 
     /**
-     * Checks the Original-Filename and FILE_ABSOLUTEPATH for the filename of the object. Returns a list with of the
-     * non-empty strings found in these fields. If nothing is found in either field, return an empty list.
+     * Checks the Original-Filename and FILE_ABSOLUTEPATH for the filename of the object. Returns a list with the non-empty
+     * strings found in these fields. If nothing is found in either field, return an empty list.
      *
      * @param d The IBDO
      * @return The list of filenames found in the field Original-Filename or FILE_ABSOLUTEPATH
      */
     public static List<String> getFullFilepathsFromParams(IBaseDataObject d) {
+        return getFullFilepathsFromParams(d, new String[] {ORIGINAL_FILENAME, FILE_ABSOLUTEPATH});
+    }
+
+    /**
+     * Uses the specified list of fields to check for filenames of the object. Returns a list with the non-empty strings
+     * found in these fields. If nothing is found in either field, return an empty list.
+     *
+     * @param d The IBDO
+     * @param filenameFields The list of fields on the IBDO to check
+     * @return The list of filenames found in the list of fields on the IBDO
+     */
+    public static List<String> getFullFilepathsFromParams(IBaseDataObject d, String[] filenameFields) {
 
         List<String> filenames = new ArrayList<>();
 
-        for (String ibdoField : defaultFilenameFields) {
+        for (String ibdoField : filenameFields) {
             if (d.hasParameter(ibdoField)) {
                 for (Object filename : d.getParameter(ibdoField)) {
                     String stringFileName = (String) filename;

--- a/src/main/java/emissary/output/DropOffUtil.java
+++ b/src/main/java/emissary/output/DropOffUtil.java
@@ -39,6 +39,7 @@ import javax.annotation.Nullable;
 import static emissary.core.Form.PREFIXES_LANG;
 import static emissary.core.Form.TEXT;
 import static emissary.core.Form.UNKNOWN;
+import static emissary.core.constants.Parameters.FILEXT;
 import static emissary.core.constants.Parameters.FILE_ABSOLUTEPATH;
 import static emissary.core.constants.Parameters.ORIGINAL_FILENAME;
 
@@ -84,7 +85,7 @@ public class DropOffUtil {
     private static final String DEFAULT_EVENT_DATE_TO_NOW = "DEFAULT_EVENT_DATE_TO_NOW";
     protected boolean defaultEventDateToNow = true;
 
-    private static List<String> DEFAULT_FILENAME_FIELDS;
+    private static List<String> defaultFilenameFields;
 
     /**
      * Create with the default configuration
@@ -150,13 +151,13 @@ public class DropOffUtil {
                 this.maxFilextLen = Integer.MAX_VALUE;
             }
 
-            DEFAULT_FILENAME_FIELDS = new ArrayList<>();
-            List<String> defaultFilenameFields = actualConfigG.findEntries("FILENAME_FIELDS");
-            if (!defaultFilenameFields.isEmpty()) {
-                DEFAULT_FILENAME_FIELDS.addAll(defaultFilenameFields);
+            defaultFilenameFields = new ArrayList<>();
+            List<String> configuredFilenameFields = actualConfigG.findEntries("FILENAME_FIELDS");
+            if (!configuredFilenameFields.isEmpty()) {
+                defaultFilenameFields.addAll(configuredFilenameFields);
             } else {
-                DEFAULT_FILENAME_FIELDS.add(ORIGINAL_FILENAME);
-                DEFAULT_FILENAME_FIELDS.add(FILE_ABSOLUTEPATH);
+                defaultFilenameFields.add(ORIGINAL_FILENAME);
+                defaultFilenameFields.add(FILE_ABSOLUTEPATH);
             }
         } else {
             logger.debug("Configuration is null for DropOffUtil, using defaults");
@@ -984,7 +985,7 @@ public class DropOffUtil {
     /**
      * Utilizes the static methods getFullFilepathsFromParams and getFileExtensions to extract the file extensions from all
      * the filenames of the object of a given {@link IBaseDataObject}. If one or more file extensions are extracted, the
-     * IBaseDataObject's "FILEXT" parameter is set as the unique set of extracted file extensions, converted to lowercase.
+     * IBaseDataObject's FILEXT parameter is set as the unique set of extracted file extensions, converted to lowercase.
      *
      * @param p IBaseDataObject to process
      *
@@ -993,7 +994,7 @@ public class DropOffUtil {
         List<String> filenames = getFullFilepathsFromParams(p);
         Set<String> extensions = getFileExtensions(filenames, this.maxFilextLen);
         if (!extensions.isEmpty()) {
-            p.setParameter("FILEXT", extensions);
+            p.setParameter(FILEXT, extensions);
         }
     }
 
@@ -1028,7 +1029,7 @@ public class DropOffUtil {
 
         List<String> filenames = new ArrayList<>();
 
-        for (String ibdoField : DEFAULT_FILENAME_FIELDS) {
+        for (String ibdoField : defaultFilenameFields) {
             if (d.hasParameter(ibdoField)) {
                 for (Object filename : d.getParameter(ibdoField)) {
                     String stringFileName = (String) filename;

--- a/src/main/java/emissary/output/DropOffUtil.java
+++ b/src/main/java/emissary/output/DropOffUtil.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SimpleTimeZone;
 import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
 import javax.annotation.Nullable;
 
 import static emissary.core.Form.PREFIXES_LANG;
@@ -86,6 +87,7 @@ public class DropOffUtil {
     protected boolean defaultEventDateToNow = true;
 
     private static List<String> defaultFilenameFields;
+    private static final ReentrantLock filenameFieldsLock = new ReentrantLock();
 
     /**
      * Create with the default configuration
@@ -151,13 +153,23 @@ public class DropOffUtil {
                 this.maxFilextLen = Integer.MAX_VALUE;
             }
 
-            defaultFilenameFields = new ArrayList<>();
-            List<String> configuredFilenameFields = actualConfigG.findEntries("FILENAME_FIELDS");
-            if (!configuredFilenameFields.isEmpty()) {
-                defaultFilenameFields.addAll(configuredFilenameFields);
-            } else {
-                defaultFilenameFields.add(ORIGINAL_FILENAME);
-                defaultFilenameFields.add(FILE_ABSOLUTEPATH);
+            try {
+                filenameFieldsLock.lockInterruptibly();
+
+                defaultFilenameFields = new ArrayList<>();
+                List<String> configuredFilenameFields = actualConfigG.findEntries("FILENAME_FIELDS");
+                if (!configuredFilenameFields.isEmpty()) {
+                    defaultFilenameFields.addAll(configuredFilenameFields);
+                } else {
+                    defaultFilenameFields.add(ORIGINAL_FILENAME);
+                    defaultFilenameFields.add(FILE_ABSOLUTEPATH);
+                }
+            } catch (InterruptedException e) {
+                logger.debug("A thread with a reentrant lock was interrupted");
+            } finally {
+                if (filenameFieldsLock.isHeldByCurrentThread()) {
+                    filenameFieldsLock.unlock();
+                }
             }
         } else {
             logger.debug("Configuration is null for DropOffUtil, using defaults");
@@ -1029,14 +1041,23 @@ public class DropOffUtil {
 
         List<String> filenames = new ArrayList<>();
 
-        for (String ibdoField : defaultFilenameFields) {
-            if (d.hasParameter(ibdoField)) {
-                for (Object filename : d.getParameter(ibdoField)) {
-                    String stringFileName = (String) filename;
-                    if (StringUtils.isNotBlank(stringFileName)) {
-                        filenames.add(stringFileName);
+        try {
+            filenameFieldsLock.lockInterruptibly();
+            for (String ibdoField : defaultFilenameFields) {
+                if (d.hasParameter(ibdoField)) {
+                    for (Object filename : d.getParameter(ibdoField)) {
+                        String stringFileName = (String) filename;
+                        if (StringUtils.isNotBlank(stringFileName)) {
+                            filenames.add(stringFileName);
+                        }
                     }
                 }
+            }
+        } catch (InterruptedException e) {
+            logger.debug("A thread with a reentrant lock was interrupted");
+        } finally {
+            if (filenameFieldsLock.isHeldByCurrentThread()) {
+                filenameFieldsLock.unlock();
             }
         }
         return filenames;

--- a/src/test/java/emissary/output/DropOffUtilTest.java
+++ b/src/test/java/emissary/output/DropOffUtilTest.java
@@ -608,11 +608,11 @@ class DropOffUtilTest extends UnitTest {
 
         // tests a combination of either FILE_ABSOLUTEPATH and Original-Filename, neither, and both set at once
         String[] fileAbsolutepaths = {"D:\\Users\\jdoe\\Documents\\Taxes 2023.csv", "", "/paper.abc.zzz",
-                "/home/jdoe/SHARED_D.IR/cat.mov", ""};
+                "/home/jdoe/SHARED_D.IR/cat.mov", "/home/user/.bashrc", ""};
         String[] originalFilenames = {"", "D:\\Users\\jdoe\\interesting.folder\\a.table", "flowers.456.123",
-                "/home/jdoe/SHARED_D.IR/cat", ""};
+                "/home/jdoe/SHARED_D.IR/cat", "taxes.thisfileextensionistoolong", ""};
 
-        String[][] extensions = {{"csv"}, {"table"}, {"zzz", "123"}, {"mov"}, {""}};
+        String[][] extensions = {{"csv"}, {"table"}, {"zzz", "123"}, {"mov"}, {"bashrc"}, {""}};
 
         final IBaseDataObject ibdo = new BaseDataObject();
 

--- a/src/test/java/emissary/output/DropOffUtilTest.java
+++ b/src/test/java/emissary/output/DropOffUtilTest.java
@@ -663,6 +663,17 @@ class DropOffUtilTest extends UnitTest {
         assertEquals("theOtherFile.csv", bestFilenames.get(1), "The Original-Filename should have been extracted");
     }
 
+    @Test
+    void getFullFilepathsFromParamsCustomFields() {
+        IBaseDataObject ibdo = new BaseDataObject();
+        ibdo.setParameter("CustomField", "customName.txt");
+        ibdo.setParameter(ORIGINAL_FILENAME, "groceries.xml");
+        List<String> bestFilenames = DropOffUtil.getFullFilepathsFromParams(ibdo, new String[] {"CustomField"});
+
+        assertEquals(1, bestFilenames.size(), "Only one filename should have been extracted");
+        assertEquals("customName.txt", bestFilenames.get(0), "Only the value in CustomField should have been extracted");
+    }
+
     private void setupMetadata(IBaseDataObject bdo, String fieldValue, DropOffUtil.FileTypeCheckParameter fileTypeCheckParameter) {
         bdo.clearParameters();
         bdo.putParameter(fileTypeCheckParameter.getFieldName(), fieldValue);

--- a/src/test/java/emissary/output/DropOffUtilTest.java
+++ b/src/test/java/emissary/output/DropOffUtilTest.java
@@ -603,38 +603,33 @@ class DropOffUtilTest extends UnitTest {
     }
 
     @Test
-    void testExtractFullFilepaths() {
+    void testExtractFileExtensionsWithFullFilepaths() {
         DropOffUtil util = new DropOffUtil();
 
+        // tests a combination of either FILE_ABSOLUTEPATH and Original-Filename, neither, and both set at once
+        String[] fileAbsolutepaths = {"D:\\Users\\jdoe\\Documents\\Taxes 2023.csv", "", "/paper.abc.zzz",
+                "/home/jdoe/SHARED_D.IR/cat.mov", ""};
+        String[] originalFilenames = {"", "D:\\Users\\jdoe\\interesting.folder\\a.table", "flowers.456.123",
+                "/home/jdoe/SHARED_D.IR/cat", ""};
+
+        String[][] extensions = {{"csv"}, {"table"}, {"zzz", "123"}, {"mov"}, {""}};
+
         final IBaseDataObject ibdo = new BaseDataObject();
-        ibdo.setParameter(FILE_ABSOLUTEPATH, "D:\\Users\\jdoe\\Documents\\Taxes 2023.csv");
-        util.extractUniqueFileExtensions(ibdo);
-        assertEquals("csv", ibdo.getStringParameter(FILEXT), "FILEXT should be extracted");
-        ibdo.setParameter(FILEXT, "");
 
-        ibdo.setParameter(FILE_ABSOLUTEPATH, "D:\\Users\\jdoe\\interesting.folder\\a.table");
-        util.extractUniqueFileExtensions(ibdo);
-        assertEquals("table", ibdo.getStringParameter(FILEXT), "FILEXT should be extracted");
-        ibdo.setParameter(FILEXT, "");
-
-        ibdo.setParameter(FILE_ABSOLUTEPATH, "/paper.abc.zzz");
-        util.extractUniqueFileExtensions(ibdo);
-        assertEquals("zzz", ibdo.getStringParameter(FILEXT), "FILEXT should be extracted");
-        ibdo.setParameter(FILEXT, "");
-
-        ibdo.setParameter(FILE_ABSOLUTEPATH, "flowers.456.123");
-        util.extractUniqueFileExtensions(ibdo);
-        assertEquals("123", ibdo.getStringParameter(FILEXT), "FILEXT should be extracted");
-        ibdo.setParameter(FILEXT, "");
-
-        ibdo.setParameter(FILE_ABSOLUTEPATH, "/home/jdoe/SHARED_D.IR/cat.mov");
-        util.extractUniqueFileExtensions(ibdo);
-        assertEquals("mov", ibdo.getStringParameter(FILEXT), "FILEXT should be extracted");
-        ibdo.setParameter(FILEXT, "");
-
-        ibdo.setParameter(FILE_ABSOLUTEPATH, "/home/jdoe/SHARED_D.IR/cat");
-        util.extractUniqueFileExtensions(ibdo);
-        assertEquals("", ibdo.getStringParameter(FILEXT), "FILEXT should not be extracted if there is no period in the filename");
+        for (int i = 0; i < fileAbsolutepaths.length; i++) {
+            ibdo.setParameter(FILE_ABSOLUTEPATH, fileAbsolutepaths[i]);
+            ibdo.setParameter(ORIGINAL_FILENAME, originalFilenames[i]);
+            util.extractUniqueFileExtensions(ibdo);
+            for (String extension : extensions[i]) {
+                assertEquals(extensions[i].length, ibdo.getParameter(FILEXT).size(), "Only "
+                        + extensions[i].length + " file extensions should have been extracted");
+                assertTrue(ibdo.getParameter(FILEXT).contains(extension), "FILEXT should be extracted");
+            }
+            // reset for the next test
+            ibdo.setParameter(FILEXT, "");
+            ibdo.setParameter(FILE_ABSOLUTEPATH, "");
+            ibdo.setParameter(ORIGINAL_FILENAME, "");
+        }
     }
 
     @Test
@@ -652,16 +647,16 @@ class DropOffUtilTest extends UnitTest {
 
         ibdo.setParameter(ORIGINAL_FILENAME, "");
         ibdo.setParameter(FILE_ABSOLUTEPATH, "");
-        bestFilenames = DropOffUtil.getBestFilenames(ibdo);
+        bestFilenames = DropOffUtil.getFullFilepathsFromParams(ibdo);
         assertEquals(0, bestFilenames.size(), "No filename should have been found");
 
         ibdo.setParameter(FILE_ABSOLUTEPATH, "theOtherFile.csv");
-        bestFilenames = DropOffUtil.getBestFilenames(ibdo);
+        bestFilenames = DropOffUtil.getFullFilepathsFromParams(ibdo);
         assertEquals(1, bestFilenames.size(), "There should be one filename extracted");
         assertEquals("theOtherFile.csv", bestFilenames.get(0), "The FILE_ABSOLUTEPATH should have been extracted");
 
         ibdo.setParameter(ORIGINAL_FILENAME, "file.docx");
-        bestFilenames = DropOffUtil.getBestFilenames(ibdo);
+        bestFilenames = DropOffUtil.getFullFilepathsFromParams(ibdo);
         assertEquals(2, bestFilenames.size(), "There should be two filenames extracted");
         assertEquals("file.docx", bestFilenames.get(0), "The Original-Filename should have been extracted");
         assertEquals("theOtherFile.csv", bestFilenames.get(1), "The Original-Filename should have been extracted");

--- a/src/test/java/emissary/output/DropOffUtilTest.java
+++ b/src/test/java/emissary/output/DropOffUtilTest.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import static emissary.core.Form.TEXT;
 import static emissary.core.Form.UNKNOWN;
 import static emissary.core.constants.Parameters.EVENT_DATE;
+import static emissary.core.constants.Parameters.FILEXT;
 import static emissary.core.constants.Parameters.FILE_ABSOLUTEPATH;
 import static emissary.core.constants.Parameters.FILE_DATE;
 import static emissary.core.constants.Parameters.ORIGINAL_FILENAME;
@@ -39,7 +40,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DropOffUtilTest extends UnitTest {
     private DropOffUtil util = null;
     private IBaseDataObject payload = null;
-    static final String FILEXT = "FILEXT";
 
     @BeforeEach
     public void createUtil() {
@@ -612,7 +612,7 @@ class DropOffUtilTest extends UnitTest {
         String[] originalFilenames = {"", "D:\\Users\\jdoe\\interesting.folder\\a.table", "flowers.456.123",
                 "/home/jdoe/SHARED_D.IR/cat", "taxes.thisfileextensionistoolong", ""};
 
-        String[][] extensions = {{"csv"}, {"table"}, {"zzz", "123"}, {"mov"}, {"bashrc"}, {""}};
+        String[][] extensions = {{"csv"}, {"table"}, {"zzz", "123"}, {"mov"}, {"bashrc"}, {}};
 
         final IBaseDataObject ibdo = new BaseDataObject();
 
@@ -620,15 +620,16 @@ class DropOffUtilTest extends UnitTest {
             ibdo.setParameter(FILE_ABSOLUTEPATH, fileAbsolutepaths[i]);
             ibdo.setParameter(ORIGINAL_FILENAME, originalFilenames[i]);
             util.extractUniqueFileExtensions(ibdo);
+            if (extensions[i].length == 0) {
+                assertFalse(ibdo.hasParameter(FILEXT));
+            }
             for (String extension : extensions[i]) {
                 assertEquals(extensions[i].length, ibdo.getParameter(FILEXT).size(), "Only "
                         + extensions[i].length + " file extensions should have been extracted");
                 assertTrue(ibdo.getParameter(FILEXT).contains(extension), "FILEXT should be extracted");
             }
             // reset for the next test
-            ibdo.setParameter(FILEXT, "");
-            ibdo.setParameter(FILE_ABSOLUTEPATH, "");
-            ibdo.setParameter(ORIGINAL_FILENAME, "");
+            ibdo.clearParameters();
         }
     }
 
@@ -641,7 +642,7 @@ class DropOffUtilTest extends UnitTest {
     }
 
     @Test
-    void testGetBestFilename() {
+    void testGetFullFilepathsFromParams() {
         IBaseDataObject ibdo = new BaseDataObject();
         List<String> bestFilenames;
 


### PR DESCRIPTION
Modifying DropOffUtil.extractUniqueFileExtensions() to support full file paths and adding FILE_ABSOLUTEPATH as a field to look in to populate the FILEXT field on the IBDO. The existing behavior only used the Original-Filename field to populate FILEXT. 

As part of this change, I also added a static method DropOffUtil.getBestFilenames() that looks at the IBDO in the FILE_ABSOLUTEPATH and Original-Filename fields and returns all values found in both of those fields. 