### PR TITLE
Reverted KffFile back to using RandomAccessFile for file I/O, but now synchronizing access to its use

### DIFF
--- a/src/main/java/emissary/kff/KffFile.java
+++ b/src/main/java/emissary/kff/KffFile.java
@@ -1,18 +1,13 @@
 package emissary.kff;
 
-import emissary.core.channels.FileChannelFactory;
-import emissary.core.channels.SeekableByteChannelFactory;
-
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
-import java.nio.channels.SeekableByteChannel;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.util.concurrent.locks.ReentrantLock;
 import javax.annotation.Nonnull;
 
 /**
@@ -31,10 +26,10 @@ import javax.annotation.Nonnull;
  * </p>
  */
 public class KffFile implements KffFilter {
-    private final Logger logger;
+    private static final Logger logger = LoggerFactory.getLogger(KffFile.class);
 
     /** File containing SHA-1/CRC32 results of known files */
-    protected SeekableByteChannelFactory knownFileFactory;
+    protected RandomAccessFile knownFile;
 
     /** Byte buffer that is mapped to the above file */
     protected ByteBuffer mappedBuf;
@@ -43,7 +38,7 @@ public class KffFile implements KffFilter {
     private int bSearchInitHigh;
 
     public static final int DEFAULT_RECORD_LENGTH = 24;
-    protected int recordLength;
+    protected final int recordLength;
 
     /** String logical name for this filter */
     protected String filterName = "UNKNOWN";
@@ -51,6 +46,8 @@ public class KffFile implements KffFilter {
     protected FilterType ftype = FilterType.Unknown;
 
     protected String myPreferredAlgorithm = "SHA-1";
+
+    protected ReentrantLock reentrantLock = new ReentrantLock();
 
     /**
      * Creates a new instance of KffFile
@@ -81,16 +78,11 @@ public class KffFile implements KffFilter {
         this.filterName = filterName;
         this.recordLength = recordLength;
 
-        // Set logger to run time class
-        logger = LoggerFactory.getLogger(this.getClass());
-
         // Open file in read-only mode
-        knownFileFactory = FileChannelFactory.create(Paths.get(filename));
+        knownFile = new RandomAccessFile(filename, "r");
 
-        // Initial high value for binary search is the largest index
-        try (SeekableByteChannel sbc = knownFileFactory.create()) {
-            bSearchInitHigh = ((int) sbc.size() / recordLength) - 1;
-        }
+        // Initial high value for binary search is largest index
+        bSearchInitHigh = ((int) knownFile.length() / recordLength) - 1;
 
         logger.debug("KFF File {} has {} records", filename, (bSearchInitHigh + 1));
     }
@@ -152,21 +144,22 @@ public class KffFile implements KffFilter {
 
         /* Buffer to hold a record */
         byte[] rec = new byte[recordLength];
-        ByteBuffer byteBuffer = ByteBuffer.wrap(rec);
-        // Search until the indexes cross
-        try (SeekableByteChannel knownFile = knownFileFactory.create()) {
-            while (low <= high) {
-                byteBuffer.clear();
 
+        reentrantLock.lock();
+        try {
+            // Search until the indexes cross
+            while (low <= high) {
                 // Calculate the midpoint
                 int mid = (low + high) >> 1;
 
-                knownFile.position(rec.length * (long) mid);
-                int count = IOUtils.read(knownFile, byteBuffer);
-                if (count != rec.length) {
+                // Multiply the index by the record length to get the buffer position and read the record
+                knownFile.seek(recordLength * mid);
+                int count = knownFile.read(rec);
+                if (count != recordLength) {
                     logger.warn("Short read on KffFile at {} read {} expected {}", (recordLength * mid), count, recordLength);
                     return false;
                 }
+
                 // Compare the record with the target. Adjust the indexes accordingly.
                 int c = compare(rec, hash, crc);
                 if (c < 0) {
@@ -179,8 +172,11 @@ public class KffFile implements KffFilter {
             }
         } catch (IOException e) {
             logger.warn("Exception reading KffFile", e);
+        } finally {
+            if (reentrantLock.isHeldByCurrentThread()) {
+                reentrantLock.unlock();
+            }
         }
-
         // not found
         return false;
     }
@@ -188,21 +184,19 @@ public class KffFile implements KffFilter {
     /**
      * Compares the given hash/crc to the one in the record.
      *
-     * @param rec bytes from the kff binary file, one record long
+     * @param record bytes from the kff binary file, one record long
      * @param hash HASH to compare to record
      * @param crc CRC to compare to record
      * @return &lt;0 if given value is less than record, &gt;0 if given value is greater than record, 0 if they match
      */
-    private int compare(@Nonnull byte[] rec, @Nonnull byte[] hash, long crc) {
+    private int compare(byte[] record, byte[] hash, long crc) {
         int i;
 
-        // Compare the HASHs first. We can't compare the bytes directly
-        // because a Java byte is signed and may generate the wrong
-        // result. We must convert to integers and then mask off the
-        // sign bits to get proper results.
+        // Compare the hashes first. We can't compare the bytes directly because a Java byte is signed and may generate the
+        // wrong result. We must convert to integers and then mask off the sign bits to get proper results.
         for (i = 0; i < hash.length; i++) {
             int ihash = hash[i] & 0xff;
-            int irec = rec[i] & 0xff;
+            int irec = record[i] & 0xff;
             if (ihash < irec) {
                 return -1;
             } else if (ihash > irec) {
@@ -210,11 +204,11 @@ public class KffFile implements KffFilter {
             }
         }
 
-        // If the HASHs match, check the CRCs.
+        // If the hashes match, check the CRCs.
         if (crc != -1L) {
-            for (int j = 24; i < rec.length; i++, j -= 8) {
+            for (int j = 24; i < record.length; i++, j -= 8) {
                 int icrc = ((int) crc >> j) & 0xff;
-                int irec = rec[i] & 0xff;
+                int irec = record[i] & 0xff;
                 if (icrc < irec) {
                     return -1;
                 } else if (icrc > irec) {
@@ -229,10 +223,10 @@ public class KffFile implements KffFilter {
     public boolean check(String fname, ChecksumResults csum) throws Exception {
         byte[] hash = csum.getHash(myPreferredAlgorithm);
         if (hash == null) {
-            logger.warn("Filter cannot be used, {} not computed on {}", myPreferredAlgorithm, fname);
+            logger.warn("Filter cannot be used, " + myPreferredAlgorithm + " not computed on " + fname);
             return false;
         }
-        return binaryFileSearch(hash, csum.getCrc());
+        return binaryFileSearch(csum.getHash(myPreferredAlgorithm), csum.getCrc());
     }
 
     public static void main(String[] args) throws Exception {
@@ -247,8 +241,9 @@ public class KffFile implements KffFilter {
         kff.addAlgorithm("SHA-256");
 
         for (int i = 1; i < args.length; i++) {
-            try (InputStream is = Files.newInputStream(Paths.get(args[i]))) {
-                byte[] buffer = IOUtils.toByteArray(is);
+            try (FileInputStream is = new FileInputStream(args[i])) {
+                byte[] buffer = new byte[is.available()];
+                is.read(buffer);
 
                 KffResult r = kff.check(args[i], buffer);
                 System.out.println(args[i] + ": " + r.isKnown() + " - " + r.getShaString() + " - " + r.getCrc32());

--- a/src/test/java/emissary/kff/KffFileTest.java
+++ b/src/test/java/emissary/kff/KffFileTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 import static emissary.kff.KffFile.DEFAULT_RECORD_LENGTH;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -85,12 +84,6 @@ class KffFileTest extends UnitTest {
         } catch (Exception e) {
             fail(e);
         }
-    }
-
-    @Test
-    void testKffFileMain() {
-        String[] args = {resourcePath, resourcePath};
-        assertDoesNotThrow(() -> KffFile.main(args));
     }
 
     /**


### PR DESCRIPTION
Verified that KffFileTest.testConcurrentKffFileCheckCalls() passes with synchronization in place, fails with the synchronization disabled