### PR TITLE
Removing date parsing bug workaround

### DIFF
--- a/src/main/java/emissary/util/FlexibleDateTimeParser.java
+++ b/src/main/java/emissary/util/FlexibleDateTimeParser.java
@@ -46,22 +46,11 @@ public class FlexibleDateTimeParser {
     private static final String SPACE = " ";
     private static final String EMPTY = "";
 
-    /*
-     * Three-letter time zone IDs often point to multiple time zones. Java 8 uses the time zone over the offset causing
-     * problems with the date/time in verifies. Java 9 fixes this issue. Since 9 isn't released and, even if it was, it
-     * would take some time to transition, a regex is used to strip out the short time zone if there is an offset present.
-     * See java.util.TimeZone and java.time.ZoneId#SHORT_IDS for more info.
-     */
-    private static final String SHORT_TZ_PATTERN = "(\\()?([A-Z]{3})(\\))?"; // (XXX) or XXX
-    private static final String OFFSET_PATTERN = "[ ]?[+-]\\d{2}(:?\\d{2}(:?\\d{2})?)?[ ]?"; // +00 +00:00 +0000
-    private static final String REMOVE_STZ = "|(?<=" + OFFSET_PATTERN + ")" + SHORT_TZ_PATTERN + "|" + SHORT_TZ_PATTERN + "(?=" + OFFSET_PATTERN
-            + ")";
-
     /* Remove all tabs and extra spaces */
     private static final Pattern REPLACE = Pattern.compile("\t+|[ ]+", Pattern.DOTALL);
 
     /* Remove other junk */
-    private static final Pattern REMOVE = Pattern.compile("<.+?>|=0D$" + REMOVE_STZ, Pattern.DOTALL);
+    private static final Pattern REMOVE = Pattern.compile("<.+?>|=0D$", Pattern.DOTALL);
 
     /* timezone - config var: TIMEZONE */
     private static ZoneId timezone = ZoneId.of(DEFAULT_TIMEZONE);

--- a/src/main/resources/emissary/util/FlexibleDateTimeParser.cfg
+++ b/src/main/resources/emissary/util/FlexibleDateTimeParser.cfg
@@ -3,10 +3,7 @@ TIMEZONE = "GMT"
 
 # Formatter Types
 
-# Java 8 seems to have some bugs with certain date time formats that are not fixed until Java 9
-# see: http://bugs.java.com/bugdatabase/view_bug.do?bug_id=8032051
-# anything that starts with yyyy seems to try and follow the ISO8601 standard, so beware (optionals can be ignored)
-FORMAT_DATETIME = "yyyy-M-d[['T'][ ][/]H[:][/]m[:s][[.]SSS][ ][z][ ][Z][XXX]]"
+FORMAT_DATETIME = "yyyy-M-d[['T'][ ][/]H[:][/]m[:s][[.]SSS][ ][z][ ][Z][X]]"
 FORMAT_DATETIME = "[E[,][ ]]d[ ]MMM[,][ ]yy[ H:mm[:ss][ ][z][ ][Z]]"
 FORMAT_DATETIME = "[E[,][ ]]d MMM yyyy K:mm:ss a[ ][z][ ][Z]"
 FORMAT_DATETIME = "[E[,][ ]]d[ ]MMM[.][,][ ]yyyy[ H:mm[:ss][ ][a][ ][z][ ][Z][ ][[(]z[)]]]"

--- a/src/test/java/emissary/util/FlexibleDateTimeParserTest.java
+++ b/src/test/java/emissary/util/FlexibleDateTimeParserTest.java
@@ -88,6 +88,12 @@ class FlexibleDateTimeParserTest extends UnitTest {
         test("Mon, 4 Jan 2016 18:20:30 EST +0000", EXPECTED_FULL, pattern);
         test("Mon, 4 Jan 2016 18:20:30EST+0000", EXPECTED_FULL, pattern);
         test("Mon, 4 Jan 2016 18:20:30EST +0000", EXPECTED_FULL, pattern);
+
+        // additional tests with ambiguous abbreviations -- they should continue to be ignored and have consistent
+        // behavior
+        test("Mon, 4 Jan 2016 18:20:30 +0000 CST", EXPECTED_FULL, pattern);
+        test("Mon, 4 Jan 2016 18:20:30 +0000 ACT", EXPECTED_FULL, pattern);
+        test("Mon, 4 Jan 2016 18:20:30 +0000 BST", EXPECTED_FULL, pattern);
     }
 
     @Test

--- a/src/test/java/emissary/util/FlexibleDateTimeParserTest.java
+++ b/src/test/java/emissary/util/FlexibleDateTimeParserTest.java
@@ -96,9 +96,21 @@ class FlexibleDateTimeParserTest extends UnitTest {
         test("Mon, 4 Jan 2016 18:20:30 +0000 BST", EXPECTED_FULL, pattern);
     }
 
+    /**
+     * Test to make sure our code can successfully handle dates with shorter offsets because this bug in java 8 was
+     * resolved: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8032051
+     */
+    @Test
+    void parseShortOffsets() {
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-M-d[['T'][ ][/]H[:][/]m[:s][[.]SSS][ ][z][ ][Z][X]]");
+
+        test("2013-12-11T21:25:04+01:00", 1386793504, dtf);
+        test("2013-12-11T21:25:04+01", 1386793504, dtf);
+    }
+
     @Test
     void parse_yyyyMMddTHHmmssSSSX() {
-        DateTimeFormatter pattern = DateTimeFormatter.ofPattern("yyyy-M-d[['T'][ ][/]H[:][/]m[:s][[.]SSS][ ][z][ ][Z][XXX]]");
+        DateTimeFormatter pattern = DateTimeFormatter.ofPattern("yyyy-M-d[['T'][ ][/]H[:][/]m[:s][[.]SSS][ ][z][ ][Z][X]]");
         test("2016-01-04T18:20:30.000Z", EXPECTED_FULL, pattern);
         test("2016-01-04T18:20:30Z", EXPECTED_FULL, pattern);
         test("2016-01-04T18:20:30+00:00", EXPECTED_FULL, pattern);

--- a/src/test/java/emissary/util/FlexibleDateTimeParserTest.java
+++ b/src/test/java/emissary/util/FlexibleDateTimeParserTest.java
@@ -66,14 +66,13 @@ class FlexibleDateTimeParserTest extends UnitTest {
     }
 
     /**
-     * Three-letter time zone IDs often point to multiple timezones. Java 8 uses the timezone over the offset causing
-     * problems with the datetime in verifies. Java 9 fixes this issue. Since 9 isn't released and, even if it was, it would
-     * take some time to transition, a regex strips out the short timezone if there is an offset present.
+     * Three-letter time zone IDs often point to multiple timezones. With Java 9+, there are no longer inconsistencies with
+     * parsing timezones with offsets.
      * <p>
      * See {@link java.util.TimeZone} and {@link java.time.ZoneId#SHORT_IDS}
      */
     @Test
-    void stripThreeLetterTimeZonesWhenThereIsAnOffset() {
+    void parseOffsetWhenThereIsAThreeLetterTimeZone() {
         DateTimeFormatter pattern = DateTimeFormatter.ofPattern("[E[,][ ]]d[ ]MMM[.][,][ ]yyyy[ H:mm[:ss][ ][a][ ][z][ ][Z][ ][[(]z[)]]]");
 
         // without offset we expect the default ZoneId


### PR DESCRIPTION
There two few issues with date parsing in java 8 that should be resolved in java 11. The point of this ticket is to make sure our date parsing code no longer has issues so we can move over to using the DateTimeFormatter from SimpleDateFormat.

 - FlexibleDateTimeParser has a custom workaround of removing offsets from date strings due to an issue with parsing date strings with a time zone and an offset in java 8. The previous behavior would ignore the offset and use the timezone, so we added a custom solution to strip out the three-letter time zone. Now that we are using java11, the modifications are no longer needed so remove this workaround.

 - http://bugs.java.com/bugdatabase/view_bug.do?bug_id=8032051. Added a test to make sure our code is successfully able to parse dates that have a shorter offset.