### PR TITLE
Add a newInputStream() to the IBaseDataObject.

### DIFF
--- a/src/main/java/emissary/core/BaseDataObject.java
+++ b/src/main/java/emissary/core/BaseDataObject.java
@@ -15,10 +15,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
 import java.nio.channels.SeekableByteChannel;
 import java.rmi.Remote;
 import java.util.ArrayList;
@@ -367,6 +369,23 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
             default:
                 return null;
         }
+    }
+
+    /**
+     * Returns a new InputStream to the data that this BaseDataObject contains.
+     * 
+     * NOTE 1: Mutating the data elements of this IBaseDataObject while reading from the InputStream will have indeterminate
+     * results.
+     * 
+     * NOTE 2: The calling code is responsible for closing the returned InputStream.
+     * 
+     * @return a new InputStream to the data that this BaseDataObject contains.
+     */
+    @Override
+    public InputStream newInputStream() {
+        final SeekableByteChannelFactory sbcf = getChannelFactory();
+
+        return sbcf == null ? null : Channels.newInputStream(sbcf.create());
     }
 
     /**

--- a/src/main/java/emissary/core/BaseDataObject.java
+++ b/src/main/java/emissary/core/BaseDataObject.java
@@ -372,14 +372,7 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
     }
 
     /**
-     * Returns a new InputStream to the data that this BaseDataObject contains.
-     * 
-     * NOTE 1: Mutating the data elements of this IBaseDataObject while reading from the InputStream will have indeterminate
-     * results.
-     * 
-     * NOTE 2: The calling code is responsible for closing the returned InputStream.
-     * 
-     * @return a new InputStream to the data that this BaseDataObject contains.
+     * {@inheritDoc}
      */
     @Override
     public InputStream newInputStream() {

--- a/src/main/java/emissary/core/IBaseDataObject.java
+++ b/src/main/java/emissary/core/IBaseDataObject.java
@@ -4,6 +4,7 @@ import emissary.core.channels.SeekableByteChannelFactory;
 import emissary.directory.DirectoryEntry;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Date;
@@ -65,6 +66,18 @@ public interface IBaseDataObject {
      * @param sbcf the new channel factory to set on this object
      */
     void setChannelFactory(final SeekableByteChannelFactory sbcf);
+
+    /**
+     * Returns a new InputStream to the data that this BaseDataObject contains.
+     * 
+     * NOTE 1: Mutating the data elements of this IBaseDataObject while reading from the InputStream will have indeterminate
+     * results.
+     * 
+     * NOTE 2: The calling code is responsible for closing the returned InputStream.
+     * 
+     * @return a new InputStream to the data that this BaseDataObject contains.
+     */
+    InputStream newInputStream();
 
     /**
      * Returns the seekable byte channel factory containing a reference to the data

--- a/src/main/java/emissary/core/IBaseDataObject.java
+++ b/src/main/java/emissary/core/IBaseDataObject.java
@@ -69,13 +69,13 @@ public interface IBaseDataObject {
 
     /**
      * Returns a new InputStream to the data that this BaseDataObject contains.
-     * 
+     * <p>
      * NOTE 1: Mutating the data elements of this IBaseDataObject while reading from the InputStream will have indeterminate
      * results.
-     * 
+     * <p>
      * NOTE 2: The calling code is responsible for closing the returned InputStream.
      * 
-     * @return a new InputStream to the data that this BaseDataObject contains.
+     * @return a new stream that reads the data that this object contains, or null if this object has no data.
      */
     InputStream newInputStream();
 

--- a/src/test/java/emissary/core/BaseDataObjectTest.java
+++ b/src/test/java/emissary/core/BaseDataObjectTest.java
@@ -1420,23 +1420,23 @@ class BaseDataObjectTest extends UnitTest {
 
         ibdo.setData(bytes1);
 
-        final InputStream bytesInputStream = ibdo.newInputStream();
-        final ByteArrayOutputStream bytesOutputStream = new ByteArrayOutputStream();
+        try (final InputStream bytesInputStream = ibdo.newInputStream();
+                final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();) {
+            IOUtils.copy(bytesInputStream, byteArrayOutputStream);
 
-        IOUtils.copy(bytesInputStream, bytesOutputStream);
-
-        assertArrayEquals(bytes1, bytesOutputStream.toByteArray());
+            assertArrayEquals(bytes1, byteArrayOutputStream.toByteArray());
+        }
 
         final byte[] bytes2 = new byte[] {4, 5, 6, 7};
         final SeekableByteChannelFactory sbcf = SeekableByteChannelHelper.memory(bytes2);
 
         ibdo.setChannelFactory(sbcf);
 
-        final InputStream sbcfInputStream = ibdo.newInputStream();
+        try (final InputStream sbcfInputStream = ibdo.newInputStream();
+                final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+            IOUtils.copy(sbcfInputStream, byteArrayOutputStream);
 
-        bytesOutputStream.reset();
-        IOUtils.copy(sbcfInputStream, bytesOutputStream);
-
-        assertArrayEquals(bytes2, bytesOutputStream.toByteArray());
+            assertArrayEquals(bytes2, byteArrayOutputStream.toByteArray());
+        }
     }
 }


### PR DESCRIPTION
This PR adds a convenience method to the IBaseDataObject to create an InputStream from either the byte[] or SeekableByteChannelFactory that defines the data.