### PR TITLE
allow "." character in name of ResourceReader resources

### DIFF
--- a/src/main/java/emissary/util/io/ResourceReader.java
+++ b/src/main/java/emissary/util/io/ResourceReader.java
@@ -106,7 +106,7 @@ public class ResourceReader {
      * Get the resource name
      */
     public String getResourceName(Package pkg, String name) {
-        return (pkg.getName() + "/" + name).replace('.', '/');
+        return (pkg.getName().replace('.', '/') + "/" + name);
     }
 
     /**

--- a/src/test/java/emissary/util/io/ResourceReaderTest.java
+++ b/src/test/java/emissary/util/io/ResourceReaderTest.java
@@ -73,6 +73,7 @@ class ResourceReaderTest extends UnitTest {
         assertEquals("emissary/util/Version.cfg", rr.getConfigDataName(Version.class), "Resource config naming");
         assertEquals("emissary/util/io/foo", rr.getResourceName(this.getClass().getPackage(), "foo"), "Resource package naming");
         assertEquals("emissary/util/io/foo.xml", rr.getXmlName(this.getClass().getPackage(), "foo"), "Resource package naming");
+        assertEquals("emissary/util/io/sample.dat", rr.getResourceName(this.thisPackage, "sample.dat"), "Sample file with extension naming");
     }
 
 }


### PR DESCRIPTION
I'm not sure of a use case where this would not be the desired behavior? It certainly prevents reasonable resource loading today for any file with an extension.