### PR TITLE
Add devcontainer.json and GitHub Codespace Support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+    "name": "Emissary-Java-11",
+    "image": "mcr.microsoft.com/devcontainers/universal:2-linux",
+    "features": {
+        "ghcr.io/devcontainers/features/java:1": {
+            "VERSION": "11",
+            "INSTALL_MAVEN": "true",
+            "MAVEN_VERSION": "3.6.3",
+            "INSTALL_GRADLE": "false"
+        }
+    },
+    "extensions": [
+		"SonarSource.sonarlint-vscode",
+		"vscjava.vscode-java-pack",
+		"streetsidesoftware.code-spell-checker"
+	]
+  }

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -266,6 +266,11 @@ PROJECT_BASE = ${project_loc}/target-eclipse
 
 Unfortunately you will have to do this for every test, that's Eclipse with the M2E plugin for you.
 
+### GitHub Codespaces (VsCode)
+A [devcontainer.json](.devcontainer/devcontainer.json) file is provided to open the repository in GitHub Codespaces for contributions or PR reviews. 
+The codespace is configured to install java 11, maven, and native software to enable builds with all unit test's passing.
+A few helpful VsCode extensions are installed as well as a maven settings file to enable dependency pulls.
+
 ### Netbeans
 
 Unfortunately, we could not find a system property [Netbeans](https://netbeans.org/) sets when running

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ![Emissary Dark Knight - some code just wants to watch the core burn](emissary-knight.png) 
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/gov.nsa/emissary/badge.svg)](https://maven-badges.herokuapp.com/maven-central/gov.nsa/emissary) [![Java CI with Maven](https://github.com/NationalSecurityAgency/emissary/actions/workflows/maven-ci.yml/badge.svg)](https://github.com/NationalSecurityAgency/emissary/actions/workflows/maven-ci.yml) [![CodeQL](https://github.com/NationalSecurityAgency/emissary/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/NationalSecurityAgency/emissary/actions/workflows/codeql-analysis.yml)
+<br>
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/NationalSecurityAgency/emissary?quickstart=1)
+
 
 Table of Contents
 =================


### PR DESCRIPTION
To support browser based contributions and PR reviews. Codespace is configured to complete full maven builds and tests