### PR TITLE
Update RegressionTest to hash alternate views instead of base64 converting.

### DIFF
--- a/src/main/java/emissary/core/IBaseDataObjectXmlCodecs.java
+++ b/src/main/java/emissary/core/IBaseDataObjectXmlCodecs.java
@@ -631,22 +631,9 @@ public final class IBaseDataObjectXmlCodecs {
 
                     parentElement.addContent(metaElement);
                     metaElement.addContent(preserve(protectedElement(IbdoXmlElementNames.NAME, view.getKey())));
-                    metaElement.addContent(preserve(protectedElementHash(IbdoXmlElementNames.VALUE, view.getValue())));
+                    metaElement.addContent(preserve(protectedElementSha256(IbdoXmlElementNames.VALUE, view.getValue())));
                 }
             }
-        }
-
-        private static Element protectedElementHash(final String name, final byte[] bytes) {
-            final Element element = new Element(name);
-
-            if (ByteUtil.hasNonPrintableValues(bytes)) {
-                element.setAttribute(IBaseDataObjectXmlCodecs.ENCODING_ATTRIBUTE_NAME, IBaseDataObjectXmlCodecs.SHA256);
-                element.addContent(ByteUtil.sha256Bytes(bytes));
-            } else {
-                element.addContent(new String(bytes, StandardCharsets.ISO_8859_1));
-            }
-
-            return element;
         }
     }
 
@@ -729,12 +716,12 @@ public final class IBaseDataObjectXmlCodecs {
     }
 
     /**
-     * Creates a 'protected' element which can be encoded with base64 if it contains unsafe characters
+     * Creates a 'protected' element which can be encoded with base64 if it contains non-printable characters
      * 
-     * See method source for specific definition of 'unsafe'.
+     * See method source for specific definition of 'non-printable'.
      * 
      * @param name of the element
-     * @param bytes to wrap, if they contain unsafe characters
+     * @param bytes to wrap, if they contain non-printable characters
      * @return the created element
      */
     public static Element protectedElementBase64(final String name, final byte[] bytes) {
@@ -747,6 +734,28 @@ public final class IBaseDataObjectXmlCodecs {
 
             element.setAttribute(ENCODING_ATTRIBUTE_NAME, BASE64);
             element.addContent(base64String);
+        } else {
+            element.addContent(new String(bytes, StandardCharsets.ISO_8859_1));
+        }
+
+        return element;
+    }
+
+    /**
+     * Creates a 'protected' element which can be hashed with sha256 if it contains non-printable characters
+     * 
+     * See method source for specific definition of 'non-printable'.
+     * 
+     * @param name of the element
+     * @param bytes to wrap, if they contain non-printable characters.
+     * @return the created element
+     */
+    public static Element protectedElementSha256(final String name, final byte[] bytes) {
+        final Element element = new Element(name);
+
+        if (ByteUtil.hasNonPrintableValues(bytes)) {
+            element.setAttribute(IBaseDataObjectXmlCodecs.ENCODING_ATTRIBUTE_NAME, IBaseDataObjectXmlCodecs.SHA256);
+            element.addContent(ByteUtil.sha256Bytes(bytes));
         } else {
             element.addContent(new String(bytes, StandardCharsets.ISO_8859_1));
         }

--- a/src/test/java/emissary/core/IBaseDataObjectXmlHelperTest.java
+++ b/src/test/java/emissary/core/IBaseDataObjectXmlHelperTest.java
@@ -21,7 +21,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Random;
+import java.util.TreeMap;
 
 import static emissary.core.IBaseDataObjectXmlCodecs.DEFAULT_ELEMENT_DECODERS;
 import static emissary.core.IBaseDataObjectXmlCodecs.DEFAULT_ELEMENT_ENCODERS;
@@ -150,6 +152,10 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
                 actualChildren, SHA256_ELEMENT_ENCODERS);
 
         expectedIbdo.setData(ByteUtil.sha256Bytes(bytes).getBytes(StandardCharsets.ISO_8859_1));
+
+        for (Entry<String, byte[]> entry : new TreeMap<>(expectedIbdo.getAlternateViews()).entrySet()) {
+            expectedIbdo.addAlternateView(entry.getKey(), ByteUtil.sha256Bytes(entry.getValue()).getBytes(StandardCharsets.ISO_8859_1));
+        }
 
         final String sha256Diff = PlaceComparisonHelper.checkDifferences(expectedIbdo, sha256ActualIbdo, expectedChildren,
                 actualChildren, "testSha256Conversion", DiffCheckConfiguration.onlyCheckData());

--- a/src/test/java/emissary/test/core/junit5/RegressionTest.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map.Entry;
+import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -141,6 +143,10 @@ public abstract class RegressionTest extends ExtractionTest {
             final String tname) {
         if (!IBaseDataObjectXmlCodecs.SHA256_ELEMENT_ENCODERS.equals(getEncoders())) {
             return;
+        }
+
+        for (Entry<String, byte[]> entry : new TreeMap<>(payload.getAlternateViews()).entrySet()) {
+            payload.addAlternateView(entry.getKey(), ByteUtil.sha256Bytes(entry.getValue()).getBytes(StandardCharsets.ISO_8859_1));
         }
 
         if (payload.data() != null && ByteUtil.hasNonPrintableValues(payload.data())) {


### PR DESCRIPTION
This PR updates RegressionTest to sha256 hash non-printable alternate views instead of converting them to printable bytes using base64.