### PR TITLE
EmissaryServer shutdown when unannounced places are started in strict-mode

### DIFF
--- a/src/main/java/emissary/server/EmissaryServer.java
+++ b/src/main/java/emissary/server/EmissaryServer.java
@@ -13,6 +13,7 @@ import emissary.core.MetricsManager;
 import emissary.core.Namespace;
 import emissary.core.NamespaceException;
 import emissary.core.ResourceWatcher;
+import emissary.core.sentinel.Sentinel;
 import emissary.directory.DirectoryPlace;
 import emissary.directory.EmissaryNode;
 import emissary.place.IServiceProviderPlace;
@@ -320,6 +321,13 @@ public class EmissaryServer {
             LOG.info("Done pausing server");
         } catch (Exception ex) {
             LOG.error("Error pausing server", ex);
+        }
+
+        try {
+            Sentinel sentinel = Sentinel.lookup();
+            sentinel.quit();
+        } catch (Exception ex) {
+            LOG.warn("No sentinel available");
         }
 
         try {

--- a/src/test/java/emissary/admin/StartupTest.java
+++ b/src/test/java/emissary/admin/StartupTest.java
@@ -59,39 +59,34 @@ class StartupTest extends UnitTest {
     void testInvisPlaceStart() throws IOException {
         // setup node, startup, and DirectoryPlace
         EmissaryNode node = new EmissaryNode();
-        Startup startup = new Startup(node.getNodeConfigurator(), node);
         String location = "http://" + node.getNodeName() + ":" + node.getNodePort();
         dirStartUp();
 
         // test if place is already started before startup
-        startup.activeDirPlaces.add(location + "/PlaceAlreadyStartedTest");
-        startup.placeAlreadyStarted.add(location + "/PlaceAlreadyStartedTest");
-        assertTrue(startup.verifyNoInvisiblePlacesStarted());
-        startup.activeDirPlaces.clear();
-        startup.placeAlreadyStarted.clear();
+        Startup.activeDirPlaces.add(location + "/PlaceAlreadyStartedTest");
+        Startup.placeAlreadyStarted.add(location + "/PlaceAlreadyStartedTest");
+        assertTrue(Startup.verifyNoInvisiblePlacesStarted());
+        Startup.activeDirPlaces.clear();
+        Startup.placeAlreadyStarted.clear();
 
         // test if place is started up normally and is active dir
-        startup.places.put(location, DevNullPlace.class.getSimpleName());
-        startup.activeDirPlaces.add(DevNullPlace.class.getSimpleName());
-        assertTrue(startup.verifyNoInvisiblePlacesStarted());
-        startup.activeDirPlaces.clear();
-        startup.places.remove(location, DevNullPlace.class.getSimpleName());
+        Startup.places.put(location, DevNullPlace.class.getSimpleName());
+        Startup.activeDirPlaces.add(DevNullPlace.class.getSimpleName());
+        assertTrue(Startup.verifyNoInvisiblePlacesStarted());
+        Startup.activeDirPlaces.clear();
+        Startup.places.remove(location, DevNullPlace.class.getSimpleName());
 
         // test unannounced place with active dir
-        startup.activeDirPlaces.add(location + "/PlaceStartUnannouncedTest");
-        assertFalse(startup.verifyNoInvisiblePlacesStarted());
-        startup.activeDirPlaces.clear();
+        Startup.activeDirPlaces.add(location + "/PlaceStartUnannouncedTest");
+        assertFalse(Startup.verifyNoInvisiblePlacesStarted());
+        Startup.activeDirPlaces.clear();
 
         // teardown
         dirTeardown();
     }
 
     @Test
-    void verifyNoInvisiblePlacesStartedHandlesNullLocalPlace() throws IOException {
-        // setup node, startup, and DirectoryPlace
-        EmissaryNode node = new EmissaryNode();
-        Startup startup = new Startup(node.getNodeConfigurator(), node);
-
+    void verifyNoInvisiblePlacesStartedHandlesNullLocalPlace() {
         try (MockedStatic<DirectoryPlace> dirPlace = Mockito.mockStatic(DirectoryPlace.class)) {
 
             DirectoryEntry entry = mock(DirectoryEntry.class);
@@ -105,7 +100,7 @@ class StartupTest extends UnitTest {
 
             dirPlace.when(DirectoryPlace::lookup).thenReturn(directoryPlace);
 
-            assertTrue(startup.verifyNoInvisiblePlacesStarted());
+            assertTrue(Startup.verifyNoInvisiblePlacesStarted());
         }
     }
 

--- a/src/test/java/emissary/server/EmissaryServerIT.java
+++ b/src/test/java/emissary/server/EmissaryServerIT.java
@@ -1,8 +1,11 @@
 package emissary.server;
 
+import emissary.admin.Startup;
 import emissary.client.EmissaryClient;
 import emissary.client.response.MapResponseEntity;
 import emissary.command.ServerCommand;
+import emissary.core.EmissaryException;
+import emissary.directory.EmissaryNode;
 import emissary.test.core.junit5.UnitTest;
 import emissary.util.Version;
 
@@ -15,6 +18,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class EmissaryServerIT extends UnitTest {
 
@@ -49,4 +53,15 @@ class EmissaryServerIT extends UnitTest {
         }
     }
 
+    @Test
+    void testInvisPlacesOnStrictStartUp() throws EmissaryException {
+        ServerCommand cmd = ServerCommand.parse(ServerCommand.class, "--strict");
+        EmissaryServer server = new EmissaryServer(cmd);
+        EmissaryNode node = new EmissaryNode();
+        String location = "http://" + node.getNodeName() + ":" + node.getNodePort();
+        Startup.getInvisPlaces().add(location + "/PlaceStartUnannouncedTest");
+        server.startServer();
+        // make sure server is shutdown due to invis places on strict startup
+        assertFalse(server.isServerRunning());
+    }
 }


### PR DESCRIPTION
If EmissaryServer is started up not in strict-mode, it still will just log unannounced places that are started up.
In strict-mode, the starting of unannounced places will result in EmissaryServer being shutdown.
Added a test to EmissaryServerIT for this, as well as updated StartupTest based on changes made to Startup.