### PR TITLE
Updated RegressionTest so its handling of alternate views mirrors its handling of primary views

### DIFF
--- a/src/test/java/emissary/test/core/junit5/RegressionTest.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTest.java
@@ -177,6 +177,7 @@ public abstract class RegressionTest extends ExtractionTest {
 
     /**
      * Generates a SHA 256 hash of the provided bytes if they contain any non-printable characters
+     * 
      * @param bytes the bytes to evaluate
      * @return a value optionally containing the generated hash
      */


### PR DESCRIPTION
Conditional generation of SHA-256 hash of the view bytes