### PR TITLE
fix Class raw type warning in Factory.java

### DIFF
--- a/src/main/java/emissary/core/Factory.java
+++ b/src/main/java/emissary/core/Factory.java
@@ -60,7 +60,7 @@ public class Factory {
             }
             logger.debug("checking:" + types);
 
-            final Constructor<?> constructor = ConstructorLookupCache.lookup(clazz, types.toArray(new Class[0]));
+            final Constructor<?> constructor = ConstructorLookupCache.lookup(clazz, types.toArray(new Class<?>[0]));
             if (constructor == null) {
                 logger.info("Failed to find constructor for args({}) types ({}) : {}", args.length, types.size(), types);
                 throw new Error("failed to find suitable constructor for class " + className);


### PR DESCRIPTION
```
[WARNING] /home/runner/work/emissary/emissary/src/main/java/emissary/core/Factory.java:[63,103] found raw type: java.lang.Class
  missing type arguments for generic class java.lang.Class<T>
```