### PR TITLE
address warning for unused TimedResource in t-w-r declarations

### DIFF
--- a/src/main/java/emissary/core/HDMobileAgent.java
+++ b/src/main/java/emissary/core/HDMobileAgent.java
@@ -406,7 +406,8 @@ public class HDMobileAgent extends MobileAgent {
         logger.debug("In atPlaceHD {} with {} payload items", place, payloadListArg.size());
 
         List<IBaseDataObject> ret = Collections.emptyList();
-        try (TimedResource tr = resourceWatcherStart(place)) {
+        TimedResource tr = resourceWatcherStart(place);
+        try {
             // Process and get back a list of sprouted payloads
             lastPlaceProcessed = place.getDirectoryEntry().getKey();
 
@@ -440,6 +441,9 @@ public class HDMobileAgent extends MobileAgent {
                 p.replaceCurrentForm(MobileAgent.ERROR_FORM);
             }
         } finally {
+            if (tr != null) {
+                tr.close();
+            }
             if (!(place instanceof EmptyFormPlace)) {
                 for (final IBaseDataObject p : payloadListArg) {
                     if (p.currentFormSize() == 0) {

--- a/src/main/java/emissary/core/HDMobileAgent.java
+++ b/src/main/java/emissary/core/HDMobileAgent.java
@@ -406,8 +406,10 @@ public class HDMobileAgent extends MobileAgent {
         logger.debug("In atPlaceHD {} with {} payload items", place, payloadListArg.size());
 
         List<IBaseDataObject> ret = Collections.emptyList();
-        TimedResource tr = resourceWatcherStart(place);
-        try {
+
+        try (TimedResource tr = resourceWatcherStart(place)) {
+            assert tr != null; // to silence an unused resource warning
+
             // Process and get back a list of sprouted payloads
             lastPlaceProcessed = place.getDirectoryEntry().getKey();
 
@@ -441,9 +443,6 @@ public class HDMobileAgent extends MobileAgent {
                 p.replaceCurrentForm(MobileAgent.ERROR_FORM);
             }
         } finally {
-            if (tr != null) {
-                tr.close();
-            }
             if (!(place instanceof EmptyFormPlace)) {
                 for (final IBaseDataObject p : payloadListArg) {
                     if (p.currentFormSize() == 0) {

--- a/src/main/java/emissary/core/MobileAgent.java
+++ b/src/main/java/emissary/core/MobileAgent.java
@@ -340,7 +340,8 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
     protected void atPlace(final IServiceProviderPlace place, final IBaseDataObject payloadArg) {
         logger.debug("In atPlace {} with {}", place, payloadArg.shortName());
 
-        try (TimedResource timer = resourceWatcherStart(place)) {
+        TimedResource timer = resourceWatcherStart(place);
+        try {
             this.lastPlaceProcessed = place.getDirectoryEntry().getKey();
             if (this.moveErrorsOccurred > 0) {
                 payloadArg.setParameter("AGENT_MOVE_ERRORS", Integer.toString(this.moveErrorsOccurred));
@@ -357,6 +358,9 @@ public abstract class MobileAgent implements IMobileAgent, MobileAgentMBean {
             payloadArg.addProcessingError("atPlace(" + place + "): " + problem);
             payloadArg.replaceCurrentForm(ERROR_FORM);
         } finally {
+            if (timer != null) {
+                timer.close();
+            }
             if (!(place instanceof EmptyFormPlace) && payloadArg.currentFormSize() == 0) {
                 logger.error("Place {} left an empty form stack, changing it to ERROR", place);
                 payloadArg.addProcessingError(place + " left an empty form stack");

--- a/src/main/java/emissary/place/CoordinationPlace.java
+++ b/src/main/java/emissary/place/CoordinationPlace.java
@@ -199,8 +199,9 @@ public class CoordinationPlace extends ServiceProviderPlace {
             List<IBaseDataObject> sprouts = null;
 
             // Like an agent would do it
-            TimedResource tr = resourceWatcherStart(p);
-            try {
+            try (TimedResource tr = resourceWatcherStart(p)) {
+                assert tr != null; // to silence an unused resource warning
+
                 if (hd) {
                     // Do the normal HD processing
                     sprouts = p.agentProcessHeavyDuty(d);
@@ -213,9 +214,6 @@ public class CoordinationPlace extends ServiceProviderPlace {
                 logger.warn("agentProcess {} called from Coordinate problem", (hd ? "HeavyDuty" : "Call"), ex);
                 errorOccurred = true;
             } finally {
-                if (tr != null) {
-                    tr.close();
-                }
                 if (Thread.interrupted()) {
                     logger.warn("Place {} was interrupted during execution.", p);
                 }
@@ -265,7 +263,7 @@ public class CoordinationPlace extends ServiceProviderPlace {
         } catch (EmissaryException ex) {
             logger.debug("No resource monitoring enabled");
         }
-        return tr;
+        return (tr == null) ? TimedResource.EMPTY : tr;
     }
 
     /**


### PR DESCRIPTION
```
[WARNING] /home/runner/work/emissary/emissary/src/main/java/emissary/core/MobileAgent.java:[343,28] auto-closeable resource timer is never referenced in body of corresponding try statement
[WARNING] /home/runner/work/emissary/emissary/src/main/java/emissary/place/CoordinationPlace.java:[201,32] auto-closeable resource tr is never referenced in body of corresponding try statement
[WARNING] /home/runner/work/emissary/emissary/src/main/java/emissary/core/HDMobileAgent.java:[409,28] auto-closeable resource tr is never referenced in body of corresponding try statement
```

The proposed solution is a bit of a step-back since it does not take advantage of the language feature for AutoCloseable resources. This scenario lives in an edge case where the language doesn't expect a usage where the declared resource is never used in the try block. IntelliJ actually has a nod to this and using a variable name of `ignored` silences the IDE warning. That doesn't work for maven and adding the `-try` lint flag is much too large in scope. 

A different solution would be to add `@SuppressWarnings("unused")` on the method, but that's still a bit heavier in scope than I would like. The code could be refactored to minimize the impact of such an annotation if that is preferred though.