### PR TITLE
Improve SegmentChannelFactory testing.

### DIFF
--- a/src/main/java/emissary/core/channels/SegmentChannelFactory.java
+++ b/src/main/java/emissary/core/channels/SegmentChannelFactory.java
@@ -45,7 +45,7 @@ public final class SegmentChannelFactory {
 
         private SegmentChannelFactoryImpl(final SeekableByteChannelFactory seekableByteChannelFactory, final long start,
                 final long length) {
-            Validate.notNull(seekableByteChannelFactory, "Required: seekableByteChannelFactory not null!");
+            Validate.isTrue(seekableByteChannelFactory != null, "Required: seekableByteChannelFactory != null!");
             Validate.isTrue(start >= 0, "Required: start >= 0!");
             Validate.isTrue(length >= 0, "Required: length >= 0!");
             try (SeekableByteChannel sbc = seekableByteChannelFactory.create()) {

--- a/src/test/java/emissary/core/channels/SegmentChannelFactoryTest.java
+++ b/src/test/java/emissary/core/channels/SegmentChannelFactoryTest.java
@@ -3,13 +3,19 @@ package emissary.core.channels;
 import emissary.test.core.junit5.UnitTest;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SegmentChannelFactoryTest extends UnitTest {
@@ -20,14 +26,21 @@ class SegmentChannelFactoryTest extends UnitTest {
         new Random(0).nextBytes(bytes);
 
         final SeekableByteChannelFactory sbcf = InMemoryChannelFactory.create(bytes);
+        final ExceptionChannelFactory ecf = new ExceptionChannelFactory();
 
-        assertThrows(NullPointerException.class, () -> SegmentChannelFactory.create(null, 0, 0));
+        assertThrows(IllegalArgumentException.class, () -> SegmentChannelFactory.create(null, 0, 0));
         assertThrows(IllegalArgumentException.class, () -> SegmentChannelFactory.create(sbcf, -1, 0));
         assertThrows(IllegalArgumentException.class, () -> SegmentChannelFactory.create(sbcf, 0, -1));
         assertThrows(IllegalArgumentException.class, () -> SegmentChannelFactory.create(sbcf, bytes.length + 1, 0));
         assertThrows(IllegalArgumentException.class, () -> SegmentChannelFactory.create(sbcf, 0, bytes.length + 1));
-        assertThrows(IllegalArgumentException.class,
-                () -> SegmentChannelFactory.create(new ExceptionChannelFactory(), 0, 0));
+        assertThrows(IllegalArgumentException.class, () -> SegmentChannelFactory.create(ecf, 0, 0));
+
+        final CheckCloseChannelFactory cccf = new CheckCloseChannelFactory();
+
+        try (SeekableByteChannel sbc = SegmentChannelFactory.create(cccf, 0, 0).create()) {
+        }
+
+        assertEquals(List.of(true, true), cccf.isClosedList);
 
         // Test all start and length combinations.
         for (int start = 0; start <= bytes.length; start++) {
@@ -57,6 +70,37 @@ class SegmentChannelFactoryTest extends UnitTest {
                 @Override
                 protected long sizeImpl() throws IOException {
                     throw new IOException("Test SBC that only throws IOExceptions!");
+                }
+            };
+        }
+    }
+
+    private static class CheckCloseChannelFactory implements SeekableByteChannelFactory {
+        private final AtomicInteger instanceNumber = new AtomicInteger(0);
+
+        public final List<Boolean> isClosedList = Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        public SeekableByteChannel create() {
+            LoggerFactory.getLogger(SegmentChannelFactoryTest.class).info("CHECKCLOSE", new Throwable("CHECKCLOSE"));
+            isClosedList.add(false);
+
+            return new AbstractSeekableByteChannel() {
+                final int myInstanceNumber = instanceNumber.getAndIncrement();
+
+                @Override
+                protected void closeImpl() throws IOException {
+                    isClosedList.set(myInstanceNumber, true);
+                }
+
+                @Override
+                protected int readImpl(ByteBuffer byteBuffer) throws IOException {
+                    return 0;
+                }
+
+                @Override
+                protected long sizeImpl() throws IOException {
+                    return 1;
                 }
             };
         }


### PR DESCRIPTION
This PR improved the testing of SegmentChannelFactory primarily by ensuring that closing the channel also closes the underlying SeekableByteChannel.