### PR TITLE
fail builds when duplicate resources detected

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -925,8 +925,8 @@
             </exceptions>
             <printEqualFiles>false</printEqualFiles>
             <failBuildInCaseOfDifferentContentConflict>true</failBuildInCaseOfDifferentContentConflict>
-            <failBuildInCaseOfEqualContentConflict>false</failBuildInCaseOfEqualContentConflict>
-            <failBuildInCaseOfConflict>false</failBuildInCaseOfConflict>
+            <failBuildInCaseOfEqualContentConflict>true</failBuildInCaseOfEqualContentConflict>
+            <failBuildInCaseOfConflict>true</failBuildInCaseOfConflict>
             <checkCompileClasspath>true</checkCompileClasspath>
             <checkRuntimeClasspath>true</checkRuntimeClasspath>
             <checkTestClasspath>true</checkTestClasspath>


### PR DESCRIPTION
this activates when running `mvn clean verify`