### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "Maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+      day: "friday"
+    labels:
+      - "CI/CD"
+      - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "Maven"
+  - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Check for maven updates daily and action updates weekly.

Motivation to this change was a lot of actions need version updates and wanted to see if this can create PR's for those updates.