### PR TITLE
Commons updates (codec, io, compress, lang)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dep.commons-compress.version>1.24.0</dep.commons-compress.version>
     <dep.commons-exec.version>1.3</dep.commons-exec.version>
     <dep.commons-io.version>2.13.0</dep.commons-io.version>
-    <dep.commons-lang.version>3.12.0</dep.commons-lang.version>
+    <dep.commons-lang.version>3.13.0</dep.commons-lang.version>
     <dep.commons-pool2.version>2.11.1</dep.commons-pool2.version>
     <dep.dropwizard.metrics.version>4.2.4</dep.dropwizard.metrics.version>
     <dep.errorprone.version>2.23.0</dep.errorprone.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <checkstyleFormatter>${project.basedir}/contrib/checkstyle.xml</checkstyleFormatter>
     <dep.commons-codec.version>1.16.0</dep.commons-codec.version>
     <dep.commons-collections.version>4.4</dep.commons-collections.version>
-    <dep.commons-compress.version>1.21</dep.commons-compress.version>
+    <dep.commons-compress.version>1.24.0</dep.commons-compress.version>
     <dep.commons-exec.version>1.3</dep.commons-exec.version>
     <dep.commons-io.version>2.13.0</dep.commons-io.version>
     <dep.commons-lang.version>3.12.0</dep.commons-lang.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <dep.commons-collections.version>4.4</dep.commons-collections.version>
     <dep.commons-compress.version>1.21</dep.commons-compress.version>
     <dep.commons-exec.version>1.3</dep.commons-exec.version>
-    <dep.commons-io.version>2.11.0</dep.commons-io.version>
+    <dep.commons-io.version>2.13.0</dep.commons-io.version>
     <dep.commons-lang.version>3.12.0</dep.commons-lang.version>
     <dep.commons-pool2.version>2.11.1</dep.commons-pool2.version>
     <dep.dropwizard.metrics.version>4.2.4</dep.dropwizard.metrics.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <EMISSARY_VERSION>${project.version}</EMISSARY_VERSION>
     <argLine />
     <checkstyleFormatter>${project.basedir}/contrib/checkstyle.xml</checkstyleFormatter>
-    <dep.commons-codec.version>1.15</dep.commons-codec.version>
+    <dep.commons-codec.version>1.16.0</dep.commons-codec.version>
     <dep.commons-collections.version>4.4</dep.commons-collections.version>
     <dep.commons-compress.version>1.21</dep.commons-compress.version>
     <dep.commons-exec.version>1.3</dep.commons-exec.version>


### PR DESCRIPTION
All tests complete successfully.
A number of depreciation warnings have appeared - due to commons-compress update

Release notes:
https://commons.apache.org/proper/commons-codec/changes-report.html#a1.16.0
https://commons.apache.org/proper/commons-io/changes-report.html#a2.12.0
https://commons.apache.org/proper/commons-io/changes-report.html#a2.13.0
https://commons.apache.org/proper/commons-compress/changes-report.html#a1.22
https://commons.apache.org/proper/commons-compress/changes-report.html#a1.23.0
https://commons.apache.org/proper/commons-compress/changes-report.html#a1.24.0
https://commons.apache.org/proper/commons-lang/changes-report.html#a3.13.0