### PR TITLE
guava 32.0.0-jre -> 32.1.2-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dep.dropwizard.metrics.version>4.2.4</dep.dropwizard.metrics.version>
     <dep.errorprone.version>2.23.0</dep.errorprone.version>
     <dep.gson.version>2.8.9</dep.gson.version>
-    <dep.guava.version>32.0.0-jre</dep.guava.version>
+    <dep.guava.version>32.1.2-jre</dep.guava.version>
     <dep.httpclient.version>5.2.1</dep.httpclient.version>
     <dep.httpcore.version>5.2.1</dep.httpcore.version>
     <dep.impsort.version>1.8.0</dep.impsort.version>


### PR DESCRIPTION
Test cases look good.
Release notes:
https://github.com/google/guava/releases

Conflicting reports of availability.

Drafting pending further verification.