### PR TITLE
commons-lang 3.12.0 -> 3.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dep.commons-compress.version>1.21</dep.commons-compress.version>
     <dep.commons-exec.version>1.3</dep.commons-exec.version>
     <dep.commons-io.version>2.11.0</dep.commons-io.version>
-    <dep.commons-lang.version>3.12.0</dep.commons-lang.version>
+    <dep.commons-lang.version>3.13.0</dep.commons-lang.version>
     <dep.commons-pool2.version>2.11.1</dep.commons-pool2.version>
     <dep.dropwizard.metrics.version>4.2.4</dep.dropwizard.metrics.version>
     <dep.errorprone.version>2.23.0</dep.errorprone.version>


### PR DESCRIPTION
Test cases look good.
Release notes:
https://commons.apache.org/proper/commons-lang/changes-report.html#a3.13.0

Conflicting reports of availability.

Drafting pending further verification.