### PR TITLE
commons-compress 1.21 -> 1.24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <checkstyleFormatter>${project.basedir}/contrib/checkstyle.xml</checkstyleFormatter>
     <dep.commons-codec.version>1.15</dep.commons-codec.version>
     <dep.commons-collections.version>4.4</dep.commons-collections.version>
-    <dep.commons-compress.version>1.21</dep.commons-compress.version>
+    <dep.commons-compress.version>1.24.0</dep.commons-compress.version>
     <dep.commons-exec.version>1.3</dep.commons-exec.version>
     <dep.commons-io.version>2.11.0</dep.commons-io.version>
     <dep.commons-lang.version>3.12.0</dep.commons-lang.version>


### PR DESCRIPTION
Test cases look good.
Release notes:
https://commons.apache.org/proper/commons-compress/changes-report.html#a1.22
https://commons.apache.org/proper/commons-compress/changes-report.html#a1.23.0
https://commons.apache.org/proper/commons-compress/changes-report.html#a1.24.0

Conflicting reports of availability.

Drafting pending further verification.