### PR TITLE
Remove deprecated defaultString()

### DIFF
--- a/src/main/java/emissary/core/sentinel/Sentinel.java
+++ b/src/main/java/emissary/core/sentinel/Sentinel.java
@@ -255,7 +255,7 @@ public class Sentinel implements Runnable {
         }
 
         public static String getPlaceName(String directoryEntryKey) {
-            return StringUtils.defaultString(StringUtils.substringAfterLast(directoryEntryKey, "/"), "");
+            return StringUtils.defaultString(StringUtils.substringAfterLast(directoryEntryKey, "/"));
         }
 
         public long getTimer() {


### PR DESCRIPTION
Super simple fix to replace deprecated defaultString with non-deprecated format and remove maven-compiler warning.

https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/StringUtils.html
`[defaultString]
Returns either the passed in String, or if the String is null, an empty String ("").`