### PR TITLE
Addressing auto-closeable warnings

### DIFF
--- a/src/test/java/emissary/core/channels/AbstractSeekableByteChannelTest.java
+++ b/src/test/java/emissary/core/channels/AbstractSeekableByteChannelTest.java
@@ -51,21 +51,16 @@ class AbstractSeekableByteChannelTest extends UnitTest {
 
     @Test
     void testOpenClose() throws IOException {
-        try (SeekableByteChannel sbc = new TestSeekableByteChannel(10)) {
-            assertTrue(sbc.isOpen());
+        SeekableByteChannel sbc = new TestSeekableByteChannel(10);
+        assertTrue(sbc.isOpen());
+        sbc.close();
+        assertFalse(sbc.isOpen());
 
-            sbc.close();
+        assertThrows(ClosedChannelException.class, () -> sbc.size());
+        assertThrows(ClosedChannelException.class, () -> sbc.read(ByteBuffer.allocate(5)));
+        assertThrows(ClosedChannelException.class, () -> sbc.position());
+        assertThrows(ClosedChannelException.class, () -> sbc.position(5));
 
-            assertFalse(sbc.isOpen());
-
-            sbc.close();
-
-            assertFalse(sbc.isOpen());
-            assertThrows(ClosedChannelException.class, () -> sbc.size());
-            assertThrows(ClosedChannelException.class, () -> sbc.read(ByteBuffer.allocate(5)));
-            assertThrows(ClosedChannelException.class, () -> sbc.position());
-            assertThrows(ClosedChannelException.class, () -> sbc.position(5));
-        }
     }
 
     @Test

--- a/src/test/java/emissary/core/channels/FileChannelFactoryTest.java
+++ b/src/test/java/emissary/core/channels/FileChannelFactoryTest.java
@@ -68,18 +68,11 @@ class FileChannelFactoryTest extends UnitTest {
 
     @Test
     void testClose() throws IOException {
-        try (final SeekableByteChannel sbc = sbcf.create()) {
-            assertTrue(sbc.isOpen());
-            sbc.close();
-            assertFalse(sbc.isOpen());
-        }
-
-        try (final SeekableByteChannel sbc = sbcf.create()) {
-            assertTrue(sbc.isOpen());
-            sbc.read(ByteBuffer.allocate(1));
-            sbc.close();
-            assertFalse(sbc.isOpen());
-        }
+        final SeekableByteChannel sbc = sbcf.create();
+        assertTrue(sbc.isOpen());
+        sbc.read(ByteBuffer.allocate(1));
+        sbc.close();
+        assertFalse(sbc.isOpen());
     }
 
     @Test

--- a/src/test/java/emissary/core/channels/InputStreamChannelFactoryTest.java
+++ b/src/test/java/emissary/core/channels/InputStreamChannelFactoryTest.java
@@ -59,13 +59,13 @@ class InputStreamChannelFactoryTest extends UnitTest {
 
     @Test
     void testClose() throws IOException {
-        try (SeekableByteChannel sbc = InputStreamChannelFactory.create(testBytes.length, new TestInputStreamFactory(testBytes)).create()) {
+        SeekableByteChannel sbc = InputStreamChannelFactory.create(testBytes.length, new TestInputStreamFactory(testBytes)).create();
             // Call close twice - should not do or throw anything beyond the first time.
             sbc.close();
             assertFalse(sbc.isOpen());
+
             assertDoesNotThrow(() -> sbc.close());
             assertFalse(sbc.isOpen());
-        }
     }
 
     @Test

--- a/src/test/java/emissary/core/channels/InputStreamChannelFactoryTest.java
+++ b/src/test/java/emissary/core/channels/InputStreamChannelFactoryTest.java
@@ -60,12 +60,12 @@ class InputStreamChannelFactoryTest extends UnitTest {
     @Test
     void testClose() throws IOException {
         SeekableByteChannel sbc = InputStreamChannelFactory.create(testBytes.length, new TestInputStreamFactory(testBytes)).create();
-            // Call close twice - should not do or throw anything beyond the first time.
-            sbc.close();
-            assertFalse(sbc.isOpen());
+        // Call close twice - should not do or throw anything beyond the first time.
+        sbc.close();
+        assertFalse(sbc.isOpen());
 
-            assertDoesNotThrow(() -> sbc.close());
-            assertFalse(sbc.isOpen());
+        assertDoesNotThrow(() -> sbc.close());
+        assertFalse(sbc.isOpen());
     }
 
     @Test


### PR DESCRIPTION
Decided to remove the try-with-resources blocks altogether to resolve the build warnings. If needed, I can make them try-finally so that there aren't any "explicit call to close()" warnings.