### PR TITLE
remove janino dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,11 +389,6 @@
       <artifactId>httpclient5</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.janino</groupId>
-      <artifactId>janino</artifactId>
-      <version>3.1.7</version>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-plus</artifactId>
     </dependency>


### PR DESCRIPTION
this came in with https://github.com/NationalSecurityAgency/emissary/commit/ea905bb2a69f8f88d9943ac3b8bf5bbc135b8614 but it may not be needed anymore?