### PR TITLE
switch to using main branch in actions

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -29,7 +29,7 @@ jobs:
           echo "BRANCH=$([ -n "${{ inputs.branch }}" ] && echo "${{ inputs.branch }}" || echo "${{ github.ref_name }}")" >> "$GITHUB_ENV"
 
       - name: Check for protected branch
-        if: ${{ env.BRANCH == 'master' }}
+        if: ${{ env.BRANCH == 'main' }}
         run: |
           echo "Cannot cherry pick to protected branch"
           exit 1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,10 +14,10 @@ name: "CodeQL"
 
 on: # yamllint disable-line rule:truthy
   push:
-    branches: [master, release-*]
+    branches: [main, release-*]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master, release-*]
+    branches: [main, release-*]
   schedule:
     - cron: "15 19 * * 1"
 

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -3,9 +3,9 @@ name: Lint Codebase
 
 on: # yamllint disable-line rule:truthy
   push:
-    branches: [master, release/**, patch/**]
+    branches: [main, release/**, patch/**]
   pull_request:
-    branches: [master, release/**, patch/**]
+    branches: [main, release/**, patch/**]
 
 permissions:
   contents: read

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -3,9 +3,9 @@ name: Java CI with Maven
 
 on: # yamllint disable-line rule:truthy
   push:
-    branches: [master, release/**, patch/**]
+    branches: [main, release/**, patch/**]
   pull_request:
-    branches: [master, release/**, patch/**]
+    branches: [main, release/**, patch/**]
 
 jobs:
   build:

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -93,7 +93,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "emissary-master -- Commit: <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|${{ github.sha }}> merged by ${{ github.actor }}.\nCI Job Status: *${{ join(needs.*.result, ' ')}}*"
+                    "text": "emissary-main -- Commit: <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|${{ github.sha }}> merged by ${{ github.actor }}.\nCI Job Status: *${{ join(needs.*.result, ' ')}}*"
                   }
                 }
               ]

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check release is using correct branch
-        if: ${{ github.event.inputs.release_type == 'release' && github.ref_name != 'master' }}
+        if: ${{ github.event.inputs.release_type == 'release' && github.ref_name != 'main' }}
         run: |
-          echo "Release is not using the correct branch, please target 'master'"
+          echo "Release is not using the correct branch, please target 'main'"
           exit 1
       - name: Check milestone release type is using correct branch
-        if: ${{ github.event.inputs.release_type == 'milestone' && github.ref_name != 'master' }}
+        if: ${{ github.event.inputs.release_type == 'milestone' && github.ref_name != 'main' }}
         run: |
-          echo "Milestone release is not using the correct branch, please target 'master'"
+          echo "Milestone release is not using the correct branch, please target 'main'"
           exit 1
       - name: Check milestone has release suffix
         if: ${{ github.event.inputs.release_type == 'milestone' && github.event.inputs.release_suffix == '' }}
@@ -143,7 +143,7 @@ jobs:
         run: git push origin :${{ github.ref_name }}
 
   snapshot-bump:
-    if: ${{ github.event.inputs.release_type == 'release' && github.ref_name == 'master' }}
+    if: ${{ github.event.inputs.release_type == 'release' && github.ref_name == 'main' }}
     needs: release
     runs-on: ubuntu-latest
     permissions:
@@ -183,7 +183,7 @@ jobs:
           git push -u origin ${{ env.PR_BRANCH }}
 
       - name: Create pull request
-        run: gh pr create -B master -H ${{ env.PR_BRANCH }} --title 'next development iteration ${{ env.NEXT_DEV_VERSION }}' --body 'Created by GitHub Action'
+        run: gh pr create -B main -H ${{ env.PR_BRANCH }} --title 'next development iteration ${{ env.NEXT_DEV_VERSION }}' --body 'Created by GitHub Action'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/maven-version.yml
+++ b/.github/workflows/maven-version.yml
@@ -61,6 +61,6 @@ jobs:
           git push -u origin ${{ env.PR_BRANCH }}
 
       - name: Create pull request
-        run: gh pr create -B master -H ${{ env.PR_BRANCH }} --title 'next development iteration ${{ github.event.inputs.next_version }}' --body 'Created by GitHub Action'
+        run: gh pr create -B main -H ${{ env.PR_BRANCH }} --title 'next development iteration ${{ github.event.inputs.next_version }}' --body 'Created by GitHub Action'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,31 +17,31 @@ Release process uses GitHub actions and involves:
   - Remove the "-SNAPSHOT" suffix from the version and create scm tag
   - Create a GitHub release and upload artifacts
 - If patch release, delete the patch branch
-- For a formal release only, increment snapshot version on a branch and open a pull request 
+- For a formal release only, increment snapshot version on a branch and open a pull request
 - Publish the artifacts to GitHub Maven Repo
 
-The release process used for this repository creates a branch for every release that is prefixed with `release/`. Tags are not added nor are releases performed on the `master` branch. 
-The `master` branch is the target for merging new commits and for development releases (-SNAPSHOT) only. All patches will originate using a `patch/` prefixed branch and once complete 
-a new `release/` branch will be created. 
+The release process used for this repository creates a branch for every release that is prefixed with `release/`. Tags are not added nor are releases performed on the `main` branch.
+The `main` branch is the target for merging new commits and for development releases (-SNAPSHOT) only. All patches will originate using a `patch/` prefixed branch and once complete 
+a new `release/` branch will be created.
 
 ## Versioning
 
-While not strictly enforced, versioning generally follows the [Semantic Versioning](https://semver.org/) Guide. 
+While not strictly enforced, versioning generally follows the [Semantic Versioning](https://semver.org/) Guide.
 
 ## Release Types
 
 ### Formal Release
 
-Formal release for the project and is intended to be stable. 
+Formal release for the project and is intended to be stable.
 
 ```
 Action: `Maven: Release`
 Options:
-- From: `Branch: master` 
+- From: `Branch: main`
 - Type: `Release`
 - Suffix: Leave blank
 ```
-Creates a branch called `release/<version>` and performs release. One commit is added to a branch called `action/<version>` only to increment to the next snapshot version, and 
+Creates a branch called `release/<version>` and performs release. One commit is added to a branch called `action/<version>` only to increment to the next snapshot version, and
 a pull request is created that needs to be approved and merged to finish the release process.
 
 
@@ -52,7 +52,7 @@ Releases may have bugs or vulnerabilities with a high enough severity that requi
 #### Create Patch Branch
 
 Creating a patch branch can be done manually or using the GitHub action. The action was added as a convenience, and is not required as part
-of the workflow. 
+of the workflow.
 
 Note: When manually creating a patch branch, the name must start with `patch/` and must be based on a release branch, i.e. `release/<version>`.
 ```
@@ -66,7 +66,7 @@ The user can specify one or more commit hashes, separated by spaces, to cherry-p
 
 #### Release Patch
 
-Patch release for the project that intended to fix one or more bugs/vulnerabilities for a release.  Patches are not intended for new functionality 
+Patch release for the project that intended to fix one or more bugs/vulnerabilities for a release.  Patches are not intended for new functionality
 unless it is directly supporting a bugfix/hotfix.
 
 ```
@@ -93,7 +93,7 @@ Options:
 - Suffix: `-M1` <- this is just an example it can be anything, e.g. `M1` OR `-MILESTONE1`
 ```
 
-Creates a branch called `release/<version><suffix>`, i.e. `release/8.0.0-M1`, and performs release. No commits or pull request are created to increment 
+Creates a branch called `release/<version><suffix>`, i.e. `release/8.0.0-M1`, and performs release. No commits or pull request are created to increment
 to the next version.
 
 ## Publishing a Release
@@ -109,7 +109,7 @@ Pushes release artifacts to a repo using `maven deploy`.
 
 ## Publishing a Release to Maven Central
 
-Policy does not allow publishing to maven central via Action and is only authorized to be perforemd by specific individuals. 
+Policy does not allow publishing to maven central via Action and is only authorized to be perforemd by specific individuals.
 
 Using the `oss` profile will make the artifacts available here: [Sonatype/Maven Central](https://central.sonatype.com/artifact/gov.nsa/emissary)
 


### PR DESCRIPTION
This will have to go in tandem with changes in github to use use a new protected branch as well as jenkins jobs internally to understand the new branch name. Any open PRs will need to be re-targeted as well.