### PR TITLE
Changing useObjectTraceLogger variable back to protected

### DIFF
--- a/src/main/java/emissary/pickup/PickUpPlace.java
+++ b/src/main/java/emissary/pickup/PickUpPlace.java
@@ -79,7 +79,7 @@ public abstract class PickUpPlace extends ServiceProviderPlace implements IPickU
     // Metadata items that should always be copied to children
     protected Set<String> ALWAYS_COPY_METADATA_VALS = new HashSet<>();
 
-    private boolean useObjectTraceLogger = false;
+    protected boolean useObjectTraceLogger = false;
 
     public PickUpPlace() throws IOException {
         super();

--- a/src/main/java/emissary/util/ObjectTracing.java
+++ b/src/main/java/emissary/util/ObjectTracing.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import static net.logstash.logback.marker.Markers.appendEntries;
 
+@Deprecated
 public class ObjectTracing {
 
     protected static Logger objectTraceLogger = LoggerFactory.getLogger("objectTrace");;


### PR DESCRIPTION
[This change](https://github.com/NationalSecurityAgency/emissary/pull/630/files) accidentally reverted useObjectTraceLogger back to private (probably due to a rebase issue). Changing it back to protected so it can be referenced by child classes. 

Also deprecating the old utils/ObjectTrace class. The class will be removed at a later date.