### PR TITLE
Excluding YodaCondition from Error-Prone Violations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1420,7 +1420,8 @@
                   -Xep:Java8ApiChecker:OFF \
                   -Xep:UnnecessaryFinal:OFF \
                   -Xep:Var:OFF \
-                  -Xep:Varifier:OFF</arg>
+                  -Xep:Varifier:OFF \
+                  -Xep:YodaCondition:OFF</arg>
               </compilerArgs>
               <annotationProcessorPaths>
                 <path>


### PR DESCRIPTION
Based on discussion in https://github.com/NationalSecurityAgency/emissary/pull/682, excluding YodaCondition complaints from error-prone violations.