### PR TITLE
github-actions :: publish site to github pages in release action 

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -131,6 +131,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Publish site to GitHub Pages
+        run: mvn site site:stage scm-publish:publish-scm -DskipTests
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Delete branch
         continue-on-error: true
         if: ${{ github.event.inputs.release_type == 'patch' && startsWith(github.ref_name, 'patch/') }}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ the path of a set of related payload objects through the workflow and
 the [emissary.directory.DirectoryPlace](src/main/java/emissary/directory/DirectoryPlace.java) which manages the available
 services, their cost and quality and keep the P2P network connected.
 
+### Maven Site and Javadoc hosted on GitHub Pages: https://code.nsa.gov/emissary/
+
 ## Minimum Requirements
 
 - Linux or MacOSX operating system

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,12 @@
     <url>https://github.com/NationalSecurityAgency/emissary/issues</url>
   </issueManagement>
   <ciManagement />
-  <distributionManagement />
+  <distributionManagement>
+    <site>
+      <id>github</id>
+      <url>scm:git:git@github.com:NationalSecurityAgency/emissary.git</url>
+    </site>
+  </distributionManagement>
   <properties>
     <BUILD_TIMESTAMP>${maven.build.timestamp}</BUILD_TIMESTAMP>
     <EMISSARY_VERSION>${project.version}</EMISSARY_VERSION>
@@ -868,6 +873,14 @@
               <delimiter>@</delimiter>
               <!-- to add Ant-like tokens style -->
             </delimiters>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-scm-publish-plugin</artifactId>
+          <version>3.2.1</version>
+          <configuration>
+            <scmBranch>gh-pages</scmBranch>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Builds on top of: https://github.com/NationalSecurityAgency/emissary/pull/701 and will need to be rebased after.

Site gets published to GitHub pages: https://code.nsa.gov/emissary/