### PR TITLE
Revert "remove janino dependency"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -371,6 +371,11 @@
       <artifactId>httpclient5</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.codehaus.janino</groupId>
+      <artifactId>janino</artifactId>
+      <version>3.1.7</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-plus</artifactId>
     </dependency>


### PR DESCRIPTION
Reverts NationalSecurityAgency/emissary#691

Needed for ObjectTracing feature.