### PR TITLE
Update RegressionTest difference output style.

### DIFF
--- a/src/test/java/emissary/test/core/junit5/RegressionTestUtil.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTestUtil.java
@@ -77,7 +77,7 @@ public final class RegressionTestUtil {
     /**
      * Default configuration to only check data when comparing
      */
-    private static final DiffCheckConfiguration DIFF_CHECK = DiffCheckConfiguration.onlyCheckData();
+    private static final DiffCheckConfiguration DIFF_CHECK = DiffCheckConfiguration.configure().enableData().enableKeyValueParameterDiff().build();
 
     /**
      * Logger instance

--- a/src/test/java/emissary/test/core/junit5/RegressionTestUtil.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTestUtil.java
@@ -75,7 +75,7 @@ public final class RegressionTestUtil {
     private static final SAXBuilder XML_BUILDER = new SAXBuilder(XMLReaders.NONVALIDATING);
 
     /**
-     * Default configuration to only check data when comparing
+     * Difference configuration to use when comparing IBDO's.
      */
     private static final DiffCheckConfiguration DIFF_CHECK = DiffCheckConfiguration.configure().enableData().enableKeyValueParameterDiff().build();
 


### PR DESCRIPTION
When PlaceComparisonHelper was updated to have different output styles for differing parameters, RegressionTest used the default style, which is to only show differing keys. This PR updates only RegressionTest to use the more informative differing key/values style.