### PR TITLE
Deprecate IBDO.clone()/BDO.clone() in preparation for deletion per Sonar warning

### DIFF
--- a/src/main/java/emissary/core/BaseDataObject.java
+++ b/src/main/java/emissary/core/BaseDataObject.java
@@ -1310,6 +1310,7 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
     /**
      * Clone this payload
      */
+    @Deprecated
     @Override
     public IBaseDataObject clone() throws CloneNotSupportedException {
         final BaseDataObject c = (BaseDataObject) super.clone();

--- a/src/main/java/emissary/core/IBaseDataObject.java
+++ b/src/main/java/emissary/core/IBaseDataObject.java
@@ -781,6 +781,7 @@ public interface IBaseDataObject {
     /**
      * Support deep copy via clone
      */
+    @Deprecated
     IBaseDataObject clone() throws CloneNotSupportedException;
 
     /**


### PR DESCRIPTION
Sonar has the below warning for IBaseDataObject.clone() and BaseDataObject.clone(). There is an IBaseDataObjectHelper.clone(...) method that will do both the partial clone that BaseDataObject.clone() does along with a full clone. Therefore, the clone methods on IBaseDataObject and BaseDataObject are not needed. They are being deprecated in this PR and then will be deleted in a future PR.

--

WARNING:
Remove this "clone" implementation; use a copy constructor or copy factory instead.

--

REASON:
Many consider clone and Cloneable broken in Java, largely because the rules for overriding clone are tricky and difficult to get right, according to Joshua Bloch:

Object’s clone method is very tricky. It’s based on field copies, and it’s "extra-linguistic." It creates an object without calling a constructor. There are no guarantees that it preserves the invariants established by the constructors. There have been lots of bugs over the years, both in and outside Sun, stemming from the fact that if you just call super.clone repeatedly up the chain until you have cloned an object, you have a shallow copy of the object. The clone generally shares state with the object being cloned. If that state is mutable, you don’t have two independent objects. If you modify one, the other changes as well. And all of a sudden, you get random behavior.

A copy constructor or copy factory should be used instead.