### PR TITLE
Excluding BooleanParameter from error-prone warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1390,6 +1390,7 @@
                   -XepAllSuggestionsAsWarnings \
                   -XepDisableWarningsInGeneratedCode \
                   -Xep:AndroidJdkLibsChecker:OFF \
+                  -Xep:BooleanParameter:OFF \
                   -Xep:DefaultCharset:OFF \
                   -Xep:InlineMeSuggester:OFF \
                   -Xep:InlineTrivialConstant:OFF \
@@ -1398,8 +1399,7 @@
                   -Xep:UnnecessaryFinal:OFF \
                   -Xep:Var:OFF \
                   -Xep:Varifier:OFF \
-                  -Xep:YodaCondition:OFF \
-                  -Xep:BooleanParameter:OFF</arg>
+                  -Xep:YodaCondition:OFF</arg>
               </compilerArgs>
               <annotationProcessorPaths>
                 <path>

--- a/pom.xml
+++ b/pom.xml
@@ -1398,7 +1398,8 @@
                   -Xep:UnnecessaryFinal:OFF \
                   -Xep:Var:OFF \
                   -Xep:Varifier:OFF \
-                  -Xep:YodaCondition:OFF</arg>
+                  -Xep:YodaCondition:OFF \
+                  -Xep:BooleanParameter:OFF</arg>
               </compilerArgs>
               <annotationProcessorPaths>
                 <path>


### PR DESCRIPTION
Parent issue: https://github.com/NationalSecurityAgency/burrito-grande/issues/2600
Excluding `BooleanParameter` error-prone warnings.

BooleanParameter is just adding comments to things like `runTest(800L, 1500L, 200L, 100L, /* simple= */true);` so that you know what the boolean is referencing, but this just makes the code messier, and really is not necessary at all.
