### PR TITLE
moving invis place check out of EmissaryServer

### DIFF
--- a/src/main/java/emissary/command/ServerCommand.java
+++ b/src/main/java/emissary/command/ServerCommand.java
@@ -1,5 +1,6 @@
 package emissary.command;
 
+import emissary.admin.Startup;
 import emissary.client.EmissaryResponse;
 import emissary.command.converter.ProjectBaseConverter;
 import emissary.command.validator.ServerModeValidator;
@@ -124,6 +125,13 @@ public class ServerCommand extends ServiceCommand {
         try {
             LOG.info("Running Emissary Server");
             new EmissaryServer(this).startServer();
+
+            // after server start-up, check if invisible place start-ups occurred on strict server start-up, and shut down server if
+            // so.
+            if (Startup.isInvisPlacesStartedInStrictMode() && EmissaryServer.isStarted()) {
+                EmissaryServer.stopServer(true);
+                LOG.info("Server shut down due to invisible place startups on strict-mode: {}", Startup.getInvisPlaces());
+            }
         } catch (EmissaryException e) {
             LOG.error("Unable to start server", e);
         }

--- a/src/main/java/emissary/server/EmissaryServer.java
+++ b/src/main/java/emissary/server/EmissaryServer.java
@@ -1,6 +1,5 @@
 package emissary.server;
 
-import emissary.admin.Startup;
 import emissary.client.EmissaryClient;
 import emissary.client.EmissaryResponse;
 import emissary.client.HTTPConnectionFactory;
@@ -195,12 +194,6 @@ public class EmissaryServer {
             }
 
             LOG.info("Started EmissaryServer at {}", serverLocation);
-
-            // check if invisible place start-ups occurred on strict server start-up, and shut down server if so.
-            if (Startup.isInvisPlacesStartedInStrictMode() && this.server.isStarted()) {
-                EmissaryServer.stopServer(true);
-                LOG.info("Server shut down due to invisible place startups on strict-mode: {}", Startup.getInvisPlaces());
-            }
 
             return configuredServer;
         } catch (Throwable t) {

--- a/src/test/java/emissary/server/EmissaryServerIT.java
+++ b/src/test/java/emissary/server/EmissaryServerIT.java
@@ -1,11 +1,8 @@
 package emissary.server;
 
-import emissary.admin.Startup;
 import emissary.client.EmissaryClient;
 import emissary.client.response.MapResponseEntity;
 import emissary.command.ServerCommand;
-import emissary.core.EmissaryException;
-import emissary.directory.EmissaryNode;
 import emissary.test.core.junit5.UnitTest;
 import emissary.util.Version;
 
@@ -18,7 +15,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class EmissaryServerIT extends UnitTest {
 
@@ -51,17 +47,5 @@ class EmissaryServerIT extends UnitTest {
             // throws some stopping warning, good place to start when fixing the stop
             server.stop();
         }
-    }
-
-    @Test
-    void testInvisPlacesOnStrictStartUp() throws EmissaryException {
-        ServerCommand cmd = ServerCommand.parse(ServerCommand.class, "--strict");
-        EmissaryServer server = new EmissaryServer(cmd);
-        EmissaryNode node = new EmissaryNode();
-        String location = "http://" + node.getNodeName() + ":" + node.getNodePort();
-        Startup.getInvisPlaces().add(location + "/PlaceStartUnannouncedTest");
-        server.startServer();
-        // make sure server is shutdown due to invis places on strict startup
-        assertFalse(server.isServerRunning());
     }
 }


### PR DESCRIPTION
Moving the invis place check out of EmissaryServer. The hope is with this that this will allow the return of the fully `configuredServer` before shutting down if there are invis places. Can also be moved to ServiceCommand, but I felt this location made the most sense.