### PR TITLE
errorprone :: tackle a handful of single occurrence rules

### DIFF
--- a/src/main/java/emissary/command/FeedCommand.java
+++ b/src/main/java/emissary/command/FeedCommand.java
@@ -104,7 +104,7 @@ public class FeedCommand extends ServiceCommand {
 
         LOG.info("Starting feeder using {} as the workspace class", workspaceClass);
         try {
-            WorkSpace ws = (WorkSpace) Class.forName(workspaceClass).getConstructor(FeedCommand.class).newInstance(this);
+            WorkSpace ws = Class.forName(workspaceClass).asSubclass(WorkSpace.class).getDeclaredConstructor(FeedCommand.class).newInstance();
             ws.run();
         } catch (Exception e) {
             LOG.error("Error running WorkSpace class: {} ", workspaceClass, e);

--- a/src/main/java/emissary/command/HttpCommand.java
+++ b/src/main/java/emissary/command/HttpCommand.java
@@ -16,12 +16,8 @@ import java.io.File;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-/* abstract command to configure http options
- * <p>
- * Used for both running servers and clients, so things
- * like port or host change meaning depending on how it
- * will be used. This class just setup up the config options.
- *
+/**
+ * Abstract command used to set up config options for both servers and clients.
  */
 public abstract class HttpCommand extends BaseCommand {
     static final Logger LOG = LoggerFactory.getLogger(HttpCommand.class);

--- a/src/main/java/emissary/core/DataObjectFactory.java
+++ b/src/main/java/emissary/core/DataObjectFactory.java
@@ -20,7 +20,7 @@ public class DataObjectFactory {
 
     private static final Logger logger = LoggerFactory.getLogger(DataObjectFactory.class);
 
-    /**
+    /*
      * Initialize our implementation details
      */
     static {

--- a/src/main/java/emissary/kff/SpamSumSignature.java
+++ b/src/main/java/emissary/kff/SpamSumSignature.java
@@ -90,7 +90,7 @@ public class SpamSumSignature {
             return false;
         }
 
-        return this.equals((SpamSumSignature) obj);
+        return this.isEqual((SpamSumSignature) obj);
     }
 
     @Override
@@ -98,7 +98,7 @@ public class SpamSumSignature {
         return super.hashCode();
     }
 
-    public boolean equals(SpamSumSignature other) {
+    public boolean isEqual(SpamSumSignature other) {
         if (this.blockSize != other.blockSize) {
             return false;
         }

--- a/src/main/java/emissary/output/DropOffUtil.java
+++ b/src/main/java/emissary/output/DropOffUtil.java
@@ -705,7 +705,7 @@ public class DropOffUtil {
         COMPLETE_FILETYPE("COMPLETE_FILETYPE"), FILETYPE("FILETYPE"), FINAL_ID("FINAL_ID"), FONT_ENCODING("FontEncoding"), POPPED_FORMS(
                 "POPPED_FORMS");
 
-        String fieldName;
+        final String fieldName;
 
         FileTypeCheckParameter(String fieldName) {
             this.fieldName = fieldName;

--- a/src/main/java/emissary/output/roller/JournaledCoalescer.java
+++ b/src/main/java/emissary/output/roller/JournaledCoalescer.java
@@ -22,6 +22,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static emissary.output.roller.journal.Journal.EXT;
@@ -222,7 +223,7 @@ public class JournaledCoalescer implements IJournaler, ICoalescer {
         outputMap.forEach(this::coalesceFiles);
     }
 
-    private void loadJournal(Path path, HashMap<String, Collection<Journal>> outputMap) {
+    private void loadJournal(Path path, Map<String, Collection<Journal>> outputMap) {
         try (JournalReader jr = new JournalReader(path)) {
             Journal j = jr.getJournal();
             outputMap.computeIfAbsent(j.getKey(), k -> new ArrayList<>()).add(j);

--- a/src/main/java/emissary/util/FlexibleDateTimeParser.java
+++ b/src/main/java/emissary/util/FlexibleDateTimeParser.java
@@ -58,7 +58,7 @@ public class FlexibleDateTimeParser {
     /* date time formats - vars: FORMAT_DATETIME */
     private static List<DateTimeFormatter> dateFormats = new ArrayList<>();
 
-    /** init */
+    /* init */
     static {
         configure();
     }

--- a/src/test/java/emissary/core/ResourceWatcherTest.java
+++ b/src/test/java/emissary/core/ResourceWatcherTest.java
@@ -6,8 +6,6 @@ import emissary.place.sample.DevNullPlace;
 import emissary.test.core.junit5.UnitTest;
 
 import com.codahale.metrics.Timer;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -23,16 +21,6 @@ class ResourceWatcherTest extends UnitTest {
 
     public ResourceWatcher resourceWatcher = null;
     public IServiceProviderPlace place = null;
-
-    @Override
-    @BeforeEach
-    public void setUp() throws Exception {}
-
-    @Override
-    @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
-    }
 
     @Test
     void testResourceWatcherWithMultipleThreads() throws Exception {

--- a/src/test/java/emissary/core/channels/ChannelTestHelper.java
+++ b/src/test/java/emissary/core/channels/ChannelTestHelper.java
@@ -16,7 +16,8 @@ public class ChannelTestHelper {
     public static void checkByteArrayAgainstSbc(final byte[] bytesToVerify, final SeekableByteChannelFactory sbcf)
             throws IOException {
         try (final SeekableByteChannel sbc = sbcf.create()) {
-            int startIndex, length;
+            int startIndex;
+            int length;
             for (startIndex = 0; startIndex < bytesToVerify.length; startIndex++) {
                 for (length = bytesToVerify.length - startIndex; length > 0; length--) {
                     checkSegment(sbc, bytesToVerify, startIndex, length);

--- a/src/test/java/emissary/output/filter/DataFilterTest.java
+++ b/src/test/java/emissary/output/filter/DataFilterTest.java
@@ -10,9 +10,7 @@ import emissary.util.shell.Executrix;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,8 +42,6 @@ class DataFilterTest extends UnitTest {
         payload.setData("This is the data".getBytes());
         payload.setFileType("FTYPE");
         payload.setFilename("/this/is/a/testfile");
-        List<IBaseDataObject> payloadList = new ArrayList<>();
-        payloadList.add(payload);
 
         Map<String, Object> params = new HashMap<>();
 
@@ -60,5 +56,4 @@ class DataFilterTest extends UnitTest {
 
         expected.delete();
     }
-
 }

--- a/src/test/java/emissary/parser/MyDataIdentifierTest.java
+++ b/src/test/java/emissary/parser/MyDataIdentifierTest.java
@@ -57,7 +57,7 @@ class DataIdentifierTest extends UnitTest {
 
     @Test
     void testExtensibility() {
-        DataIdentifierT id = new DataIdentifierT();
+        MyDataIdentifier id = new MyDataIdentifier();
         assertEquals(id.getTestStringMaxSize(), id.checkSize(), "String size to test");
 
         // Check byte array
@@ -67,7 +67,7 @@ class DataIdentifierTest extends UnitTest {
     }
 
 
-    private static final class DataIdentifierT extends DataIdentifier {
+    private static final class MyDataIdentifier extends DataIdentifier {
         public int checkSize() {
             return DATA_ID_STR_SZ;
         }

--- a/src/test/java/emissary/place/CoordinationPlaceTest.java
+++ b/src/test/java/emissary/place/CoordinationPlaceTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -56,13 +55,13 @@ class CoordinationPlaceTest extends UnitTest {
     @Test
     void shouldContinue() {
         // test the default behavior
-        assertTrue(place.shouldContinue(Mockito.mock(IBaseDataObject.class), Mockito.mock(IServiceProviderPlace.class)));
+        assertTrue(place.shouldContinue(mock(IBaseDataObject.class), mock(IServiceProviderPlace.class)));
     }
 
     @Test
     void shouldSkip() {
         // test the default behavior
-        assertFalse(place.shouldSkip(Mockito.mock(IBaseDataObject.class), Mockito.mock(IServiceProviderPlace.class)));
+        assertFalse(place.shouldSkip(mock(IBaseDataObject.class), mock(IServiceProviderPlace.class)));
     }
 
     @Test
@@ -74,7 +73,7 @@ class CoordinationPlaceTest extends UnitTest {
 
     @Test
     void processHeavyDuty() throws Exception {
-        when(mockCoordPlace.agentProcessHeavyDuty(any(IBaseDataObject.class))).thenReturn(
+        when(mockCoordPlace.agentProcessHeavyDuty(Mockito.any(IBaseDataObject.class))).thenReturn(
                 Collections.singletonList(DataObjectFactory.getInstance("child testing this".getBytes(), "test_file", "text")));
 
         IBaseDataObject ibdo = DataObjectFactory.getInstance("testing this".getBytes(), "test_file", "text");

--- a/src/test/java/emissary/util/EmissaryIsolatedClassLoaderExtension.java
+++ b/src/test/java/emissary/util/EmissaryIsolatedClassLoaderExtension.java
@@ -17,7 +17,7 @@ public class EmissaryIsolatedClassLoaderExtension implements InvocationIntercept
     @Override
     public void interceptTestMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext,
             ExtensionContext extensionContext) throws Throwable {
-        if (extensionContext.getRequiredTestClass().getClassLoader().getClass().getName().equals(TestClassLoader.class)) {
+        if (extensionContext.getRequiredTestClass().getClassLoader().getClass().getName().equals(TestClassLoader.class.getName())) {
             invocation.proceed();
             return;
         }

--- a/src/test/java/emissary/util/PayloadUtilTest.java
+++ b/src/test/java/emissary/util/PayloadUtilTest.java
@@ -33,9 +33,7 @@ public class PayloadUtilTest extends UnitTest {
         timezone = System.getProperty("user.timezone");
         System.setProperty("user.timezone", "GMT");
 
-        for (char character : validFormCharsString.toCharArray()) {
-            validFormChars.add(character);
-        }
+        validFormCharsString.chars().forEach(character -> validFormChars.add((char) character));
     }
 
     @AfterAll

--- a/src/test/java/emissary/util/io/LoggingPrintStreamTest.java
+++ b/src/test/java/emissary/util/io/LoggingPrintStreamTest.java
@@ -6,6 +6,7 @@ import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.ConsoleAppender;
 import ch.qos.logback.core.read.ListAppender;
+import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang3.Validate;
 import org.apache.log4j.MDC;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static emissary.util.io.LoggingPrintStream.NORMAL_SEPARATOR;
 import static emissary.util.io.LoggingPrintStream.THROWABLE_PREFIX;
-import static org.apache.commons.io.output.NullOutputStream.INSTANCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -43,12 +43,14 @@ class LoggingPrintStreamTest {
         final org.slf4j.event.Level slf4jLevel = org.slf4j.event.Level.TRACE;
 
         assertThrows(NullPointerException.class, () -> new LoggingPrintStream(null, "TEST", logger, slf4jLevel, 1, TimeUnit.SECONDS));
-        assertThrows(NullPointerException.class, () -> new LoggingPrintStream(INSTANCE, null, logger, slf4jLevel, 1, TimeUnit.SECONDS));
-        assertThrows(NullPointerException.class, () -> new LoggingPrintStream(INSTANCE, "TEST", null, slf4jLevel, 1, TimeUnit.SECONDS));
-        assertThrows(NullPointerException.class, () -> new LoggingPrintStream(INSTANCE, "TEST", logger, null, 1, TimeUnit.SECONDS));
+        assertThrows(NullPointerException.class,
+                () -> new LoggingPrintStream(NullOutputStream.INSTANCE, null, logger, slf4jLevel, 1, TimeUnit.SECONDS));
+        assertThrows(NullPointerException.class,
+                () -> new LoggingPrintStream(NullOutputStream.INSTANCE, "TEST", null, slf4jLevel, 1, TimeUnit.SECONDS));
+        assertThrows(NullPointerException.class, () -> new LoggingPrintStream(NullOutputStream.INSTANCE, "TEST", logger, null, 1, TimeUnit.SECONDS));
         assertThrows(IllegalArgumentException.class,
-                () -> new LoggingPrintStream(INSTANCE, "TEST", logger, slf4jLevel, -1, TimeUnit.SECONDS));
-        assertThrows(NullPointerException.class, () -> new LoggingPrintStream(INSTANCE, "TEST", logger, slf4jLevel, 1, null));
+                () -> new LoggingPrintStream(NullOutputStream.INSTANCE, "TEST", logger, slf4jLevel, -1, TimeUnit.SECONDS));
+        assertThrows(NullPointerException.class, () -> new LoggingPrintStream(NullOutputStream.INSTANCE, "TEST", logger, slf4jLevel, 1, null));
     }
 
     @Test
@@ -56,7 +58,7 @@ class LoggingPrintStreamTest {
         final Logger logger = (Logger) LoggerFactory.getLogger(LoggingPrintStream.class);
         final org.slf4j.event.Level slf4jLevel = org.slf4j.event.Level.TRACE;
 
-        LoggingPrintStream loggingPrintStream = new LoggingPrintStream(INSTANCE, "TEST", logger, slf4jLevel, 30, TimeUnit.SECONDS);
+        LoggingPrintStream loggingPrintStream = new LoggingPrintStream(NullOutputStream.INSTANCE, "TEST", logger, slf4jLevel, 30, TimeUnit.SECONDS);
         try {
             loggingPrintStream.close();
         } finally {
@@ -69,19 +71,19 @@ class LoggingPrintStreamTest {
     void testLoggingLevel() {
         LogbackTester logbackTester = new LogbackTester(LoggingPrintStreamTest.class.getName());
         LoggingPrintStream loggingPrintStreamDebug =
-                new LoggingPrintStream(INSTANCE, logbackTester.name + "_DEBUG", logbackTester.logger,
+                new LoggingPrintStream(NullOutputStream.INSTANCE, logbackTester.name + "_DEBUG", logbackTester.logger,
                         org.slf4j.event.Level.DEBUG, 30, TimeUnit.SECONDS);
         LoggingPrintStream loggingPrintStreamError =
-                new LoggingPrintStream(INSTANCE, logbackTester.name + "_ERROR", logbackTester.logger,
+                new LoggingPrintStream(NullOutputStream.INSTANCE, logbackTester.name + "_ERROR", logbackTester.logger,
                         org.slf4j.event.Level.ERROR, 30, TimeUnit.SECONDS);
         LoggingPrintStream loggingPrintStreamInfo =
-                new LoggingPrintStream(INSTANCE, logbackTester.name + "_INFO", logbackTester.logger,
+                new LoggingPrintStream(NullOutputStream.INSTANCE, logbackTester.name + "_INFO", logbackTester.logger,
                         org.slf4j.event.Level.INFO, 30, TimeUnit.SECONDS);
         LoggingPrintStream loggingPrintStreamTrace =
-                new LoggingPrintStream(INSTANCE, logbackTester.name + "_TRACE", logbackTester.logger,
+                new LoggingPrintStream(NullOutputStream.INSTANCE, logbackTester.name + "_TRACE", logbackTester.logger,
                         org.slf4j.event.Level.TRACE, 30, TimeUnit.SECONDS);
         LoggingPrintStream loggingPrintStreamWarn =
-                new LoggingPrintStream(INSTANCE, logbackTester.name + "_WARN", logbackTester.logger,
+                new LoggingPrintStream(NullOutputStream.INSTANCE, logbackTester.name + "_WARN", logbackTester.logger,
                         org.slf4j.event.Level.WARN, 30, TimeUnit.SECONDS);
         try {
             logbackTester.logger.setLevel(Level.ALL);
@@ -128,7 +130,7 @@ class LoggingPrintStreamTest {
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         LoggingPrintStream loggingPrintStream =
-                new LoggingPrintStream(INSTANCE, "STDTEST", logger, slf4jLevel, 30, TimeUnit.SECONDS);
+                new LoggingPrintStream(NullOutputStream.INSTANCE, "STDTEST", logger, slf4jLevel, 30, TimeUnit.SECONDS);
         try {
             final ConsoleAppender<ILoggingEvent> consoleAppender = new ConsoleAppender<>();
             final PatternLayoutEncoder patternLayoutEncoder = new PatternLayoutEncoder();


### PR DESCRIPTION
```
   1 [UnsafeReflectiveConstructionCast]
   1 [NonOverridingEquals]
   1 [NonCanonicalStaticMemberImport]
   1 [NonApiType]
   1 [RedundantOverride]
   1 [MultiVariableDeclaration]
   1 [ModifiedButNotUsed]
   1 [LoopOverCharArray]
   1 [ImmutableEnumChecker]
   1 [EqualsIncompatibleType]
   1 [ClassNamedLikeTypeParameter]
   1 [BadImport]
   1 [AlmostJavadoc]
```