### PR TITLE
upgrade dropwizard metrics to 4.2.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <dep.commons-io.version>2.13.0</dep.commons-io.version>
     <dep.commons-lang.version>3.13.0</dep.commons-lang.version>
     <dep.commons-pool2.version>2.11.1</dep.commons-pool2.version>
-    <dep.dropwizard.metrics.version>4.2.4</dep.dropwizard.metrics.version>
+    <dep.dropwizard.metrics.version>4.2.25</dep.dropwizard.metrics.version>
     <dep.errorprone.version>2.23.0</dep.errorprone.version>
     <dep.gson.version>2.10.1</dep.gson.version>
     <dep.guava.version>32.1.2-jre</dep.guava.version>


### PR DESCRIPTION
Resolves **high** vulnerability in amqp-cleint which is transitive to dropwizard metrics. Latest version of dropwizard upgrades to 5.20.0 of amqp-client

https://ossindex.sonatype.org/component/pkg:maven/com.rabbitmq/amqp-client@5.13.1?utm_source=ossindex-client&utm_medium=integration&utm_content=1.7.0

Emissary SBOM report: https://sbom.sonatype.com/report/T1-118f0f57da8c6b3097cc-e3d8ea0398999-1712343746-99037adeebb341d799462d1f507f865c

After:
```
...
[INFO] +- io.dropwizard.metrics:metrics-graphite:jar:4.2.25:compile
[INFO] |  +- io.dropwizard.metrics:metrics-core:jar:4.2.25:compile
[INFO] |  \- com.rabbitmq:amqp-client:jar:5.20.0:compile
...
```