### PR TITLE
Disconnect internal places in ComparisonPlace.

### DIFF
--- a/src/main/java/emissary/place/ComparisonPlace.java
+++ b/src/main/java/emissary/place/ComparisonPlace.java
@@ -75,6 +75,9 @@ public class ComparisonPlace extends ServiceProviderPlace {
         placeA = createPlace(placeAClassName, placeAConfigName);
         placeB = createPlace(placeBClassName, placeBConfigName);
 
+        placeA.shutDown();
+        placeB.shutDown();
+
         Validate.isTrue(placeA.processMethodImplemented == placeB.processMethodImplemented, PROCESS_PROCESSHD_MSG);
     }
 


### PR DESCRIPTION
Places automatically connect themselves when they are created. The internal places within ComparisonPlace will get flagged as "starting up without being announced" if they are not disconnected. This PR disconnects the internal places since they will be executed specifically by ComparisonPlace.