### PR TITLE
sonarlint :: deprecate finalize method in JournaledCoalescer

### DIFF
--- a/src/main/java/emissary/output/roller/JournaledCoalescer.java
+++ b/src/main/java/emissary/output/roller/JournaledCoalescer.java
@@ -136,7 +136,7 @@ public class JournaledCoalescer implements IJournaler, ICoalescer {
             for (Path entry : stream) {
                 String finalOutputFilename = FilenameUtils.getBaseName(entry.toString());
                 if (isOrphanedFile(finalOutputFilename)) {
-                    finalize(entry, outputPath.resolve(finalOutputFilename));
+                    finalizeRoll(entry, outputPath.resolve(finalOutputFilename));
                 }
             }
         } catch (IOException e) {
@@ -247,7 +247,7 @@ public class JournaledCoalescer implements IJournaler, ICoalescer {
             // Check to see if we already rolled files successfully and crashed on deletion
             if (Files.exists(rolledOutputPath)) {
                 LOG.warn("Full output file already found {}. Deleting old part files.", rolledOutputPath);
-                finalize(journals, rolledOutputPath, finalOutputPath);
+                finalizeRoll(journals, rolledOutputPath, finalOutputPath);
                 return;
             }
 
@@ -267,7 +267,7 @@ public class JournaledCoalescer implements IJournaler, ICoalescer {
             Files.move(workingOutputPath, rolledOutputPath);
             LOG.info("Successfully coalesced {} files into: {}. Size: {}", journals.size(), rolledOutputPath, Files.size(rolledOutputPath));
 
-            finalize(journals, rolledOutputPath, finalOutputPath);
+            finalizeRoll(journals, rolledOutputPath, finalOutputPath);
         } catch (IOException ex) {
             LOG.error("IOException while processing journals for {}", key, ex);
         }
@@ -322,12 +322,24 @@ public class JournaledCoalescer implements IJournaler, ICoalescer {
         return this.rolling;
     }
 
+    /** @deprecated replaced by {@link #finalizeRoll(Collection, Path, Path)} */
+    @Deprecated
     protected void finalize(Collection<Journal> journals, Path rolledOutputPath, Path finalOutputPath) throws IOException {
-        cleanupFiles(journals);
-        finalize(rolledOutputPath, finalOutputPath);
+        finalizeRoll(journals, rolledOutputPath, finalOutputPath);
     }
 
+    /** @deprecated replaced by {@link #finalizeRoll(Path, Path)} */
+    @Deprecated
     protected void finalize(Path rolledOutputPath, Path finalOutputPath) throws IOException {
+        finalizeRoll(rolledOutputPath, finalOutputPath);
+    }
+
+    protected void finalizeRoll(Collection<Journal> journals, Path rolledOutputPath, Path finalOutputPath) throws IOException {
+        cleanupFiles(journals);
+        finalizeRoll(rolledOutputPath, finalOutputPath);
+    }
+
+    protected void finalizeRoll(Path rolledOutputPath, Path finalOutputPath) throws IOException {
         if (!Files.exists(rolledOutputPath)) {
             return;
         }

--- a/src/main/java/emissary/output/roller/JournaledCoalescer.java
+++ b/src/main/java/emissary/output/roller/JournaledCoalescer.java
@@ -323,14 +323,14 @@ public class JournaledCoalescer implements IJournaler, ICoalescer {
     }
 
     /** @deprecated replaced by {@link #finalizeRoll(Collection, Path, Path)} */
-    @Deprecated
-    protected void finalize(Collection<Journal> journals, Path rolledOutputPath, Path finalOutputPath) throws IOException {
+    @Deprecated(since = "8.1.0")
+    protected void finalize(Collection<Journal> journals, Path rolledOutputPath, Path finalOutputPath) throws IOException { // NOSONAR
         finalizeRoll(journals, rolledOutputPath, finalOutputPath);
     }
 
     /** @deprecated replaced by {@link #finalizeRoll(Path, Path)} */
-    @Deprecated
-    protected void finalize(Path rolledOutputPath, Path finalOutputPath) throws IOException {
+    @Deprecated(since = "8.1.0")
+    protected void finalize(Path rolledOutputPath, Path finalOutputPath) throws IOException { // NOSONAR
         finalizeRoll(rolledOutputPath, finalOutputPath);
     }
 


### PR DESCRIPTION
A simple attempt to stop this warning eventually without the chance of downstream breakage.