### PR TITLE
Check repo name for slack notification

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -99,7 +99,7 @@ jobs:
         run: mvn -B -e -ntp "-Dstyle.color=always" -PerrorProne verify -DskipTests
 
   slack-notify:
-    if: ${{ github.event_name == 'push' && github.event.repository.fork == 'false' }}
+    if: ${{ github.event_name == 'push' && github.repository == 'NationalSecurityAgency/emissary' }}
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -188,7 +188,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   slack-notify-start:
-    if: ${{ github.event.repository.fork == 'false' }}
+    if: ${{ github.repository == 'NationalSecurityAgency/emissary' }}
     needs: get_version
     runs-on: ubuntu-latest
     steps:
@@ -216,7 +216,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
   slack-notify-complete:
-    if: ${{ github.event.repository.fork == 'false' }}
+    if: ${{ github.repository == 'NationalSecurityAgency/emissary' }}
     needs: [get_version, release]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Attempt to fix regression introduced in https://github.com/NationalSecurityAgency/emissary/pull/746 where no slack notifications were being triggered.