### PR TITLE
shutdown RollManager before ResourceWatcher

### DIFF
--- a/src/main/java/emissary/server/EmissaryServer.java
+++ b/src/main/java/emissary/server/EmissaryServer.java
@@ -366,6 +366,12 @@ public class EmissaryServer {
         }
         LOG.info("Done stopping all places");
 
+        try {
+            MetricsManager.lookup().shutdown();
+        } catch (Exception ex) {
+            LOG.warn("No metrics manager available");
+        }
+
         // Print the stats
         try {
             ResourceWatcher rw = ResourceWatcher.lookup();
@@ -373,12 +379,6 @@ public class EmissaryServer {
             rw.quit();
         } catch (Exception ex) {
             LOG.warn("No resource statistics available");
-        }
-
-        try {
-            MetricsManager.lookup().shutdown();
-        } catch (Exception ex) {
-            LOG.warn("No metrics manager available");
         }
 
         SPILoader.unload();

--- a/src/main/java/emissary/server/EmissaryServer.java
+++ b/src/main/java/emissary/server/EmissaryServer.java
@@ -366,13 +366,13 @@ public class EmissaryServer {
         }
         LOG.info("Done stopping all places");
 
+        RollManager.shutdown();
+
         try {
             MetricsManager.lookup().shutdown();
         } catch (Exception ex) {
             LOG.warn("No metrics manager available");
         }
-
-        RollManager.shutdown();
 
         // Print the stats
         try {

--- a/src/main/java/emissary/server/EmissaryServer.java
+++ b/src/main/java/emissary/server/EmissaryServer.java
@@ -368,12 +368,6 @@ public class EmissaryServer {
 
         RollManager.shutdown();
 
-        try {
-            MetricsManager.lookup().shutdown();
-        } catch (Exception ex) {
-            LOG.warn("No metrics manager available");
-        }
-
         // Print the stats
         try {
             ResourceWatcher rw = ResourceWatcher.lookup();
@@ -381,6 +375,12 @@ public class EmissaryServer {
             rw.quit();
         } catch (Exception ex) {
             LOG.warn("No resource statistics available");
+        }
+
+        try {
+            MetricsManager.lookup().shutdown();
+        } catch (Exception ex) {
+            LOG.warn("No metrics manager available");
         }
 
         SPILoader.unload();

--- a/src/main/java/emissary/server/EmissaryServer.java
+++ b/src/main/java/emissary/server/EmissaryServer.java
@@ -372,6 +372,8 @@ public class EmissaryServer {
             LOG.warn("No metrics manager available");
         }
 
+        RollManager.shutdown();
+
         // Print the stats
         try {
             ResourceWatcher rw = ResourceWatcher.lookup();
@@ -382,8 +384,6 @@ public class EmissaryServer {
         }
 
         SPILoader.unload();
-
-        RollManager.shutdown();
 
         LOG.info("Done stopping all services");
 


### PR DESCRIPTION
There was an issue with roll actions trying to roll metrics after the ResourceWatcher was stopped. This switch should allow metrics to be output, close all rollers, and then the ResourceWatcher will stop.