### PR TITLE
provide more info when SBCF are different

### DIFF
--- a/src/main/java/emissary/core/IBaseDataObjectDiffHelper.java
+++ b/src/main/java/emissary/core/IBaseDataObjectDiffHelper.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.Channels;
 import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -157,8 +158,10 @@ public class IBaseDataObjectDiffHelper {
                     InputStream is1 = Channels.newInputStream(sbc1);
                     InputStream is2 = Channels.newInputStream(sbc2)) {
                 if (!IOUtils.contentEquals(is1, is2)) {
-                    differences.add(String.format("%s not equal. 1.cs=%s 2.cs=%s",
-                            identifier, sbc1.size(), sbc2.size()));
+                    differences.add(String.format("%s not equal. 1.is=%s 2.is=%s",
+                            identifier,
+                            IOUtils.toString(Channels.newInputStream(sbcf1.create()), StandardCharsets.UTF_8),
+                            IOUtils.toString(Channels.newInputStream(sbcf2.create()), StandardCharsets.UTF_8)));
                 }
             } catch (IOException e) {
                 differences.add(String.format("Failed to compare %s: %s", identifier, e.getMessage()));

--- a/src/main/java/emissary/util/PlaceComparisonHelper.java
+++ b/src/main/java/emissary/util/PlaceComparisonHelper.java
@@ -142,19 +142,22 @@ public class PlaceComparisonHelper {
 
         if (!parentDifferences.isEmpty() || !childDifferences.isEmpty()) {
             final StringBuilder sb = new StringBuilder();
-            sb.append(String.format("Differences found for %s%s", identifier, StringUtils.LF));
             for (int i = 0; i < parentDifferences.size(); i++) {
-                if (i == 0)
-                    sb.append(String.format("%s---Old place differences---%s%s", StringUtils.LF, StringUtils.LF, StringUtils.LF));
-                sb.append(String.format("%s%s", parentDifferences.get(i), StringUtils.LF));
+                if (i != 0) {
+                    sb.append(StringUtils.LF);
+                }
+                sb.append(identifier).append(": parent_difference: ");
+                sb.append(parentDifferences.get(i));
             }
             if (!parentDifferences.isEmpty() && !childDifferences.isEmpty()) {
                 sb.append(StringUtils.LF);
             }
             for (int i = 0; i < childDifferences.size(); i++) {
-                if (i == 0)
-                    sb.append(String.format("%s---New place differences---%s%s", StringUtils.LF, StringUtils.LF, StringUtils.LF));
-                sb.append(String.format("%s%s", childDifferences.get(i), StringUtils.LF));
+                if (i != 0) {
+                    sb.append(StringUtils.LF);
+                }
+                sb.append(identifier).append(": child_difference: ");
+                sb.append(childDifferences.get(i));
             }
             return sb.toString();
         }

--- a/src/main/java/emissary/util/PlaceComparisonHelper.java
+++ b/src/main/java/emissary/util/PlaceComparisonHelper.java
@@ -142,24 +142,20 @@ public class PlaceComparisonHelper {
 
         if (!parentDifferences.isEmpty() || !childDifferences.isEmpty()) {
             final StringBuilder sb = new StringBuilder();
+            sb.append(String.format("Differences found for %s%s", identifier, StringUtils.LF));
             for (int i = 0; i < parentDifferences.size(); i++) {
-                if (i != 0) {
-                    sb.append(StringUtils.LF);
-                }
-                sb.append(identifier).append(": PDiff: ");
-                sb.append(parentDifferences.get(i));
+                if (i == 0)
+                    sb.append(String.format("%s---Old place differences---%s%s", StringUtils.LF, StringUtils.LF, StringUtils.LF));
+                sb.append(String.format("%s%s", parentDifferences.get(i), StringUtils.LF));
             }
             if (!parentDifferences.isEmpty() && !childDifferences.isEmpty()) {
                 sb.append(StringUtils.LF);
             }
             for (int i = 0; i < childDifferences.size(); i++) {
-                if (i != 0) {
-                    sb.append(StringUtils.LF);
-                }
-                sb.append(identifier).append(": CDiff: ");
-                sb.append(childDifferences.get(i));
+                if (i == 0)
+                    sb.append(String.format("%s---New place differences---%s%s", StringUtils.LF, StringUtils.LF, StringUtils.LF));
+                sb.append(String.format("%s%s", childDifferences.get(i), StringUtils.LF));
             }
-
             return sb.toString();
         }
 

--- a/src/test/java/emissary/place/ComparisonPlaceTest.java
+++ b/src/test/java/emissary/place/ComparisonPlaceTest.java
@@ -36,8 +36,6 @@ class ComparisonPlaceTest extends UnitTest {
     private static final String PROCESSHD_PLACE_A_CHANGES = "emissary.place.ComparisonPlaceTest.ProcessHDPlaceAChanges";
     private static final String PROCESSHD_PLACE_B_CHANGES = "emissary.place.ComparisonPlaceTest.ProcessHDPlaceBChanges";
 
-    private static final String nl = StringUtils.LF;
-
     @Test
     void testConfiguration() throws Exception {
         assertThrows(NullPointerException.class, () -> new ComparisonPlace(null, null, MISSING_LOGGING_IDENTIFIER));
@@ -61,20 +59,16 @@ class ComparisonPlaceTest extends UnitTest {
 
     @Test
     void testProcessPlaceAChanges() throws Exception {
-        final String logMessage = "Differences found for COMPARISONPLACETEST" + nl + nl +
-                "---Old place differences---" + nl + nl +
-                "meta elements are not equal" + nl +
-                "Minimal Map Key Set 1: [KEY]" + nl + "Minimal Map Key Set 2: []" + nl + nl;
+        final String logMessage = "COMPARISONPLACETEST: parent_difference: <meta> elements are not equal: " +
+                "minimal_map_key_set_1=[KEY] : minimal_map_key_set_2=[] ";
 
         testComparisonPlace(PROCESS_PLACE_A_CHANGES, logMessage);
     }
 
     @Test
     void testProcessPlaceBChanges() throws Exception {
-        final String logMessage = "Differences found for COMPARISONPLACETEST" + nl + nl +
-                "---Old place differences---" + nl + nl +
-                "meta elements are not equal" + nl +
-                "Minimal Map Key Set 1: []" + nl + "Minimal Map Key Set 2: [KEY]" + nl + nl;
+        final String logMessage = "COMPARISONPLACETEST: parent_difference: <meta> elements are not equal: " +
+                "minimal_map_key_set_1=[] : minimal_map_key_set_2=[KEY] ";
 
         testComparisonPlace(PROCESS_PLACE_B_CHANGES, logMessage);
     }
@@ -86,26 +80,20 @@ class ComparisonPlaceTest extends UnitTest {
 
     @Test
     void testProcessHDPlaceAChanges() throws Exception {
-        final String logMessage = "Differences found for COMPARISONPLACETEST" + nl + nl +
-                "---Old place differences---" + nl + nl +
-                "meta elements are not equal" + nl +
-                "Minimal Map Key Set 1: [KEY]" + nl + "Minimal Map Key Set 2: []" + nl + nl + nl + nl +
-                "---New place differences---" + nl + nl +
-                "COMPARISONPLACETEST : 0 : meta elements are not equal" + nl +
-                "Minimal Map Key Set 1: [KEY]" + nl + "Minimal Map Key Set 2: []" + nl + nl;
+        final String logMessage = "COMPARISONPLACETEST: parent_difference: <meta> elements are not equal: " +
+                "minimal_map_key_set_1=[KEY] : minimal_map_key_set_2=[] " + StringUtils.LF +
+                "COMPARISONPLACETEST: child_difference: COMPARISONPLACETEST : 0 : <meta> elements are not equal: " +
+                "minimal_map_key_set_1=[KEY] : minimal_map_key_set_2=[] ";
 
         testComparisonPlace(PROCESSHD_PLACE_A_CHANGES, logMessage);
     }
 
     @Test
     void testProcessHDPlaceBChanges() throws Exception {
-        final String logMessage = "Differences found for COMPARISONPLACETEST" + nl + nl +
-                "---Old place differences---" + nl + nl +
-                "meta elements are not equal" + nl +
-                "Minimal Map Key Set 1: []" + nl + "Minimal Map Key Set 2: [KEY]" + nl + nl + nl + nl +
-                "---New place differences---" + nl + nl +
-                "COMPARISONPLACETEST : 0 : meta elements are not equal" + nl +
-                "Minimal Map Key Set 1: []" + nl + "Minimal Map Key Set 2: [KEY]" + nl + nl;
+        final String logMessage = "COMPARISONPLACETEST: parent_difference: <meta> elements are not equal: " +
+                "minimal_map_key_set_1=[] : minimal_map_key_set_2=[KEY] " + StringUtils.LF +
+                "COMPARISONPLACETEST: child_difference: COMPARISONPLACETEST : 0 : <meta> elements are not equal: " +
+                "minimal_map_key_set_1=[] : minimal_map_key_set_2=[KEY] ";
 
         testComparisonPlace(PROCESSHD_PLACE_B_CHANGES, logMessage);
     }

--- a/src/test/java/emissary/place/ComparisonPlaceTest.java
+++ b/src/test/java/emissary/place/ComparisonPlaceTest.java
@@ -7,6 +7,7 @@ import emissary.test.core.junit5.LogbackTester.SimplifiedLogEvent;
 import emissary.test.core.junit5.UnitTest;
 
 import ch.qos.logback.classic.Level;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -35,6 +36,8 @@ class ComparisonPlaceTest extends UnitTest {
     private static final String PROCESSHD_PLACE_A_CHANGES = "emissary.place.ComparisonPlaceTest.ProcessHDPlaceAChanges";
     private static final String PROCESSHD_PLACE_B_CHANGES = "emissary.place.ComparisonPlaceTest.ProcessHDPlaceBChanges";
 
+    private static final String nl = StringUtils.LF;
+
     @Test
     void testConfiguration() throws Exception {
         assertThrows(NullPointerException.class, () -> new ComparisonPlace(null, null, MISSING_LOGGING_IDENTIFIER));
@@ -58,14 +61,20 @@ class ComparisonPlaceTest extends UnitTest {
 
     @Test
     void testProcessPlaceAChanges() throws Exception {
-        final String logMessage = "COMPARISONPLACETEST: PDiff: meta are not equal-Differing Keys: [KEY] : []";
+        final String logMessage = "Differences found for COMPARISONPLACETEST" + nl + nl +
+                "---Old place differences---" + nl + nl +
+                "meta elements are not equal" + nl +
+                "Minimal Map Key Set 1: [KEY]" + nl + "Minimal Map Key Set 2: []" + nl + nl;
 
         testComparisonPlace(PROCESS_PLACE_A_CHANGES, logMessage);
     }
 
     @Test
     void testProcessPlaceBChanges() throws Exception {
-        final String logMessage = "COMPARISONPLACETEST: PDiff: meta are not equal-Differing Keys: [] : [KEY]";
+        final String logMessage = "Differences found for COMPARISONPLACETEST" + nl + nl +
+                "---Old place differences---" + nl + nl +
+                "meta elements are not equal" + nl +
+                "Minimal Map Key Set 1: []" + nl + "Minimal Map Key Set 2: [KEY]" + nl + nl;
 
         testComparisonPlace(PROCESS_PLACE_B_CHANGES, logMessage);
     }
@@ -77,16 +86,26 @@ class ComparisonPlaceTest extends UnitTest {
 
     @Test
     void testProcessHDPlaceAChanges() throws Exception {
-        final String logMessage = "COMPARISONPLACETEST: PDiff: meta are not equal-Differing Keys: [KEY] : []\n" +
-                "COMPARISONPLACETEST: CDiff: COMPARISONPLACETEST : 0 : meta are not equal-Differing Keys: [KEY] : []";
+        final String logMessage = "Differences found for COMPARISONPLACETEST" + nl + nl +
+                "---Old place differences---" + nl + nl +
+                "meta elements are not equal" + nl +
+                "Minimal Map Key Set 1: [KEY]" + nl + "Minimal Map Key Set 2: []" + nl + nl + nl + nl +
+                "---New place differences---" + nl + nl +
+                "COMPARISONPLACETEST : 0 : meta elements are not equal" + nl +
+                "Minimal Map Key Set 1: [KEY]" + nl + "Minimal Map Key Set 2: []" + nl + nl;
 
         testComparisonPlace(PROCESSHD_PLACE_A_CHANGES, logMessage);
     }
 
     @Test
     void testProcessHDPlaceBChanges() throws Exception {
-        final String logMessage = "COMPARISONPLACETEST: PDiff: meta are not equal-Differing Keys: [] : [KEY]\n" +
-                "COMPARISONPLACETEST: CDiff: COMPARISONPLACETEST : 0 : meta are not equal-Differing Keys: [] : [KEY]";
+        final String logMessage = "Differences found for COMPARISONPLACETEST" + nl + nl +
+                "---Old place differences---" + nl + nl +
+                "meta elements are not equal" + nl +
+                "Minimal Map Key Set 1: []" + nl + "Minimal Map Key Set 2: [KEY]" + nl + nl + nl + nl +
+                "---New place differences---" + nl + nl +
+                "COMPARISONPLACETEST : 0 : meta elements are not equal" + nl +
+                "Minimal Map Key Set 1: []" + nl + "Minimal Map Key Set 2: [KEY]" + nl + nl;
 
         testComparisonPlace(PROCESSHD_PLACE_B_CHANGES, logMessage);
     }

--- a/src/test/java/emissary/test/core/junit5/RegressionTestUtil.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTestUtil.java
@@ -117,9 +117,6 @@ public final class RegressionTestUtil {
         return pathBuilder.resolve("test/resources");
     }
 
-    /**
-     * @see ExtractionTest#checkAnswers(Document, IBaseDataObject, List, String)
-     */
     public static void checkAnswers(final Document answers, final IBaseDataObject payload, final List<SimplifiedLogEvent> actualSimplifiedLogEvents,
             final List<IBaseDataObject> attachments, final String placeName, final ElementDecoders decoders) {
         final Element root = answers.getRootElement();

--- a/src/test/java/emissary/test/core/junit5/RegressionTestUtil.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTestUtil.java
@@ -117,6 +117,9 @@ public final class RegressionTestUtil {
         return pathBuilder.resolve("test/resources");
     }
 
+    /**
+     * @see ExtractionTest#checkAnswers(Document, IBaseDataObject, List, String)
+     */
     public static void checkAnswers(final Document answers, final IBaseDataObject payload, final List<SimplifiedLogEvent> actualSimplifiedLogEvents,
             final List<IBaseDataObject> attachments, final String placeName, final ElementDecoders decoders) {
         final Element root = answers.getRootElement();
@@ -129,7 +132,7 @@ public final class RegressionTestUtil {
         final String differences = PlaceComparisonHelper.checkDifferences(expectedIbdo, payload, expectedAttachments,
                 attachments, placeName, DIFF_CHECK);
 
-        assertNull(differences, differences);
+        assertNull(differences);
 
         final List<SimplifiedLogEvent> expectedSimplifiedLogEvents = getSimplifiedLogEvents(parent);
 


### PR DESCRIPTION
When two `SeekableByteChannelFactory` objects are found to not be the same, the `differences` string is currently appended with ```"<data parameter name> not equal. 1.cs=<byte channel 1 size> 2.cs=<byte channel 2 size>"```. 

This doesn't account for channels of the same size with different data. Finding these differences currently means stepping through the program with the debugger to manually convert each channel's input stream back into a string. Appending the data directly from each object makes this issue much easier to debug.

`differences` was also removed as the error message for `assertNull` in `RegressionTestUtil` because it already prints when the assert fails.