### PR TITLE
sonarlint :: do not ignore InterruptedException in DelayPlace

### DIFF
--- a/src/main/java/emissary/place/sample/DelayPlace.java
+++ b/src/main/java/emissary/place/sample/DelayPlace.java
@@ -1,13 +1,12 @@
 package emissary.place.sample;
 
 import emissary.core.IBaseDataObject;
-import emissary.core.ResourceException;
 import emissary.place.ServiceProviderPlace;
 
 import java.io.IOException;
 
 /**
- * This place is a sink hole for everything it registers for
+ * This place performs no action other than holding everything it processes for a configurable amount of milliseconds
  */
 public class DelayPlace extends ServiceProviderPlace {
 
@@ -37,18 +36,18 @@ public class DelayPlace extends ServiceProviderPlace {
      * Consume the data object
      */
     @Override
-    public void process(IBaseDataObject tData) throws ResourceException {
+    public void process(IBaseDataObject tData) {
         if (logger.isDebugEnabled()) {
             logger.debug("Delay starting {}", tData.getAllCurrentForms());
         }
         try {
             Thread.sleep(delayTimeMillis);
         } catch (InterruptedException e) {
-            throw new ResourceException("Timed out before delay expired", e);
+            logger.warn("Interrupted before delay expired", e);
+            Thread.currentThread().interrupt();
         }
         if (logger.isDebugEnabled()) {
             logger.debug("Delay ended {}", tData.getAllCurrentForms());
         }
     }
-
 }


### PR DESCRIPTION
Logging when performing a shutdown of the emissary server now:
```
...
2024-05-15 12:37:17,429 localhost-8001  INFO emissary.core.Pausable -   - emissary.pickup.file.FileDataServer currently paused, sleeping for 60000
2024-05-15 12:37:22,473 localhost-8001  WARN emissary.place.sample.DelayPlace - emissary-knight.png *.DELAY.ANALYZE.http://localhost:8001/DelayPlace - Interrupted before delay expired
java.lang.InterruptedException: sleep interrupted
	at java.base/java.lang.Thread.sleep(Native Method)
	at emissary.place.sample.DelayPlace.process(DelayPlace.java:44)
	at emissary.place.ServiceProviderPlace.processHeavyDuty(ServiceProviderPlace.java:642)
	at emissary.place.ServiceProviderPlace.agentProcessHeavyDuty(ServiceProviderPlace.java:591)
	at emissary.place.ServiceProviderPlace.agentProcessHeavyDuty(ServiceProviderPlace.java:556)
	at emissary.core.HDMobileAgent.atPlaceHD(HDMobileAgent.java:421)
	at emissary.core.HDMobileAgent.agentControl(HDMobileAgent.java:260)
	at emissary.core.MobileAgent.run(MobileAgent.java:149)
	at java.base/java.lang.Thread.run(Thread.java:829)
2024-05-15 12:37:22,476 localhost-8001  WARN emissary.core.MobileAgent - emissary-knight.png  - Place *.DELAY.ANALYZE.http://localhost:8001/DelayPlace$5050[1] was interrupted during execution. Adjust place time out or modify code accordingly.
2024-05-15 12:37:22,554 localhost-8001  INFO emissary.output.DropOffPlace - emissary-knight.png *.DROP_OFF.IO.http://localhost:8001/DropOffPlace$9990[1] - Finished DropOff for object 302f9490-e5f3-4b81-9342-b1670ba48ebd, with external id: emissary-knight.png, with total processing time: 30138ms, with filetype: PNG
2024-05-15 12:37:22,562 localhost-8001  INFO emissary.core.MobileAgent - emissary-knight.png  - 
filename: emissary-knight.png
   creationTimestamp: Wed May 15 12:36:52 GMT 2024
   currentForms: []
   filetype: PNG
   transform history (4) :
     UNKNOWN.FILE_PICK_UP.INPUT.http://localhost:8001/FilePickUpPlace$5050
     UNKNOWN.UNIXFILE.ID.http://localhost:8001/UnixFilePlace$2050
     PNG.DELAY.ANALYZE.http://localhost:8001/DelayPlace$5050
     PNG.DROP_OFF.IO.http://localhost:8001/DropOffPlace$9990
...
```

Previously, a shutdown would cause ERROR stack-traces and create an ERROR on the form stack rather than just triggering the "Adjust place time out" workflow WARN and complete processing like any other interrupted place. 

```
...
2024-05-15 13:19:35,889 localhost-8001  INFO emissary.core.Pausable -   - emissary.pickup.file.FileDataServer currently paused, sleeping for 60000
2024-05-15 13:19:40,928 localhost-8001 ERROR emissary.place.sample.DelayPlace - emissary-knight.png *.DELAY.ANALYZE.http://localhost:8001/DelayPlace - Place.process threw:
emissary.core.ResourceException: Timed out before delay expired
	at emissary.place.sample.DelayPlace.process(DelayPlace.java:47)
	at emissary.place.ServiceProviderPlace.processHeavyDuty(ServiceProviderPlace.java:642)
	at emissary.place.ServiceProviderPlace.agentProcessHeavyDuty(ServiceProviderPlace.java:591)
	at emissary.place.ServiceProviderPlace.agentProcessHeavyDuty(ServiceProviderPlace.java:556)
	at emissary.core.HDMobileAgent.atPlaceHD(HDMobileAgent.java:421)
	at emissary.core.HDMobileAgent.agentControl(HDMobileAgent.java:260)
	at emissary.core.MobileAgent.run(MobileAgent.java:149)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.InterruptedException: sleep interrupted
	at java.base/java.lang.Thread.sleep(Native Method)
	at emissary.place.sample.DelayPlace.process(DelayPlace.java:45)
	... 7 common frames omitted
2024-05-15 13:19:40,930 localhost-8001 ERROR emissary.place.sample.DelayPlace - emissary-knight.png *.DELAY.ANALYZE.http://localhost:8001/DelayPlace - Place.process exception
emissary.core.ResourceException: Timed out before delay expired
	at emissary.place.sample.DelayPlace.process(DelayPlace.java:47)
	at emissary.place.ServiceProviderPlace.processHeavyDuty(ServiceProviderPlace.java:642)
	at emissary.place.ServiceProviderPlace.agentProcessHeavyDuty(ServiceProviderPlace.java:591)
	at emissary.place.ServiceProviderPlace.agentProcessHeavyDuty(ServiceProviderPlace.java:556)
	at emissary.core.HDMobileAgent.atPlaceHD(HDMobileAgent.java:421)
	at emissary.core.HDMobileAgent.agentControl(HDMobileAgent.java:260)
	at emissary.core.MobileAgent.run(MobileAgent.java:149)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.InterruptedException: sleep interrupted
	at java.base/java.lang.Thread.sleep(Native Method)
	at emissary.place.sample.DelayPlace.process(DelayPlace.java:45)
	... 7 common frames omitted
2024-05-15 13:19:41,006 localhost-8001  INFO emissary.output.DropOffPlace - emissary-knight.png *.DROP_OFF.IO.http://localhost:8001/DropOffPlace$9990[1] - Finished DropOff for object 4ddfdb1c-0208-40bc-8b6c-1ae9d1a5c6a3, with external id: emissary-knight.png, with total processing time: 30129ms, with filetype: PNG
2024-05-15 13:19:41,013 localhost-8001  INFO emissary.core.MobileAgent - emissary-knight.png  - 
filename: emissary-knight.png
   creationTimestamp: Wed May 15 13:19:10 GMT 2024
   currentForms: []
   filetype: PNG
   transform history (4) :
     UNKNOWN.FILE_PICK_UP.INPUT.http://localhost:8001/FilePickUpPlace$5050
     UNKNOWN.UNIXFILE.ID.http://localhost:8001/UnixFilePlace$2050
     PNG.DELAY.ANALYZE.http://localhost:8001/DelayPlace$5050
     ERROR.DROP_OFF.IO.http://localhost:8001/DropOffPlace$9990
...
```