### PR TITLE
sonarlint :: remove Serializable from JsonOutputFilter inner class

### DIFF
--- a/src/main/java/emissary/output/filter/JsonOutputFilter.java
+++ b/src/main/java/emissary/output/filter/JsonOutputFilter.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.databind.ser.std.MapProperty;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -94,9 +93,7 @@ public class JsonOutputFilter extends AbstractRollableFilter {
         return jsonMapper.writeValueAsBytes(list);
     }
 
-    class IbdoParameterFilter extends SimpleBeanPropertyFilter implements Serializable {
-
-        private static final long serialVersionUID = 1L;
+    class IbdoParameterFilter extends SimpleBeanPropertyFilter {
 
         protected final boolean outputAll;
         protected final boolean emptyDenylist;
@@ -248,7 +245,7 @@ public class JsonOutputFilter extends AbstractRollableFilter {
      * This class is used so we do not have to annotate the IBaseDataObject. Set custom annotations on the method signatures
      * to include/exclude fields in the ibdo.
      */
-    static abstract class IbdoMixin {
+    abstract static class IbdoMixin {
         @JsonProperty("internalId")
         abstract UUID getInternalId();
 
@@ -336,7 +333,7 @@ public class JsonOutputFilter extends AbstractRollableFilter {
         abstract String getProcessingError();
     }
 
-    static abstract class IbdoParameterMixin extends IbdoMixin {
+    abstract static class IbdoParameterMixin extends IbdoMixin {
         @JsonIgnore
         abstract byte[] data();
 
@@ -344,7 +341,7 @@ public class JsonOutputFilter extends AbstractRollableFilter {
         abstract Map<String, byte[]> getAlternateViews();
     }
 
-    static abstract class IbdoPayloadMixin extends IbdoMixin {
+    abstract static class IbdoPayloadMixin extends IbdoMixin {
         @JsonProperty("payload")
         @JsonInclude(NON_EMPTY)
         abstract byte[] data();


### PR DESCRIPTION
Addresses https://cloud-ci.sgs.com/sonar/coding_rules?open=java%3AS2066&rule_key=java%3AS2066 for IbdoParameterFilter

From what I can tell, this was initially committed this way and I believe it to be unnecessary. From what I understand about the use of SimpleBeanPropertyFilter, the implementing class does not need to be serializable as a whole and removing that behavior removes the need to classify it as static.

