### PR TITLE
sonarlint :: add unload method to remove ThreadLocal objects

### DIFF
--- a/src/main/java/emissary/util/ClassLookupCache.java
+++ b/src/main/java/emissary/util/ClassLookupCache.java
@@ -140,6 +140,13 @@ public final class ClassLookupCache {
         }
     }
 
+    /**
+     * Destroy the ThreadLocal cache object
+     */
+    public static void unload() {
+        cachedLookupResult.remove();
+    }
+
     /** This is a static utility class, so prevent instantiation. */
     private ClassLookupCache() {}
 }

--- a/src/main/java/emissary/util/ConstructorLookupCache.java
+++ b/src/main/java/emissary/util/ConstructorLookupCache.java
@@ -256,6 +256,13 @@ public final class ConstructorLookupCache {
         }
     }
 
+    /**
+     * Destroy the ThreadLocal cache object
+     */
+    public static void unload() {
+        cachedConstructorLookup.remove();
+    }
+
     /** This is a static utility class, so prevent instantiation. */
     private ConstructorLookupCache() {}
 }

--- a/src/main/java/emissary/util/io/FileManipulator.java
+++ b/src/main/java/emissary/util/io/FileManipulator.java
@@ -1,7 +1,3 @@
-/*
-  $Id$
- */
-
 package emissary.util.io;
 
 import java.io.File;
@@ -11,8 +7,6 @@ import java.security.SecureRandom;
 /**
  * A class of utility methods for manipulating files.
  */
-
-
 public class FileManipulator implements Serializable {
 
     static final long serialVersionUID = 365259266882118692L;
@@ -52,6 +46,13 @@ public class FileManipulator implements Serializable {
 
     public static String mkTempFile(final String dirPath) {
         return mkTempFile(dirPath, "temp");
+    }
+
+    /**
+     * Destroy the ThreadLocal SecureRandom object
+     */
+    public static void unload() {
+        secureRandomThreadLocal.remove();
     }
 
     /** This class is not meant to be instantiated. */


### PR DESCRIPTION
https://rules.sonarsource.com/java/RSPEC-5164/

Another somewhat silly warning because having a method and calling that method are two different things, but it doesn't hurt to add a method to provide the capability. I just don't know that it's useful (or necessary to call them) with how we are using these objects since they live for the duration of the application.