### PR TITLE
2860 Fix errorProne build 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,7 @@
     <dep.jetty.version>11.0.16</dep.jetty.version>
     <dep.junit-jupiter.version>5.10.0</dep.junit-jupiter.version>
     <dep.logback.version>1.4.14</dep.logback.version>
-    <!-- seems to have an impact with java 11 integration, update with
-		caution -->
+    <!-- seems to have an impact with java 11 integration, update with caution -->
     <dep.maven-surefire-plugin.version>3.1.0</dep.maven-surefire-plugin.version>
     <dep.mockito.version>5.5.0</dep.mockito.version>
     <dep.picocli.version>4.7.4</dep.picocli.version>
@@ -94,19 +93,15 @@
     <maven.min-version>3.5.0</maven.min-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <!-- With Java 8 and the latest version of surefire, user.timezone is
-		not read correctly.  Reevaluate one day.
+    <!-- With Java 8 and the latest version of surefire, user.timezone is not read correctly.  Reevaluate one day.
          See https://issues.apache.org/jira/browse/SUREFIRE-1176 or
-		http://stackoverflow.com/questions/19121928/java-system-getproperty-user-timezone-does-not-work
+		 http://stackoverflow.com/questions/19121928/java-system-getproperty-user-timezone-does-not-work
 
-         The COMPAT locale provider is used because the date formatter parsing has
-		changed significantly
+         The COMPAT locale provider is used because the date formatter parsing has changed significantly
          when using the CLDR locale provider, which is the default in JDK11.
-		https://www.oracle.com/technetwork/java/javase/documentation/java11locales-5069639.html
+		 https://www.oracle.com/technetwork/java/javase/documentation/java11locales-5069639.html
       -->
-    <surefire.argline>@{argLine} -Xmx1024m -Xms256m
-			-Djava.locale.providers=COMPAT -Djava.net.preferIPv4Stack=true
-			-Duser.timezone=GMT -Djava.awt.headless=true</surefire.argline>
+    <surefire.argline>@{argLine} -Xmx1024m -Xms256m	-Djava.locale.providers=COMPAT -Djava.net.preferIPv4Stack=true -Duser.timezone=GMT -Djava.awt.headless=true</surefire.argline>
     <surefire.forkCount>.5C</surefire.forkCount>
   </properties>
   <dependencyManagement>
@@ -695,12 +690,9 @@
             <!-- this combination of these two configurations
               (failOnViolation=true and violationSeverity=error) means
               any checks with severity=error will fail the build -->
-            <!-- TODO enforce more checkstyle categories as the
-						build gets cleaned up -->
-            <!-- As you fix checkstyle warning categories, change
-						the severity of that category
-              to "error" so it will fail the build if new violations of that category get
-						introduced. -->
+            <!-- TODO enforce more checkstyle categories as the	build gets cleaned up -->
+            <!-- As you fix checkstyle warning categories, change the severity of that category
+              to "error" so it will fail the build if new violations of that category get introduced. -->
             <failOnViolation>true</failOnViolation>
             <violationSeverity>error</violationSeverity>
             <includeTestSourceDirectory>true</includeTestSourceDirectory>
@@ -1406,8 +1398,7 @@
       </build>
     </profile>
     <profile>
-      <!-- on by default, but disable with '-P !autoformat' or
-			'-DskipFormat' -->
+      <!-- on by default, but disable with '-P !autoformat' or '-DskipFormat' -->
       <id>autoformat</id>
       <activation>
         <property>
@@ -1468,23 +1459,23 @@
                 <!--arg>-Xlint:all</arg-->
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>-Xplugin:ErrorProne \
-									-XepAllDisabledChecksAsWarnings \
-									-XepAllErrorsAsWarnings \
-									-XepAllSuggestionsAsWarnings \
-									-XepDisableWarningsInGeneratedCode \
-									-Xep:AndroidJdkLibsChecker:OFF \
-									-Xep:BooleanParameter:OFF \
-									-Xep:CanIgnoreReturnValueSuggester:OFF \
-									-Xep:DefaultCharset:OFF \
-									-Xep:InlineMeSuggester:OFF \
-									-Xep:InlineTrivialConstant:OFF \
-									-Xep:Java7ApiChecker:OFF \
-									-Xep:Java8ApiChecker:OFF \
-									-Xep:StringSplitter:OFF \
-									-Xep:UnnecessaryFinal:OFF \
-									-Xep:Var:OFF \
-									-Xep:Varifier:OFF \
-									-Xep:YodaCondition:OFF</arg>
+                  -XepAllDisabledChecksAsWarnings \
+                  -XepAllErrorsAsWarnings \
+                  -XepAllSuggestionsAsWarnings \
+                  -XepDisableWarningsInGeneratedCode \
+                  -Xep:AndroidJdkLibsChecker:OFF \
+                  -Xep:BooleanParameter:OFF \
+                  -Xep:CanIgnoreReturnValueSuggester:OFF \
+                  -Xep:DefaultCharset:OFF \
+                  -Xep:InlineMeSuggester:OFF \
+                  -Xep:InlineTrivialConstant:OFF \
+                  -Xep:Java7ApiChecker:OFF \
+                  -Xep:Java8ApiChecker:OFF \
+                  -Xep:StringSplitter:OFF \
+                  -Xep:UnnecessaryFinal:OFF \
+                  -Xep:Var:OFF \
+                  -Xep:Varifier:OFF \
+                  -Xep:YodaCondition:OFF</arg>
               </compilerArgs>
               <annotationProcessorPaths>
                 <path>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,8 @@
     <dep.jetty.version>11.0.16</dep.jetty.version>
     <dep.junit-jupiter.version>5.10.0</dep.junit-jupiter.version>
     <dep.logback.version>1.4.14</dep.logback.version>
-    <!-- seems to have an impact with java 11 integration, update with caution -->
+    <!-- seems to have an impact with java 11 integration, update with
+		caution -->
     <dep.maven-surefire-plugin.version>3.1.0</dep.maven-surefire-plugin.version>
     <dep.mockito.version>5.5.0</dep.mockito.version>
     <dep.picocli.version>4.7.4</dep.picocli.version>
@@ -93,15 +94,19 @@
     <maven.min-version>3.5.0</maven.min-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <!-- With Java 8 and the latest version of surefire, user.timezone is not read correctly.  Reevaluate one day.
+    <!-- With Java 8 and the latest version of surefire, user.timezone is
+		not read correctly.  Reevaluate one day.
          See https://issues.apache.org/jira/browse/SUREFIRE-1176 or
-         http://stackoverflow.com/questions/19121928/java-system-getproperty-user-timezone-does-not-work
+		http://stackoverflow.com/questions/19121928/java-system-getproperty-user-timezone-does-not-work
 
-         The COMPAT locale provider is used because the date formatter parsing has changed significantly
+         The COMPAT locale provider is used because the date formatter parsing has
+		changed significantly
          when using the CLDR locale provider, which is the default in JDK11.
-         https://www.oracle.com/technetwork/java/javase/documentation/java11locales-5069639.html
+		https://www.oracle.com/technetwork/java/javase/documentation/java11locales-5069639.html
       -->
-    <surefire.argline>@{argLine} -Xmx1024m -Xms256m -Djava.locale.providers=COMPAT -Djava.net.preferIPv4Stack=true -Duser.timezone=GMT -Djava.awt.headless=true</surefire.argline>
+    <surefire.argline>@{argLine} -Xmx1024m -Xms256m
+			-Djava.locale.providers=COMPAT -Djava.net.preferIPv4Stack=true
+			-Duser.timezone=GMT -Djava.awt.headless=true</surefire.argline>
     <surefire.forkCount>.5C</surefire.forkCount>
   </properties>
   <dependencyManagement>
@@ -122,9 +127,20 @@
         <version>${dep.gson.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>${dep.errorprone.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${dep.guava.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
@@ -473,6 +489,11 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
       <artifactId>jersey-test-framework-provider-jetty</artifactId>
       <scope>test</scope>
@@ -674,9 +695,12 @@
             <!-- this combination of these two configurations
               (failOnViolation=true and violationSeverity=error) means
               any checks with severity=error will fail the build -->
-            <!-- TODO enforce more checkstyle categories as the build gets cleaned up -->
-            <!-- As you fix checkstyle warning categories, change the severity of that category
-              to "error" so it will fail the build if new violations of that category get introduced. -->
+            <!-- TODO enforce more checkstyle categories as the
+						build gets cleaned up -->
+            <!-- As you fix checkstyle warning categories, change
+						the severity of that category
+              to "error" so it will fail the build if new violations of that category get
+						introduced. -->
             <failOnViolation>true</failOnViolation>
             <violationSeverity>error</violationSeverity>
             <includeTestSourceDirectory>true</includeTestSourceDirectory>
@@ -1382,7 +1406,8 @@
       </build>
     </profile>
     <profile>
-      <!-- on by default, but disable with '-P !autoformat' or '-DskipFormat' -->
+      <!-- on by default, but disable with '-P !autoformat' or
+			'-DskipFormat' -->
       <id>autoformat</id>
       <activation>
         <property>
@@ -1425,11 +1450,16 @@
               <release>${maven.compiler.release}</release>
               <showWarnings>true</showWarnings>
               <compilerArgs>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
-                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
-                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
                 <arg>-Xmaxerrs</arg>
                 <arg>-1</arg>
                 <arg>-Xmaxwarns</arg>
@@ -1438,23 +1468,23 @@
                 <!--arg>-Xlint:all</arg-->
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>-Xplugin:ErrorProne \
-                  -XepAllDisabledChecksAsWarnings \
-                  -XepAllErrorsAsWarnings \
-                  -XepAllSuggestionsAsWarnings \
-                  -XepDisableWarningsInGeneratedCode \
-                  -Xep:AndroidJdkLibsChecker:OFF \
-                  -Xep:BooleanParameter:OFF \
-                  -Xep:CanIgnoreReturnValueSuggester:OFF \
-                  -Xep:DefaultCharset:OFF \
-                  -Xep:InlineMeSuggester:OFF \
-                  -Xep:InlineTrivialConstant:OFF \
-                  -Xep:Java7ApiChecker:OFF \
-                  -Xep:Java8ApiChecker:OFF \
-                  -Xep:StringSplitter:OFF \
-                  -Xep:UnnecessaryFinal:OFF \
-                  -Xep:Var:OFF \
-                  -Xep:Varifier:OFF \
-                  -Xep:YodaCondition:OFF</arg>
+									-XepAllDisabledChecksAsWarnings \
+									-XepAllErrorsAsWarnings \
+									-XepAllSuggestionsAsWarnings \
+									-XepDisableWarningsInGeneratedCode \
+									-Xep:AndroidJdkLibsChecker:OFF \
+									-Xep:BooleanParameter:OFF \
+									-Xep:CanIgnoreReturnValueSuggester:OFF \
+									-Xep:DefaultCharset:OFF \
+									-Xep:InlineMeSuggester:OFF \
+									-Xep:InlineTrivialConstant:OFF \
+									-Xep:Java7ApiChecker:OFF \
+									-Xep:Java8ApiChecker:OFF \
+									-Xep:StringSplitter:OFF \
+									-Xep:UnnecessaryFinal:OFF \
+									-Xep:Var:OFF \
+									-Xep:Varifier:OFF \
+									-Xep:YodaCondition:OFF</arg>
               </compilerArgs>
               <annotationProcessorPaths>
                 <path>
@@ -1471,7 +1501,8 @@
     <profile>
       <id>eclipse</id>
       <activation>
-        <!-- when eclipse runs a build, this system property is already present -->
+        <!-- when eclipse runs a build, this system property is already
+				present -->
         <property>
           <name>m2e.version</name>
         </property>
@@ -1481,7 +1512,8 @@
         <maven.compiler.release>11</maven.compiler.release>
       </properties>
       <build>
-        <!--  different build directory for eclipse, so running maven and clicking in IDE don't conflict -->
+        <!--  different build directory for eclipse, so running maven and
+				clicking in IDE don't conflict -->
         <directory>${project.basedir}/target-eclipse</directory>
         <pluginManagement>
           <plugins>
@@ -1557,26 +1589,30 @@
       <id>netbeans</id>
       <activation>
         <property>
-          <!-- You must add -Dnetbeans.ide as global option to the maven command for this to work
+          <!-- You must add -Dnetbeans.ide as global option to the
+					maven command for this to work
                Could not find any property existing when Netbeans was running the build -->
           <name>netbeans.ide</name>
         </property>
       </activation>
       <build>
-        <!--  different build directory for netbeans, so running maven and clicking in IDE don't conflict -->
+        <!--  different build directory for netbeans, so running maven
+				and clicking in IDE don't conflict -->
         <directory>${project.basedir}/target-netbeans</directory>
       </build>
     </profile>
     <profile>
       <id>intellij</id>
       <activation>
-        <!-- when intellij runs a build, this system property is already present -->
+        <!-- when intellij runs a build, this system property is already
+				present -->
         <property>
           <name>idea.version</name>
         </property>
       </activation>
       <build>
-        <!--  different build directory for intellij, so running maven and clicking in IDE don't conflict -->
+        <!--  different build directory for intellij, so running maven
+				and clicking in IDE don't conflict -->
         <directory>${project.basedir}/target-idea</directory>
       </build>
     </profile>


### PR DESCRIPTION
Hobble the module encapsulation issue
```
Exception in thread "main" java.lang.IllegalAccessError: class com.google.errorprone.BaseErrorProneJavaCompiler (in unnamed module @0x6279cee3) cannot access class com.sun.tools.javac.api.BasicJavacTask (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.api to unnamed module @0x6279cee3
        at com.google.errorprone.BaseErrorProneJavaCompiler.addTaskListener(BaseErrorProneJavaCompiler.java:92)
        at com.google.errorprone.ErrorProneJavacPlugin.init(ErrorProneJavacPlugin.java:34)
        at jdk.compiler/com.sun.tools.javac.api.BasicJavacTask.initPlugin(BasicJavacTask.java:255)
        at jdk.compiler/com.sun.tools.javac.api.BasicJavacTask.initPlugins(BasicJavacTask.java:229)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:292)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:176)
        at jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:64)
        at jdk.compiler/com.sun.tools.javac.Main.main(Main.java:50)
```
Depend explicitly on the correct version of error_prone_annotations and exclude from transient inclusion.