### PR TITLE
updating RegressionTest generateAnswers for when two classes are used for test .dat & answer files

### DIFF
--- a/src/test/java/emissary/test/core/junit5/RegressionTest.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTest.java
@@ -60,7 +60,7 @@ public abstract class RegressionTest extends ExtractionTest {
      *         automatically
      */
     @ForOverride
-    protected boolean generateAnswers() {
+    protected static boolean generateAnswers() {
         return Boolean.getBoolean("generateAnswers");
     }
 

--- a/src/test/java/emissary/test/core/junit5/RegressionTest.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTest.java
@@ -307,7 +307,6 @@ public abstract class RegressionTest extends ExtractionTest {
             RegressionTestUtil.writeAnswerXml(resource, initialIbdo, finalIbdo, finalResults, finalLogEvents, getEncoders(),
                     super.answerFileClassRef);
         }
-        // RegressionTestUtil.writeAnswerXml(resource, initialIbdo, finalIbdo, finalResults, finalLogEvents, getEncoders());
     }
 
     @Override

--- a/src/test/java/emissary/test/core/junit5/RegressionTest.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTest.java
@@ -60,7 +60,7 @@ public abstract class RegressionTest extends ExtractionTest {
      *         automatically
      */
     @ForOverride
-    protected static boolean generateAnswers() {
+    protected boolean generateAnswers() {
         return Boolean.getBoolean("generateAnswers");
     }
 
@@ -301,7 +301,13 @@ public abstract class RegressionTest extends ExtractionTest {
         tweakFinalLogEventsBeforeSerialisation(resource, finalLogEvents);
 
         // Generate the full XML (setup & answers from before & after)
-        RegressionTestUtil.writeAnswerXml(resource, initialIbdo, finalIbdo, finalResults, finalLogEvents, getEncoders());
+        if (super.answerFileClassRef == null) {
+            RegressionTestUtil.writeAnswerXml(resource, initialIbdo, finalIbdo, finalResults, finalLogEvents, getEncoders());
+        } else {
+            RegressionTestUtil.writeAnswerXml(resource, initialIbdo, finalIbdo, finalResults, finalLogEvents, getEncoders(),
+                    super.answerFileClassRef);
+        }
+        // RegressionTestUtil.writeAnswerXml(resource, initialIbdo, finalIbdo, finalResults, finalLogEvents, getEncoders());
     }
 
     @Override

--- a/src/test/java/emissary/test/core/junit5/RegressionTest.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTest.java
@@ -301,12 +301,8 @@ public abstract class RegressionTest extends ExtractionTest {
         tweakFinalLogEventsBeforeSerialisation(resource, finalLogEvents);
 
         // Generate the full XML (setup & answers from before & after)
-        if (super.answerFileClassRef == null) {
-            RegressionTestUtil.writeAnswerXml(resource, initialIbdo, finalIbdo, finalResults, finalLogEvents, getEncoders());
-        } else {
-            RegressionTestUtil.writeAnswerXml(resource, initialIbdo, finalIbdo, finalResults, finalLogEvents, getEncoders(),
-                    super.answerFileClassRef);
-        }
+        RegressionTestUtil.writeAnswerXml(resource, initialIbdo, finalIbdo, finalResults, finalLogEvents, getEncoders(),
+                super.answerFileClassRef);
     }
 
     @Override
@@ -330,7 +326,7 @@ public abstract class RegressionTest extends ExtractionTest {
     @Override
     protected Document getAnswerDocumentFor(final String resource) {
         // If generating answers, get the src version, otherwise get the normal XML file
-        return generateAnswers() ? RegressionTestUtil.getAnswerDocumentFor(resource) : super.getAnswerDocumentFor(resource);
+        return generateAnswers() ? RegressionTestUtil.getAnswerDocumentFor(resource, super.answerFileClassRef) : super.getAnswerDocumentFor(resource);
     }
 
     @Override

--- a/src/test/java/emissary/test/core/junit5/RegressionTestUtil.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTestUtil.java
@@ -95,6 +95,13 @@ public final class RegressionTestUtil {
      */
     private static final Path TEST_RESX = getTestResx();
 
+    /**
+     * Used for RegressionTest generateAnswer when {@link UnitTest#getMyTestParameterFiles(Class, Class)} has two different
+     * classes, and we need to generate answer files in the ansClass directory
+     */
+    @Nullable
+    private static String ansClass = null;
+
     private RegressionTestUtil() {}
 
     /**
@@ -200,7 +207,14 @@ public final class RegressionTestUtil {
             return null;
         }
 
-        final String xmlPath = resource.substring(0, datPos) + ResourceReader.XML_SUFFIX;
+        String xmlPath;
+        if (ansClass == null) {
+            xmlPath = resource.substring(0, datPos) + ResourceReader.XML_SUFFIX;
+        } else {
+            String ansPath = ansClass.replace(".", "/");
+            int testNamePos = resource.lastIndexOf("/");
+            xmlPath = ansPath + resource.substring(testNamePos, datPos) + ResourceReader.XML_SUFFIX;
+        }
         return TEST_RESX.resolve(xmlPath);
     }
 
@@ -349,5 +363,9 @@ public final class RegressionTestUtil {
         } catch (final URISyntaxException e) {
             fail("Couldn't get path for resource: " + resource, e);
         }
+    }
+
+    public static void setAnsClass(String ansClass) {
+        RegressionTestUtil.ansClass = ansClass;
     }
 }

--- a/src/test/java/emissary/test/core/junit5/UnitTest.java
+++ b/src/test/java/emissary/test/core/junit5/UnitTest.java
@@ -145,7 +145,7 @@ public abstract class UnitTest {
 
     /**
      * Specifies a non-default source of test answer files
-     * 
+     *
      * @param ansClz Class that provides the test answer files.
      */
     protected synchronized void useAlternateAnswerFileSource(Class<?> ansClz) {


### PR DESCRIPTION
This updates `generateAnswers` to be able to generate answer files in the correct location when `getMyTestParameterFiles` is passed two separate classes. This allows files to generate/regenerate in the provided answer class, based on .dat files in the other class directory.