### PR TITLE
Modifying UnitTest so that alternative answer file location usage is thread-safe

### DIFF
--- a/src/test/java/emissary/test/core/junit5/TestingResourcesTest.java
+++ b/src/test/java/emissary/test/core/junit5/TestingResourcesTest.java
@@ -15,8 +15,15 @@ import java.util.stream.Stream;
  */
 public class TestingResourcesTest extends ExtractionTest {
 
+    static final Class<?> DATA_FILE_CLASS = HtmlEscapePlaceTest.class;
+    static final Class<?> ANSWER_FILE_CLASS = TestingResourcesTest.class;
+
     public static Stream<? extends Arguments> data() {
-        return getMyTestParameterFiles(HtmlEscapePlaceTest.class, TestingResourcesTest.class);
+        return getMyTestParameterFiles(DATA_FILE_CLASS);
+    }
+
+    public TestingResourcesTest() {
+        useAlternateAnswerFileSource(ANSWER_FILE_CLASS);
     }
 
     @Override


### PR DESCRIPTION
May need minor follow-on work to support PR #821 requirements, but this is sufficient to mitigate thread-safety concerns when running unit tests concurrently. 