### PR TITLE
Update startup logging

### DIFF
--- a/src/main/config/logback.xml
+++ b/src/main/config/logback.xml
@@ -15,8 +15,9 @@
   </appender>
   -->
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <withJansi>true</withJansi>
     <encoder>
-      <pattern>%d ${emissary.node.name}-${emissary.node.port} %5p %c - %X{shortName} %X{serviceLocation} - %m%n</pattern>
+      <pattern>%d{"yyyy-MM-dd'T'HH:mm:ss.SSS"} [%magenta(${emissary.node.name}-${emissary.node.port})] %highlight(%-5p) %cyan(%c) - %X{shortName} %X{serviceLocation} - %m%n</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
Startup was updated to use sets, so this adds logging to notify the user that a duplicate class was configured. Ideally we test for this and see if it hits in prod and then later we'll add it to strict mode failures. I also removed the logging of the full location of a place during startup and tried to make the output a little more useful by adding status and class name. Lastly, I added color output to logback to make the logs a little easier to read. 