### PR TITLE
b2895-json escape bug fix

### DIFF
--- a/src/main/java/emissary/transform/decode/JsonEscape.java
+++ b/src/main/java/emissary/transform/decode/JsonEscape.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 
 public class JsonEscape {
 
-    private final static String ESCAPES = "ntr\"'/";
+    private final static String ESCAPES = "ntr\"'/\\";
 
     /**
      * Unescape a bunch of JSON bytes that might have \\uxxxx character values. Should already be UTF-8 since JSON is

--- a/src/test/resources/emissary/transform/JsonEscapePlaceTest/sample.dat
+++ b/src/test/resources/emissary/transform/JsonEscapePlaceTest/sample.dat
@@ -14,5 +14,6 @@
         { "type": "home", "number": "212 555-1234" },
         { "type": "office",  "number": "646 555-4567" },
         { "type": "mysterious", "number": "\u0660\u0661\u0662\u0663\u0664\u0665" }
-    ]
+    ],
+    "some_name": "some\\node\\content" 
 }

--- a/src/test/resources/emissary/transform/JsonEscapePlaceTest/sample.xml
+++ b/src/test/resources/emissary/transform/JsonEscapePlaceTest/sample.xml
@@ -11,6 +11,7 @@
     
     <data matchMode="index">
       <value>٠١٢٣٤٥</value>
+      <value>some\node\content</value>
     </data>
 
   </answers>


### PR DESCRIPTION
To test and see the json escape work:

```mvn clean  verify -Dtest=JsonEscapePlaceTest```

To see it error out, revert ```src/main/java/emissary/transform/decode/JsonEscape.java``` with original line, rerun the test and it will treat ```\n``` as a new line and the test will fail

