### PR TITLE
removing public modifiers from junit5 tests where applicable

### DIFF
--- a/src/test/java/emissary/core/SafeUsageCheckerTest.java
+++ b/src/test/java/emissary/core/SafeUsageCheckerTest.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SafeUsageCheckerTest extends UnitTest {
+class SafeUsageCheckerTest extends UnitTest {
     @Test
     void testDifferentConfigs() {
         assertTrue(SafeUsageChecker.ENABLED_FROM_CONFIGURATION, "Enabled from config file should be true");

--- a/src/test/java/emissary/core/TransformHistoryTest.java
+++ b/src/test/java/emissary/core/TransformHistoryTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TransformHistoryTest extends UnitTest {
+class TransformHistoryTest extends UnitTest {
 
     @Test
     void testSet() {

--- a/src/test/java/emissary/parser/InputSessionTest.java
+++ b/src/test/java/emissary/parser/InputSessionTest.java
@@ -11,7 +11,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class InputSessionTest extends UnitTest {
+class InputSessionTest extends UnitTest {
 
     @Test
     void testRecordCounting() throws ParserException {

--- a/src/test/java/emissary/pool/AgentPoolTest.java
+++ b/src/test/java/emissary/pool/AgentPoolTest.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class AgentPoolTest extends UnitTest {
+class AgentPoolTest extends UnitTest {
 
     public static Stream<Arguments> poolSizeVales() {
         return Stream.of(

--- a/src/test/java/emissary/test/core/junit5/LogbackTesterTest.java
+++ b/src/test/java/emissary/test/core/junit5/LogbackTesterTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LogbackTesterTest extends UnitTest {
+class LogbackTesterTest extends UnitTest {
     @SuppressWarnings("HidingField")
     protected Logger logger = LoggerFactory.getLogger("TESTY");
 

--- a/src/test/java/emissary/transform/JavascriptEscapePlaceTest.java
+++ b/src/test/java/emissary/transform/JavascriptEscapePlaceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-public class JavascriptEscapePlaceTest extends ExtractionTest {
+class JavascriptEscapePlaceTest extends ExtractionTest {
 
     public static Stream<? extends Arguments> data() {
         return getMyTestParameterFiles(JavascriptEscapePlaceTest.class);

--- a/src/test/java/emissary/transform/JsonEscapePlaceTest.java
+++ b/src/test/java/emissary/transform/JsonEscapePlaceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-public class JsonEscapePlaceTest extends ExtractionTest {
+class JsonEscapePlaceTest extends ExtractionTest {
 
     public static Stream<? extends Arguments> data() {
         return getMyTestParameterFiles(JsonEscapePlaceTest.class);

--- a/src/test/java/emissary/util/DateTimeFormatParserTest.java
+++ b/src/test/java/emissary/util/DateTimeFormatParserTest.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class DateTimeFormatParserTest extends UnitTest {
+class DateTimeFormatParserTest extends UnitTest {
 
     private static final long EXPECTED_FULL = 1451931630; // 2016-01-04 18:20:30
     private static final long EXPECTED_NO_TIME = 1451865600; // 2016-01-04 00:00:00

--- a/src/test/java/emissary/util/PayloadUtilTest.java
+++ b/src/test/java/emissary/util/PayloadUtilTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class PayloadUtilTest extends UnitTest {
+class PayloadUtilTest extends UnitTest {
 
     private static String timezone = "GMT";
     private static final String validFormCharsString = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-)(/+";


### PR DESCRIPTION
to comply with JUnit5 (and subsequently sonar), public modifiers for test declaration are no longer necessary, so to have it consistent across emissary, went through and changed the tests where public is not needed.