### PR TITLE
errorprone :: suppress HidingField

### DIFF
--- a/src/test/java/emissary/core/channels/LoggingChannelFactoryTest.java
+++ b/src/test/java/emissary/core/channels/LoggingChannelFactoryTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LoggingChannelFactoryTest extends UnitTest {
     private ListAppender<ILoggingEvent> appender;
+    @SuppressWarnings("HidingField")
     private final Logger logger = (Logger) LoggerFactory.getLogger(LoggingChannelFactoryTest.class);
 
     @BeforeEach

--- a/src/test/java/emissary/core/channels/LoggingInputStreamFactoryTest.java
+++ b/src/test/java/emissary/core/channels/LoggingInputStreamFactoryTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class LoggingInputStreamFactoryTest extends UnitTest {
     @Nullable
     private ListAppender<ILoggingEvent> appender = null;
+    @SuppressWarnings("HidingField")
     private final Logger logger = (Logger) LoggerFactory.getLogger(LoggingInputStreamFactoryTest.class);
 
     @BeforeEach

--- a/src/test/java/emissary/test/core/junit5/LogbackTesterTest.java
+++ b/src/test/java/emissary/test/core/junit5/LogbackTesterTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LogbackTesterTest extends UnitTest {
+    @SuppressWarnings("HidingField")
     protected Logger logger = LoggerFactory.getLogger("TESTY");
 
     @Test

--- a/src/test/java/emissary/util/DisposeHelperTest.java
+++ b/src/test/java/emissary/util/DisposeHelperTest.java
@@ -37,6 +37,7 @@ class DisposeHelperTest extends UnitTest {
 
     @Nullable
     private ListAppender<ILoggingEvent> appender = null;
+    @SuppressWarnings("HidingField")
     private final Logger logger = (Logger) LoggerFactory.getLogger(DisposeHelper.class);
     private final Logger rLogger = (Logger) LoggerFactory.getLogger("DisposeHelperRunnable");
 


### PR DESCRIPTION
only occurs when testing classes use `import ch.qos.logback.classic.Logger;` against UnitTest's slf4j logger