### PR TITLE
deprecating JsonEscapePlace and JsonEscape utility

### DIFF
--- a/src/main/java/emissary/transform/JsonEscapePlace.java
+++ b/src/main/java/emissary/transform/JsonEscapePlace.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 
 import static emissary.core.constants.Configurations.OUTPUT_FORM;
 
+@Deprecated(forRemoval = true)
 public class JsonEscapePlace extends ServiceProviderPlace {
 
     /**

--- a/src/main/java/emissary/transform/decode/JsonEscape.java
+++ b/src/main/java/emissary/transform/decode/JsonEscape.java
@@ -5,6 +5,7 @@ import emissary.util.shell.Executrix;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
+@Deprecated(forRemoval = true)
 public class JsonEscape {
 
     private static final String ESCAPES = "ntr\"'/\\";

--- a/src/test/java/emissary/transform/JsonEscapePlaceTest.java
+++ b/src/test/java/emissary/transform/JsonEscapePlaceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.io.IOException;
 import java.util.stream.Stream;
 
+@Deprecated(forRemoval = true)
 class JsonEscapePlaceTest extends ExtractionTest {
 
     public static Stream<? extends Arguments> data() {

--- a/src/test/java/emissary/transform/decode/JsonEscapeTest.java
+++ b/src/test/java/emissary/transform/decode/JsonEscapeTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Deprecated(forRemoval = true)
 class JsonEscapeTest extends UnitTest {
     @Test
     void testEscapedAngleBracketChars() {


### PR DESCRIPTION
adding `@Deprecated(forRemoval = true)` for JsonEscapePlace and JsonEscape utility.

removing these and the references in `emissary.admin.ClassNameInventory.cfg` & `places.cfg` will happen later.