### PR TITLE
deprecating JavascriptEscapePlace and JavascriptEscape utility

### DIFF
--- a/src/main/java/emissary/transform/JavascriptEscapePlace.java
+++ b/src/main/java/emissary/transform/JavascriptEscapePlace.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 
 import static emissary.core.constants.Configurations.OUTPUT_FORM;
 
+@Deprecated(forRemoval = true)
 public class JavascriptEscapePlace extends ServiceProviderPlace {
 
     /**

--- a/src/main/java/emissary/transform/decode/JavascriptEscape.java
+++ b/src/main/java/emissary/transform/decode/JavascriptEscape.java
@@ -5,6 +5,7 @@ import emissary.util.shell.Executrix;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
+@Deprecated(forRemoval = true)
 public class JavascriptEscape {
 
     /**

--- a/src/test/java/emissary/transform/JavascriptEscapePlaceTest.java
+++ b/src/test/java/emissary/transform/JavascriptEscapePlaceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.io.IOException;
 import java.util.stream.Stream;
 
+@Deprecated(forRemoval = true)
 class JavascriptEscapePlaceTest extends ExtractionTest {
 
     public static Stream<? extends Arguments> data() {


### PR DESCRIPTION
adding `@Deprecated(forRemoval = true)` for JavascriptEscapePlace and JavascriptEscape utility.

removing these and the references in emissary.admin.ClassNameInventory.cfg & places.cfg will happen later.
