### PR TITLE
deprecating HtmlEscapePlace and HtmlEscape utility

### DIFF
--- a/src/main/java/emissary/transform/HtmlEscapePlace.java
+++ b/src/main/java/emissary/transform/HtmlEscapePlace.java
@@ -28,6 +28,7 @@ import static emissary.core.constants.Parameters.DOCUMENT_TITLE;
 import static emissary.core.constants.Parameters.SUFFIXES_HTML_ESCAPE;
 import static emissary.core.constants.Parameters.SUMMARY;
 
+@Deprecated(forRemoval = true)
 public class HtmlEscapePlace extends ServiceProviderPlace {
 
     /**

--- a/src/main/java/emissary/transform/decode/HtmlEscape.java
+++ b/src/main/java/emissary/transform/decode/HtmlEscape.java
@@ -14,6 +14,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
+@Deprecated(forRemoval = true)
 public class HtmlEscape {
 
     /* our logger */

--- a/src/test/java/emissary/transform/HtmlEscapePlaceTest.java
+++ b/src/test/java/emissary/transform/HtmlEscapePlaceTest.java
@@ -21,6 +21,7 @@ import static emissary.core.constants.Parameters.DOCUMENT_TITLE;
 import static emissary.core.constants.Parameters.SUMMARY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Deprecated(forRemoval = true)
 public class HtmlEscapePlaceTest extends ExtractionTest {
 
     public static Stream<? extends Arguments> data() {

--- a/src/test/java/emissary/transform/decode/HtmlEscapeTest.java
+++ b/src/test/java/emissary/transform/decode/HtmlEscapeTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+@Deprecated(forRemoval = true)
 class HtmlEscapeTest extends UnitTest {
 
     private static final String W = "Президент Буш";


### PR DESCRIPTION
adding `@Deprecated(forRemoval = true)` for HtmlEscapePlace and HtmlEscape utility.
removing these and the references in emissary.admin.ClassNameInventory.cfg & places.cfg will happen later.
