### PR TITLE
Add RegressionTest error message for when possible non-deterministic behavior is detected.

### DIFF
--- a/src/test/java/emissary/test/core/junit5/RegressionTest.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTest.java
@@ -337,6 +337,7 @@ public abstract class RegressionTest extends ExtractionTest {
     @Override
     protected void checkAnswers(final Document answers, final IBaseDataObject payload,
             final List<IBaseDataObject> attachments, final String tname) {
-        RegressionTestUtil.checkAnswers(answers, payload, actualSimplifiedLogEvents, attachments, place.getClass().getName(), getDecoders());
+        RegressionTestUtil.checkAnswers(answers, payload, actualSimplifiedLogEvents, attachments, place.getClass().getName(), getDecoders(),
+                generateAnswers());
     }
 }

--- a/src/test/java/emissary/test/core/junit5/RegressionTestUtil.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTestUtil.java
@@ -71,7 +71,7 @@ public final class RegressionTestUtil {
     public static final String THROWABLE_MESSAGE_NAME = "throwableMessage";
 
     public static final String NON_DETERMINISTIC_ERROR_MESSAGE =
-            "\nNOTE: Since 'generateAnswers' is true, these differences could be because of non-deterministic state in the IBDO\n";
+            "\nNOTE: Since 'generateAnswers' is true, these differences could indicate non-deterministic processing in the tested code path\n";
 
     /**
      * XML builder to read XML answer file in

--- a/src/test/java/emissary/test/core/junit5/RegressionTestUtil.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTestUtil.java
@@ -70,6 +70,9 @@ public final class RegressionTestUtil {
      */
     public static final String THROWABLE_MESSAGE_NAME = "throwableMessage";
 
+    public static final String NON_DETERMINISTIC_ERROR_MESSAGE =
+            "\nNOTE: Since 'generateAnswers' is true, these differences could be because of non-deterministic state in the IBDO\n";
+
     /**
      * XML builder to read XML answer file in
      */
@@ -119,7 +122,7 @@ public final class RegressionTestUtil {
     }
 
     public static void checkAnswers(final Document answers, final IBaseDataObject payload, final List<SimplifiedLogEvent> actualSimplifiedLogEvents,
-            final List<IBaseDataObject> attachments, final String placeName, final ElementDecoders decoders) {
+            final List<IBaseDataObject> attachments, final String placeName, final ElementDecoders decoders, final boolean generateAnswers) {
         final Element root = answers.getRootElement();
         final Element parent = root.getChild(ANSWERS);
 
@@ -130,7 +133,7 @@ public final class RegressionTestUtil {
         final String differences = PlaceComparisonHelper.checkDifferences(expectedIbdo, payload, expectedAttachments,
                 attachments, placeName, DIFF_CHECK);
 
-        assertNull(differences, differences);
+        assertNull(differences, generateAnswers ? differences + NON_DETERMINISTIC_ERROR_MESSAGE : differences);
 
         final List<SimplifiedLogEvent> expectedSimplifiedLogEvents = getSimplifiedLogEvents(parent);
 


### PR DESCRIPTION
This PR adds an error message when RegressionTest is generating answers and differences are detected. This usually indicates that there is non-deterministic state in the IBDO because the place is executed once to generate the answer file and once to check against the answer file. If these two executions produce different results, then this most likely indicates non-deterministic state.