### PR TITLE
Deprecate IBDO/BDO ByteBuffer methods.

### DIFF
--- a/src/main/java/emissary/core/BaseDataObject.java
+++ b/src/main/java/emissary/core/BaseDataObject.java
@@ -1096,6 +1096,7 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
     }
 
     @Override
+    @Deprecated(forRemoval = true)
     public ByteBuffer headerBuffer() {
         return ByteBuffer.wrap(header());
     }
@@ -1113,11 +1114,13 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
 
 
     @Override
+    @Deprecated(forRemoval = true)
     public ByteBuffer footerBuffer() {
         return ByteBuffer.wrap(footer());
     }
 
     @Override
+    @Deprecated(forRemoval = true)
     public ByteBuffer dataBuffer() {
         return ByteBuffer.wrap(data());
     }
@@ -1236,6 +1239,7 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
      */
     @Nullable
     @Override
+    @Deprecated(forRemoval = true)
     public ByteBuffer getAlternateViewBuffer(final String s) {
         final byte[] viewdata = getAlternateView(s);
         if (viewdata == null) {

--- a/src/main/java/emissary/core/IBaseDataObject.java
+++ b/src/main/java/emissary/core/IBaseDataObject.java
@@ -215,6 +215,7 @@ public interface IBaseDataObject {
      * 
      * @return buffer required by the HTML Velocity templates.
      */
+    @Deprecated(forRemoval = true)
     ByteBuffer headerBuffer();
 
     /**
@@ -222,6 +223,7 @@ public interface IBaseDataObject {
      * 
      * @return buffer required by the HTML Velocity templates.
      */
+    @Deprecated(forRemoval = true)
     ByteBuffer footerBuffer();
 
     /**
@@ -229,6 +231,7 @@ public interface IBaseDataObject {
      * 
      * @return buffer required by the HTML Velocity templates.
      */
+    @Deprecated(forRemoval = true)
     ByteBuffer dataBuffer();
 
     /**
@@ -449,6 +452,7 @@ public interface IBaseDataObject {
      * @param arg1 the name of the view to retrieve
      * @return buffer of alternate view data
      */
+    @Deprecated(forRemoval = true)
     ByteBuffer getAlternateViewBuffer(String arg1);
 
     /**


### PR DESCRIPTION
Currently, the byte[] methods are used almost exclusively compared to these methods.  Additionally, the couple of uses of these methods get the array of bytes from the ByteBuffer and don't use the ByteBuffer.