### PR TITLE
errorprone :: update UnusedException messages

### DIFF
--- a/src/main/java/emissary/core/sentinel/protocols/actions/Recover.java
+++ b/src/main/java/emissary/core/sentinel/protocols/actions/Recover.java
@@ -27,7 +27,7 @@ public class Recover extends Action {
                 logger.warn("Sentinel attempting recovery for {}", agentName);
                 mobileAgent.interrupt();
             } catch (Exception e) {
-                throw new IllegalStateException("Recovery unavailable ", e);
+                throw new IllegalStateException("Recovery unavailable", e);
             }
         }
     }

--- a/src/main/java/emissary/util/magic/MagicNumberFactory.java
+++ b/src/main/java/emissary/util/magic/MagicNumberFactory.java
@@ -331,7 +331,7 @@ public class MagicNumberFactory {
         try {
             return MagicMath.stringToInt(entry);
         } catch (NumberFormatException e) {
-            throw new ParseException(e + ": Malformatted offset value: " + entry);
+            throw new ParseException(e + ": Malformed offset value");
         }
     }
 

--- a/src/main/java/emissary/util/search/ByteTokenizer.java
+++ b/src/main/java/emissary/util/search/ByteTokenizer.java
@@ -97,8 +97,8 @@ public class ByteTokenizer implements Iterator<String> {
         try {
             Charset c = Charset.forName(encoding);
             logger.debug("Loaded charset {}", c);
-        } catch (Exception ex) {
-            throw new UnsupportedEncodingException(ex + ": No support for " + encoding);
+        } catch (IllegalArgumentException ex) {
+            throw new UnsupportedEncodingException(ex.toString());
         }
         this.encoding = encoding;
     }

--- a/src/test/java/emissary/util/magic/MagicMathTest.java
+++ b/src/test/java/emissary/util/magic/MagicMathTest.java
@@ -1,0 +1,22 @@
+package emissary.util.magic;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MagicMathTest {
+
+    @Test
+    void testStringToInt() {
+        int x = MagicMath.stringToInt("13");
+        assertEquals(13, x);
+
+        // existing behavior
+        assertThrows(NullPointerException.class, () -> MagicMath.stringToInt(null));
+
+        String entry = "blah";
+        Exception exception = assertThrows(NumberFormatException.class, () -> MagicMath.stringToInt(entry));
+        assertEquals("java.lang.NumberFormatException: For input string: \"blah\"", exception.toString());
+    }
+}

--- a/src/test/java/emissary/util/search/ByteTokenizerTest.java
+++ b/src/test/java/emissary/util/search/ByteTokenizerTest.java
@@ -1,0 +1,25 @@
+package emissary.util.search;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ByteTokenizerTest {
+
+    @Test
+    void testEncodingConstructor() throws Exception {
+
+        byte[] testBytes = "these are test bytes".getBytes(StandardCharsets.UTF_8);
+        ByteTokenizer byteTokenizer = new ByteTokenizer(testBytes, 0, 12, " ", StandardCharsets.UTF_8.name());
+        assertEquals(3, byteTokenizer.countTokens());
+
+        assertThrows(UnsupportedEncodingException.class, () -> new ByteTokenizer(testBytes, 0, 12, " ", null));
+
+        Exception exception = assertThrows(UnsupportedEncodingException.class, () -> new ByteTokenizer(testBytes, 0, 12, " ", "fake-encoding"));
+        assertEquals("java.io.UnsupportedEncodingException: java.nio.charset.UnsupportedCharsetException: fake-encoding", exception.toString());
+    }
+}


### PR DESCRIPTION
Updates with test to illustrate more clearly what the result will be. Attempts to remove some of the redundancy in the resultant messages.

I'm open to using annotations to quiet the rule and go back to the original message in these cases too if this format isn't desirable. It runs opposite to the feedback posted at https://github.com/NationalSecurityAgency/emissary/pull/842/commits/84faecfeebabc73b33588caec0010c9d726633c2#r1675701179