### PR TITLE
errorprone :: AvoidObjectArrays in Url and UrlData

### DIFF
--- a/src/main/java/emissary/util/web/Url.java
+++ b/src/main/java/emissary/util/web/Url.java
@@ -1,7 +1,3 @@
-/*
-  $Id$
- */
-
 package emissary.util.web;
 
 import org.slf4j.Logger;
@@ -14,7 +10,9 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -76,7 +74,7 @@ public class Url {
      * @param urlString the URL resource
      * @param props properties to use on the connection
      */
-    public static UrlData getUrl(final String urlString, @Nullable final UrlRequestProperty[] props) {
+    public static UrlData getUrl(final String urlString, @Nullable final List<UrlRequestProperty> props) {
         return processUrl(urlString, props, null, Url.GET);
     }
 
@@ -115,7 +113,7 @@ public class Url {
      * @param props array of properties to use
      * @param parms the POST data
      */
-    public static UrlData postUrl(final String urlString, @Nullable final UrlRequestProperty[] props, @Nullable final HttpPostParameters parms) {
+    public static UrlData postUrl(final String urlString, @Nullable final List<UrlRequestProperty> props, @Nullable final HttpPostParameters parms) {
 
         // props.addProp(new UrlRequestProperty("Content-length",parms.length()));
 
@@ -139,7 +137,8 @@ public class Url {
      * @param parms parameters to use when POSTing
      * @param method GET, HEAD, POST
      */
-    private static UrlData processUrl(final String urlString, @Nullable final UrlRequestProperty[] props, @Nullable final HttpPostParameters parms,
+    private static UrlData processUrl(final String urlString, @Nullable final List<UrlRequestProperty> props,
+            @Nullable final HttpPostParameters parms,
             final int method) {
         final UrlData response = new UrlData(urlString);
 
@@ -189,11 +188,9 @@ public class Url {
             }
 
             // Load headers into properties array
-            final UrlRequestProperty[] theProps = new UrlRequestProperty[headers.size()];
-            hdr = 0;
-
+            final List<UrlRequestProperty> theProps = new ArrayList<>(headers.size());
             for (final Map.Entry<String, String> entry : headers.entrySet()) {
-                theProps[hdr] = new UrlRequestProperty(entry.getKey(), entry.getValue());
+                theProps.add(new UrlRequestProperty(entry.getKey(), entry.getValue()));
             }
             response.setProps(theProps);
 

--- a/src/main/java/emissary/util/web/UrlData.java
+++ b/src/main/java/emissary/util/web/UrlData.java
@@ -1,10 +1,8 @@
 package emissary.util.web;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.Nullable;
-
-/*
- $Id$
- */
 
 /**
  * The consolidated output from a web page retrieval
@@ -14,7 +12,7 @@ import javax.annotation.Nullable;
 public class UrlData {
 
     String password;
-    UrlRequestProperty[] props;
+    List<UrlRequestProperty> props;
     String referer;
     int responseCode;
     byte[] theContent;
@@ -27,13 +25,12 @@ public class UrlData {
      * The request properties array sent into this constructor is copied. Note that a deep copy is not performed. If the
      * properties inside the list are changed, this class will see the changes.
      */
-    public UrlData(final String theUrl, final byte[] theContent, final int responseCode, final UrlRequestProperty[] props) {
+    public UrlData(final String theUrl, final byte[] theContent, final int responseCode, final List<UrlRequestProperty> props) {
         this.theUrl = theUrl;
         this.theContent = theContent;
         this.responseCode = responseCode;
         this.theMethod = Url.GET;
-        this.props = new UrlRequestProperty[props.length];
-        System.arraycopy(props, 0, this.props, 0, props.length);
+        this.props = new ArrayList<>(props);
     }
 
     public UrlData() {}
@@ -186,12 +183,13 @@ public class UrlData {
      * 
      * @return Value of props.
      */
-    public UrlRequestProperty[] getProps() {
-        return this.props;
+    @Nullable
+    public List<UrlRequestProperty> getProps() {
+        return this.props == null ? null : new ArrayList<>(this.props);
     }
 
     public int getNumberOfProperties() {
-        return (this.props == null) ? 0 : this.props.length;
+        return (this.props == null) ? 0 : this.props.size();
     }
 
     /**
@@ -199,8 +197,8 @@ public class UrlData {
      * 
      * @param v Value to assign to props.
      */
-    public void setProps(final UrlRequestProperty[] v) {
-        this.props = v;
+    public void setProps(final List<UrlRequestProperty> v) {
+        this.props = new ArrayList<>(v);
     }
 
     /**
@@ -215,15 +213,10 @@ public class UrlData {
         }
 
         if (this.props == null) {
-            this.props = new UrlRequestProperty[1];
-            this.props[0] = v;
-            return;
+            this.props = new ArrayList<>();
         }
 
-        final UrlRequestProperty[] np = new UrlRequestProperty[this.props.length + 1];
-        System.arraycopy(this.props, 0, np, 0, this.props.length);
-        np[np.length] = v;
-        this.props = np;
+        this.props.add(v);
     }
 
     /**
@@ -231,22 +224,19 @@ public class UrlData {
      * 
      * @param v array of new UrlRequestProperty to add
      */
-    public void addProps(@Nullable final UrlRequestProperty[] v) {
+    public void addProps(@Nullable final List<UrlRequestProperty> v) {
         if (v == null) {
             return;
         }
-        if (v.length == 0) {
+        if (v.isEmpty()) {
             return;
         }
 
-        final int plen = (this.props == null) ? 0 : this.props.length;
-
-        final UrlRequestProperty[] np = new UrlRequestProperty[plen + v.length];
-        if (this.props != null) {
-            System.arraycopy(this.props, 0, np, 0, plen);
+        if (this.props == null) {
+            this.props = new ArrayList<>();
         }
-        System.arraycopy(v, 0, np, plen, v.length);
-        this.props = np;
+
+        this.props.addAll(v);
     }
 
     /**
@@ -266,8 +256,8 @@ public class UrlData {
         sb.append(Url.theMethodString[this.theMethod]).append(": ").append(this.theUrl).append(" ").append(this.responseCode).append("/")
                 .append(this.theContent.length);
         if (headers && (this.props != null)) {
-            for (int i = 0; i < this.props.length; i++) {
-                sb.append(this.props[i].toString());
+            for (UrlRequestProperty prop : this.props) {
+                sb.append(prop.toString());
             }
         }
         sb.append("\n\n").append(new String(this.theContent)).append("\n");

--- a/src/test/java/emissary/util/web/UrlDataTest.java
+++ b/src/test/java/emissary/util/web/UrlDataTest.java
@@ -4,6 +4,9 @@ import emissary.test.core.junit5.UnitTest;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -30,8 +33,7 @@ class UrlDataTest extends UnitTest {
         assertEquals("password", urlData.getPassword());
 
         final UrlRequestProperty property = new UrlRequestProperty("KEY", "VALUE");
-        final UrlRequestProperty[] properties = new UrlRequestProperty[1];
-        properties[0] = property;
+        final List<UrlRequestProperty> properties = List.of(property);
         urlData.setProps(properties);
         assertEquals(1, urlData.getNumberOfProperties());
 
@@ -75,7 +77,7 @@ class UrlDataTest extends UnitTest {
     void testConstructor() {
         final byte[] theContent = new byte[0];
         final int responseCode = 0;
-        final UrlRequestProperty[] properties = new UrlRequestProperty[0];
+        final List<UrlRequestProperty> properties = List.of();
         final UrlData urlData = new UrlData("http://www.example.com", theContent, responseCode, properties);
         assertNull(urlData.getPassword());
         assertEquals(0, urlData.getNumberOfProperties());
@@ -91,14 +93,13 @@ class UrlDataTest extends UnitTest {
     @Test
     void testConstructorCopiesRequestProperties() {
         final UrlRequestProperty property = new UrlRequestProperty("KEY", "VALUE");
-        UrlRequestProperty[] properties = new UrlRequestProperty[1];
-        properties[0] = property;
+        List<UrlRequestProperty> properties = List.of(property);
 
         final UrlData urlData = new UrlData("http://www.example.com", new byte[0], 0, properties);
         // nullify the properties array to show that the UrlData object holds its
         // own list.
         properties = null;
-        assertEquals("VALUE", urlData.getProps()[0].getValue());
+        assertEquals("VALUE", urlData.getProps().get(0).getValue());
     }
 
     @Test
@@ -125,16 +126,14 @@ class UrlDataTest extends UnitTest {
     @Test
     void testAddZeroLengthPropertyList() {
         final UrlData urlData = new UrlData();
-        urlData.addProps(new UrlRequestProperty[0]);
+        urlData.addProps(new ArrayList<>());
         assertEquals(0, urlData.getNumberOfProperties());
     }
 
     @Test
     void testAddPropertyListToEmptyList() {
         final UrlRequestProperty property = new UrlRequestProperty("KEY", "VALUE");
-        final UrlRequestProperty[] properties = new UrlRequestProperty[2];
-        properties[0] = property;
-        properties[1] = property;
+        final List<UrlRequestProperty> properties = List.of(property, property);
         final UrlData urlData = new UrlData();
         urlData.addProps(properties);
         assertEquals(2, urlData.getNumberOfProperties());
@@ -143,9 +142,7 @@ class UrlDataTest extends UnitTest {
     @Test
     void testAddPropertyList() {
         final UrlRequestProperty property = new UrlRequestProperty("KEY", "VALUE");
-        final UrlRequestProperty[] properties = new UrlRequestProperty[2];
-        properties[0] = property;
-        properties[1] = property;
+        final List<UrlRequestProperty> properties = List.of(property, property);
         final UrlData urlData = new UrlData();
         urlData.setProps(properties);
         urlData.addProps(properties);


### PR DESCRIPTION
```
[WARNING] /nsa-emissary/src/main/java/emissary/util/web/Url.java:[79,91] [AvoidObjectArrays] Avoid accepting a UrlRequestProperty[]; consider an Iterable<UrlRequestProperty> instead
    (see https://errorprone.info/bugpattern/AvoidObjectArrays)
[WARNING] /nsa-emissary/src/main/java/emissary/util/web/Url.java:[118,92] [AvoidObjectArrays] Avoid accepting a UrlRequestProperty[]; consider an Iterable<UrlRequestProperty> instead
    (see https://errorprone.info/bugpattern/AvoidObjectArrays)

[WARNING] /nsa-emissary/src/main/java/emissary/util/web/UrlData.java:[30,113] [AvoidObjectArrays] Avoid accepting a UrlRequestProperty[]; consider an Iterable<UrlRequestProperty> instead
    (see https://errorprone.info/bugpattern/AvoidObjectArrays)
[WARNING] /nsa-emissary/src/main/java/emissary/util/web/UrlData.java:[189,29] [AvoidObjectArrays] Avoid returning a UrlRequestProperty[]; consider an ImmutableList<UrlRequestProperty> instead
    (see https://errorprone.info/bugpattern/AvoidObjectArrays)
[WARNING] /nsa-emissary/src/main/java/emissary/util/web/UrlData.java:[202,49] [AvoidObjectArrays] Avoid accepting a UrlRequestProperty[]; consider an Iterable<UrlRequestProperty> instead
    (see https://errorprone.info/bugpattern/AvoidObjectArrays)
[WARNING] /nsa-emissary/src/main/java/emissary/util/web/UrlData.java:[234,59] [AvoidObjectArrays] Avoid accepting a UrlRequestProperty[]; consider an Iterable<UrlRequestProperty> instead
    (see https://errorprone.info/bugpattern/AvoidObjectArrays)

```