### PR TITLE
update kff hash exception handling and SeekableByteChannel interactions

### DIFF
--- a/src/main/java/emissary/core/IBaseDataObjectHelper.java
+++ b/src/main/java/emissary/core/IBaseDataObjectHelper.java
@@ -10,7 +10,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -153,11 +152,7 @@ public final class IBaseDataObjectHelper {
         KffDataObjectHandler.parentToChild(childIBaseDataObject);
 
         // Hash the new child data, overwrites parent hashes if any
-        try {
-            kffDataObjectHandler.hash(childIBaseDataObject, true);
-        } catch (NoSuchAlgorithmException | IOException e) {
-            // Do not add the hash parameters
-        }
+        kffDataObjectHandler.hash(childIBaseDataObject, true);
     }
 
     /**

--- a/src/main/java/emissary/core/channels/SeekableByteChannelHelper.java
+++ b/src/main/java/emissary/core/channels/SeekableByteChannelHelper.java
@@ -19,6 +19,9 @@ import java.nio.file.Path;
 public final class SeekableByteChannelHelper {
     private static final Logger logger = LoggerFactory.getLogger(SeekableByteChannelHelper.class);
 
+    /** Channel factory backed by an empty byte array. Used for situations when a BDO should have its payload discarded. */
+    public static final SeekableByteChannelFactory EMPTY_CHANNEL_FACTORY = memory(new byte[0]);
+
     private SeekableByteChannelHelper() {}
 
     /**

--- a/src/main/java/emissary/kff/KffChain.java
+++ b/src/main/java/emissary/kff/KffChain.java
@@ -120,7 +120,7 @@ public class KffChain {
      *
      * @return result of check
      */
-    public KffResult check(final String itemName, final byte[] content) throws Exception {
+    public KffResult check(final String itemName, final byte[] content) throws NoSuchAlgorithmException {
         final ChecksumResults sums = computeSums(content);
         KffResult answer = null;
         if (content.length < kffMinDataSize || list.isEmpty()) {

--- a/src/main/java/emissary/place/KffHashPlace.java
+++ b/src/main/java/emissary/place/KffHashPlace.java
@@ -6,7 +6,6 @@ import emissary.kff.KffDataObjectHandler;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.NoSuchAlgorithmException;
 
 /**
  * Hashing place to hash payload unless hashes are set or skip flag is set. This place is intended to execute in the
@@ -62,11 +61,7 @@ public class KffHashPlace extends ServiceProviderPlace {
             return;
         }
 
-        try {
-            kff.hash(payload, useSbc);
-        } catch (final NoSuchAlgorithmException | IOException e) {
-            logger.error("KffHashPlace failed to hash data for {} - this shouldn't happen", payload.shortName(), e);
-        }
+        kff.hash(payload, useSbc);
     }
 
 }

--- a/src/test/java/emissary/core/IBaseDataObjectHelperTest.java
+++ b/src/test/java/emissary/core/IBaseDataObjectHelperTest.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -314,7 +313,6 @@ class IBaseDataObjectHelperTest extends UnitTest {
         final IBaseDataObject childIbdo1 = new BaseDataObject();
 
         childIbdo1.setChannelFactory(InMemoryChannelFactory.create("0123456789".getBytes(StandardCharsets.US_ASCII)));
-        Mockito.doThrow(NoSuchAlgorithmException.class).when(mockKffDataObjectHandler1).hash(Mockito.any(BaseDataObject.class), Mockito.anyBoolean());
         IBaseDataObjectHelper.addParentInformationToChild(parentIbdo, childIbdo1,
                 true, alwaysCopyMetadataKeys, placeKey, mockKffDataObjectHandler1);
         assertFalse(KffDataObjectHandler.hashPresent(childIbdo1));
@@ -351,7 +349,7 @@ class IBaseDataObjectHelperTest extends UnitTest {
     }
 
     @Test
-    void testAddParentInformationToChildExcluding() throws Exception {
+    void testAddParentInformationToChildExcluding() {
         final IBaseDataObject parentIbdo = ibdo1;
         final IBaseDataObject childIbdo = ibdo2;
 


### PR DESCRIPTION
born from https://github.com/NationalSecurityAgency/emissary/pull/368 but without the mandate to use `SeekableByteChannel` for hashing in all cases.

Capture the enhanced testing and exception handling updates for both types of hashing.