### PR TITLE
errorprone :: FlexibleDateTimeParser

### DIFF
--- a/src/main/java/emissary/util/FlexibleDateTimeParser.java
+++ b/src/main/java/emissary/util/FlexibleDateTimeParser.java
@@ -128,7 +128,7 @@ public final class FlexibleDateTimeParser {
      * @return the parsed immutable and thread-safe zoned-date, or null if it failed to parse
      */
     public static ZonedDateTime parse(final String dateString, boolean tryExtensiveParsing) {
-        ZonedDateTime zdt = parsingHelper(dateString, tryExtensiveParsing);
+        ZonedDateTime zdt = parseToZonedDateTime(dateString, tryExtensiveParsing);
 
         if (zdt != null || !tryExtensiveParsing) {
             return zdt;
@@ -212,7 +212,7 @@ public final class FlexibleDateTimeParser {
         if (matcher.find()) {
             String secondChanceDate = matcher.replaceAll(matcher.group(1));
             // if we removed text, attempt to parse again to see if we are more successful this time
-            return parsingHelper(secondChanceDate, true);
+            return parseToZonedDateTime(secondChanceDate, true);
         }
         return null;
     }
@@ -225,7 +225,7 @@ public final class FlexibleDateTimeParser {
      * @param tryExtensiveParsing Whether to use the extensive set of date formats
      * @return The ZonedDateTime object if our parsing was successful, or null if not
      */
-    private static ZonedDateTime parsingHelper(final String dateString, boolean tryExtensiveParsing) {
+    private static ZonedDateTime parseToZonedDateTime(final String dateString, boolean tryExtensiveParsing) {
         ZonedDateTime zdt = parse(dateString, dateFormatsMain);
 
         // if we got a successful parse or we don't want to attempt "extensive parsing", return here

--- a/src/test/java/emissary/util/FlexibleDateTimeParserTest.java
+++ b/src/test/java/emissary/util/FlexibleDateTimeParserTest.java
@@ -27,9 +27,8 @@ class FlexibleDateTimeParserTest extends UnitTest {
     @BeforeAll
     public static void setupClass() {
         // "warm-up" the class, but this runs before UnitTest has
-        // a chance to setup, so do that first
+        // a chance to set up, so do that first
         UnitTest.setupSystemProperties();
-        FlexibleDateTimeParser.getTimezone();
     }
 
     @Test
@@ -47,6 +46,24 @@ class FlexibleDateTimeParserTest extends UnitTest {
     private static void test(@Nullable String date, long expected, String msg) {
         ZonedDateTime unknownParse = FlexibleDateTimeParser.parse(date);
         Assertions.assertEquals(expected, unknownParse == null ? 0L : unknownParse.toEpochSecond(), "Error on: " + msg);
+    }
+
+    /**
+     * Test the date string against the expected output
+     *
+     * @param date the string representation of a date
+     * @param expected the expected parsed and formatted date
+     * @param formatter run a date format manually and compare the output to the unknown parser
+     */
+    private static void test(String date, long expected, DateTimeFormatter formatter) {
+        long unknownParse = FlexibleDateTimeParser.parse(date).toEpochSecond();
+        assertEquals(expected, unknownParse, "Flexible parse failed for " + formatter);
+
+        long knownParse = FlexibleDateTimeParser.parse(date, formatter).toEpochSecond();
+        assertEquals(expected, knownParse, "Manual parse failed for " + formatter);
+
+        // this is as close as I can get to testing the expected date format
+        assertEquals(unknownParse, knownParse, "Parsed date/times are not the same");
     }
 
     /**
@@ -84,24 +101,6 @@ class FlexibleDateTimeParserTest extends UnitTest {
             String dateAndOffset = dateString + " " + offset;
             testExtensiveParsing(dateAndOffset, expected, "Did not parse this string correctly: " + dateAndOffset);
         }
-    }
-
-    /**
-     * Test the date string against the expected output
-     *
-     * @param date the string representation of a date
-     * @param expected the expected parsed and formatted date
-     * @param formatter run a date format manually and compare the output to the unknown parser
-     */
-    private static void test(String date, long expected, DateTimeFormatter formatter) {
-        long unknownParse = FlexibleDateTimeParser.parse(date).toEpochSecond();
-        assertEquals(expected, unknownParse, "Flexible parse failed for " + formatter);
-
-        long knownParse = FlexibleDateTimeParser.parse(date, formatter).toEpochSecond();
-        assertEquals(expected, knownParse, "Manual parse failed for " + formatter);
-
-        // this is as close as I can get to testing the expected date format
-        assertEquals(unknownParse, knownParse, "Parsed date/times are not the same");
     }
 
     /**
@@ -190,7 +189,7 @@ class FlexibleDateTimeParserTest extends UnitTest {
 
     /**
      * Test to make sure our code can successfully handle dates with shorter offsets because this bug in java 8 was
-     * resolved: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8032051
+     * resolved: <a href="https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8032051">view_bug</a>
      */
     @Test
     void parseShortOffsets() {


### PR DESCRIPTION
```
[WARNING] /nsa-emissary/src/main/java/emissary/util/FlexibleDateTimeParser.java:[142,8] [ReturnMissingNullable] Method returns a definitely null value but is not annotated @Nullable
    (see https://errorprone.info/bugpattern/ReturnMissingNullable)
  Did you mean '@Nullable static ZonedDateTime lastDitchParsingEffort(final String date) {'?
[WARNING] /nsa-emissary/src/main/java/emissary/util/FlexibleDateTimeParser.java:[99,32] [UngroupedOverloads] Overloads should be grouped together, even when modifiers such as static or private differ between the methods; found ungrouped overloads of 'parse' on line(s): 171, 182
    (see https://errorprone.info/bugpattern/UngroupedOverloads)
  Did you mean to remove this line?
[WARNING] /nsa-emissary/src/main/java/emissary/util/FlexibleDateTimeParser.java:[111,32] [UngroupedOverloads] Overloads should be grouped together, even when modifiers such as static or private differ between the methods; found ungrouped overloads of 'parse' on line(s): 171, 182
    (see https://errorprone.info/bugpattern/UngroupedOverloads)
  Did you mean to remove this line?
[WARNING] /nsa-emissary/src/main/java/emissary/util/FlexibleDateTimeParser.java:[171,32] [UngroupedOverloads] Overloads should be grouped together, even when modifiers such as static or private differ between the methods; found ungrouped overloads of 'parse' on line(s): 99, 111
    (see https://errorprone.info/bugpattern/UngroupedOverloads)
  Did you mean to remove this line?
[WARNING] /nsa-emissary/src/main/java/emissary/util/FlexibleDateTimeParser.java:[183,32] [UngroupedOverloads] Overloads should be grouped together, even when modifiers such as static or private differ between the methods; found ungrouped overloads of 'parse' on line(s): 99, 111
    (see https://errorprone.info/bugpattern/UngroupedOverloads)
  Did you mean to remove this line?
[WARNING] /nsa-emissary/src/main/java/emissary/util/FlexibleDateTimeParser.java:[63,27] [NonFinalStaticField] Static fields should almost always be final.
    (see https://errorprone.info/bugpattern/NonFinalStaticField)
[WARNING] /nsa-emissary/src/main/java/emissary/util/FlexibleDateTimeParser.java:[68,27] [NonFinalStaticField] Static fields should almost always be final.
    (see https://errorprone.info/bugpattern/NonFinalStaticField)
[WARNING] /nsa-emissary/src/main/java/emissary/util/FlexibleDateTimeParser.java:[71,26] [NonFinalStaticField] Static fields should almost always be final.
    (see https://errorprone.info/bugpattern/NonFinalStaticField)
[WARNING] /nsa-emissary/src/main/java/emissary/util/FlexibleDateTimeParser.java:[74,43] [NonFinalStaticField] Static fields should almost always be final.
    (see https://errorprone.info/bugpattern/NonFinalStaticField)
[WARNING] /nsa-emissary/src/main/java/emissary/util/FlexibleDateTimeParser.java:[77,43] [NonFinalStaticField] Static fields should almost always be final.
    (see https://errorprone.info/bugpattern/NonFinalStaticField)


[WARNING] /nsa-emissary/src/test/java/emissary/util/FlexibleDateTimeParserTest.java:[47,24] [UngroupedOverloads] Overloads should be grouped together, even when modifiers such as static or private differ between the methods; found ungrouped overloads of 'test' on line(s): 96
    (see https://errorprone.info/bugpattern/UngroupedOverloads)
  Did you mean to remove this line?
[WARNING] /nsa-emissary/src/test/java/emissary/util/FlexibleDateTimeParserTest.java:[96,24] [UngroupedOverloads] Overloads should be grouped together, even when modifiers such as static or private differ between the methods; found ungrouped overloads of 'test' on line(s): 47
    (see https://errorprone.info/bugpattern/UngroupedOverloads)
  Did you mean to remove this line?
```
