### PR TITLE
dependencies: upgrade janino dependency to 3.1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -421,11 +421,6 @@
       <artifactId>httpclient5</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.janino</groupId>
-      <artifactId>janino</artifactId>
-      <version>3.1.7</version>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-plus</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <dep.httpcore.version>5.2.1</dep.httpcore.version>
     <dep.jackson.version>2.15.2</dep.jackson.version>
     <dep.jakarta.xml.bind-api.version>3.0.1</dep.jakarta.xml.bind-api.version>
+    <dep.janio.version>3.1.12</dep.janio.version>
     <dep.jaxb.runtime.version>3.0.1</dep.jaxb.runtime.version>
     <dep.jdom.version>2.0.6.1</dep.jdom.version>
     <dep.jersey.version>3.1.3</dep.jersey.version>
@@ -419,6 +420,11 @@
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.janino</groupId>
+      <artifactId>janino</artifactId>
+      <version>${dep.janio.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dep.httpcore.version>5.2.1</dep.httpcore.version>
     <dep.jackson.version>2.15.2</dep.jackson.version>
     <dep.jakarta.xml.bind-api.version>3.0.1</dep.jakarta.xml.bind-api.version>
-    <dep.janio.version>3.1.12</dep.janio.version>
+    <dep.janino.version>3.1.12</dep.janino.version>
     <dep.jaxb.runtime.version>3.0.1</dep.jaxb.runtime.version>
     <dep.jdom.version>2.0.6.1</dep.jdom.version>
     <dep.jersey.version>3.1.3</dep.jersey.version>
@@ -424,7 +424,7 @@
     <dependency>
       <groupId>org.codehaus.janino</groupId>
       <artifactId>janino</artifactId>
-      <version>${dep.janio.version}</version>
+      <version>${dep.janino.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Upgrading janino to mitigate  CVE: https://nvd.nist.gov/vuln/detail/CVE-2023-33546 to 3.1.12 
More details from[SBOM](https://sbom.sonatype.com/report/T1-a4e79c5353879ed9b588-e3d8ea0398999-1725999270-b61bf2b10f344f5da5d7b440a33e27c1)

Noticed that in the past we tried to remove it but had to revert that change here: https://github.com/NationalSecurityAgency/emissary/commit/9f789d54128bacd42cf4498e9a0e8930b9df8fcb


