### PR TITLE
Check valid filename in DropOffUtil

### DIFF
--- a/src/main/java/emissary/output/DropOffUtil.java
+++ b/src/main/java/emissary/output/DropOffUtil.java
@@ -221,6 +221,12 @@ public class DropOffUtil {
      * @return true iff it works
      */
     public boolean setupPath(final String fileName) {
+
+        if (!isValidFileName(fileName)) {
+            logger.error("Invalid file name: {}", fileName);
+            return false;
+        }
+
         final String pathName = fileName.substring(0, fileName.lastIndexOf(SEPARATOR));
         final Path thePath = Paths.get(pathName);
 
@@ -1062,5 +1068,16 @@ public class DropOffUtil {
                 }
             }
         }
+    }
+
+    /**
+     * Checks if the provided file name is valid. A valid file name does not contain any path traversal characters: ".." or
+     * "\\".
+     *
+     * @param fileName the file name to check
+     * @return true if the file name is valid, false otherwise
+     */
+    protected boolean isValidFileName(String fileName) {
+        return !fileName.contains("..") && !fileName.contains("\\");
     }
 }

--- a/src/test/java/emissary/output/DropOffUtilTest.java
+++ b/src/test/java/emissary/output/DropOffUtilTest.java
@@ -656,7 +656,6 @@ class DropOffUtilTest extends UnitTest {
         assertTrue(util.isValidFileName("file-name-with-dashes.txt"));
         assertTrue(util.isValidFileName("valid/fileName.txt"));
 
-
         // Invalid file names:
         assertFalse(util.isValidFileName("../invalidFileName.txt"));
         assertFalse(util.isValidFileName("invalid\\fileName.txt"));

--- a/src/test/java/emissary/output/DropOffUtilTest.java
+++ b/src/test/java/emissary/output/DropOffUtilTest.java
@@ -643,4 +643,27 @@ class DropOffUtilTest extends UnitTest {
         String fileType = DropOffUtil.getAndPutFileType(bdo, metadata, formsArg);
         assertEquals(expectedResults, fileType);
     }
+
+    @Test
+    void testIsFileNameValid() {
+        assert util != null;
+
+        // Valid file names:
+        assertTrue(util.isValidFileName("validFileName.txt"));
+        assertTrue(util.isValidFileName("another_valid-file.name"));
+        assertTrue(util.isValidFileName("file@name#with$special%chars^&.txt"));
+        assertTrue(util.isValidFileName("file_name_with_underscores.txt"));
+        assertTrue(util.isValidFileName("file-name-with-dashes.txt"));
+        assertTrue(util.isValidFileName("valid/fileName.txt"));
+
+
+        // Invalid file names:
+        assertFalse(util.isValidFileName("../invalidFileName.txt"));
+        assertFalse(util.isValidFileName("invalid\\fileName.txt"));
+        assertFalse(util.isValidFileName("..\\invalidFileName.txt"));
+
+        // Empty file name:
+        assertTrue(util.isValidFileName(""));
+    }
+
 }


### PR DESCRIPTION
Attempt to resolve: https://github.com/NationalSecurityAgency/emissary/security/code-scanning/69

> To fix the problem, we need to validate the fileName parameter before using it to construct a Path object. The validation should ensure that the fileName does not contain any path traversal characters such as ".." or any path separators. This can be achieved by checking for the presence of these characters and rejecting the input if any are found.

I am not sure if this is enough to resolve the alert. It might still hit on single `/` path separators. But I believe we want to still allow that? Or maybe we need to control the creation of every directory?

This might not be a change we want. Just throwing the idea out here. We can also silence that security alert if we deem it not relevant and mitigated in other ways. 