### PR TITLE
exclude github-actions[bot] changes from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,8 @@
 ---
 changelog:
+  exclude:
+    authors:
+      - github-actions[bot]
   categories:
     - title: New Features
       labels:


### PR DESCRIPTION
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options