### PR TITLE
updates to VersionPlace for less code-reusage downstream

### DIFF
--- a/src/main/java/emissary/place/VersionPlace.java
+++ b/src/main/java/emissary/place/VersionPlace.java
@@ -108,4 +108,12 @@ public class VersionPlace extends ServiceProviderPlace {
     public void setAbbrevHash(Boolean useAbbrevHash) {
         this.useAbbrevHash = useAbbrevHash;
     }
+
+    public boolean isIncludeDate() {
+        return includeDate;
+    }
+
+    public boolean isUseAbbrevHash() {
+        return useAbbrevHash;
+    }
 }

--- a/src/test/java/emissary/place/VersionPlaceTest.java
+++ b/src/test/java/emissary/place/VersionPlaceTest.java
@@ -5,7 +5,6 @@ import emissary.core.IBaseDataObject;
 import emissary.core.ResourceException;
 import emissary.test.core.junit5.UnitTest;
 import emissary.util.GitRepositoryState;
-import emissary.util.Version;
 import emissary.util.io.ResourceReader;
 
 import org.junit.jupiter.api.AfterEach;
@@ -16,28 +15,22 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import javax.annotation.Nullable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class VersionPlaceTest extends UnitTest {
-    @Nullable
     private IBaseDataObject payload;
-    @Nullable
     private VersionPlace place;
-    private Version version;
-    @Nullable
-    private String versionDate;
     private Path gitRepositoryFile;
+    private GitRepositoryState testGitRepoState;
 
     @Override
     @BeforeEach
     public void setUp() throws Exception {
         payload = DataObjectFactory.getInstance();
-        version = new Version();
-        versionDate = version.getTimestamp().replaceAll("\\D", "");
         gitRepositoryFile = Paths.get(new ResourceReader().getResource("emissary/util/test.git.properties").toURI());
+        testGitRepoState = GitRepositoryState.getRepositoryState(gitRepositoryFile);
     }
 
     @Override
@@ -47,7 +40,6 @@ class VersionPlaceTest extends UnitTest {
         place.shutDown();
         place = null;
         payload = null;
-        versionDate = null;
     }
 
     @Test
@@ -56,7 +48,7 @@ class VersionPlaceTest extends UnitTest {
         place = new MyVersionPlace();
 
         place.process(payload);
-        assertEquals(payload.getStringParameter("EMISSARY_VERSION"), version.getVersion() + "-" + versionDate,
+        assertEquals(testGitRepoState.getBuildVersion() + "-20240828141716", payload.getStringParameter("EMISSARY_VERSION"),
                 "added version should contain the date.");
     }
 
@@ -67,8 +59,8 @@ class VersionPlaceTest extends UnitTest {
         place = new MyVersionPlace(is);
 
         place.process(payload);
-        assertFalse(payload.getStringParameter("EMISSARY_VERSION").contains(versionDate), "the date should not be added to the version");
-        assertEquals(payload.getStringParameter("EMISSARY_VERSION"), version.getVersion(), "the version should be added");
+        assertFalse(payload.getStringParameter("EMISSARY_VERSION").contains("-20240828141716"), "the date should not be added to the version");
+        assertEquals(testGitRepoState.getBuildVersion(), payload.getStringParameter("EMISSARY_VERSION"), "the version should be added");
     }
 
     @Test
@@ -77,8 +69,7 @@ class VersionPlaceTest extends UnitTest {
         place = new MyVersionPlace();
 
         place.process(payload);
-        assertEquals(payload.getStringParameter("EMISSARY_VERSION_HASH").substring(0, 7),
-                GitRepositoryState.getRepositoryState(gitRepositoryFile).getCommitIdAbbrev(),
+        assertEquals(testGitRepoState.getCommitIdAbbrev(), payload.getStringParameter("EMISSARY_VERSION_HASH").substring(0, 7),
                 "EMISSARY_VERSION_HASH should contain (at least) the abbreviated hash");
     }
 

--- a/src/test/java/emissary/place/VersionPlaceTest.java
+++ b/src/test/java/emissary/place/VersionPlaceTest.java
@@ -15,12 +15,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import javax.annotation.Nullable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class VersionPlaceTest extends UnitTest {
+    @Nullable
     private IBaseDataObject payload;
+    @Nullable
     private VersionPlace place;
     private Path gitRepositoryFile;
     private GitRepositoryState testGitRepoState;


### PR DESCRIPTION
Basically gets rid of the use of `emissary.util.Version`, and relies on `GitRepositoryState` to get the version and hash. This allows for a lot less code-reusage for classes downstream that extend this.
Created setters for the booleans so they can be set downstream.

One thing to keep in mind for this is the BuildTime is only reset in the `emissary.git.properties` file when "mvn clean" is run