### PR TITLE
correct param for plugin.nexus-staging-maven.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <plugin.maven-source.version>3.2.1</plugin.maven-source.version>
     <!-- seems to have an impact with java 11 integration, update with caution -->
     <plugin.maven-surefire.version>3.1.0</plugin.maven-surefire.version>
-    <plugin.nexus-maven-staging.version>1.6.7</plugin.nexus-maven-staging.version>
+    <plugin.nexus-staging-maven.version>1.6.7</plugin.nexus-staging-maven.version>
     <plugin.sonar-maven.version>3.9.1.2184</plugin.sonar-maven.version>
     <plugin.sortpom-maven.version>2.15.0</plugin.sortpom-maven.version>
     <plugin.versions-maven.version>2.17.1</plugin.versions-maven.version>


### PR DESCRIPTION
mistake during: https://github.com/NationalSecurityAgency/emissary/commit/4d84b8de0e125961ebebbb99edbaa9df2d613e97

needed so the plugin in line 1422 works:
```
<plugin>
            <groupId>org.sonatype.plugins</groupId>
            <artifactId>nexus-staging-maven-plugin</artifactId>
            <version>${plugin.nexus-staging-maven.version}</version>
            <extensions>true</extensions>
            <configuration>
              <serverId>ossrh</serverId>
              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
              <autoReleaseAfterClose>true</autoReleaseAfterClose>
            </configuration>
          </plugin>
 ```