### PR TITLE
errorprone: MissingCasesInEnumSwitch

### DIFF
--- a/src/main/java/emissary/directory/DirectoryObserverManager.java
+++ b/src/main/java/emissary/directory/DirectoryObserverManager.java
@@ -232,6 +232,9 @@ public class DirectoryObserverManager {
                     matchcount++;
                     logger.debug("Match! Doing {} for {}", action, placeKey);
                     switch (action) {
+                        case PEER_GROUP_CHANGE:
+                            // TODO: remove this ordinal?
+                            break;
                         case PLACE_ADD:
                             p.placeRegistered(this.directoryKey, placeKey);
                             break;


### PR DESCRIPTION
Silence the warning, but this probably needs a bigger effort to remove this from the ordinal list if we don't want it anymore.