### PR TITLE
github-actions :: using new output format between action steps in maven-release

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -73,7 +73,7 @@ jobs:
       packages: write
     steps:
       - name: Add RELEASE_VERSION to environment variable
-        run: echo "RELEASE_VERSION=${{ steps.get_version.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
+        run: echo "RELEASE_VERSION=${{ needs.get_version.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
 
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -192,7 +192,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add RELEASE_VERSION to environment variable
-        run: echo "RELEASE_VERSION=${{ steps.get_version.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
+        run: echo "RELEASE_VERSION=${{ steps.needs.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
 
       - name: Publish to slack channel via bot token
         id: slack
@@ -222,7 +222,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add RELEASE_VERSION to environment variable
-        run: echo "RELEASE_VERSION=${{ steps.get_version.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
+        run: echo "RELEASE_VERSION=${{ steps.needs.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
 
       - name: Publish to slack channel via bot token
         id: slack

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -76,10 +76,11 @@ jobs:
     permissions:
       contents: write
       packages: write
+    env:
+      RELEASE_VERSION: ${{ needs.get_version.outputs.RELEASE_VERSION }}
     steps:
-      - name: Add RELEASE_VERSION to environment variable
-        run: echo "RELEASE_VERSION=${{ needs.get_version.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
-
+      - name: test outputs
+        run: echo ${{ needs.get_version.outputs.RELEASE_VERSION }}
       - name: Checkout repo
         uses: actions/checkout@v4
 

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -63,7 +63,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Get the version
-        run: echo "RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | grep -v '\[.*' | awk -F- '{print ""$1"${{ github.event.inputs.release_suffix }}"}')" >> "$GITHUB_OUTPUT"
+        run: echo "RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | grep -v '\[.*' | awk -F- '{print ""$1"${{ github.event.inputs.release_suffix }}"}')" >> "$GITHUB_ENV"
+
+      - name: Save the version to the output
+        run: |
+          echo "Saving RELEASE_VERSION=${RELEASE_VERSION}"
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> GITHUB_OUTPUT
 
   release:
     needs: get_version

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -63,9 +63,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Get the version
-        run: echo "RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | grep -v '\[.*' | awk -F- '{print ""$1"${{ github.event.inputs.release_suffix }}"}')" >> "$GITHUB_ENV"
-    outputs:
-      RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+        run: echo "RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | grep -v '\[.*' | awk -F- '{print ""$1"${{ github.event.inputs.release_suffix }}"}')" >> "$GITHUB_OUTPUT"
 
   release:
     needs: get_version
@@ -75,7 +73,7 @@ jobs:
       packages: write
     steps:
       - name: Add RELEASE_VERSION to environment variable
-        run: echo "RELEASE_VERSION=${{ needs.get_version.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
+        run: echo "RELEASE_VERSION=${{ steps.get_version.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
 
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -194,7 +192,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add RELEASE_VERSION to environment variable
-        run: echo "RELEASE_VERSION=${{ needs.get_version.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
+        run: echo "RELEASE_VERSION=${{ steps.get_version.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
 
       - name: Publish to slack channel via bot token
         id: slack
@@ -224,7 +222,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add RELEASE_VERSION to environment variable
-        run: echo "RELEASE_VERSION=${{ needs.get_version.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
+        run: echo "RELEASE_VERSION=${{ steps.get_version.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
 
       - name: Publish to slack channel via bot token
         id: slack

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -192,7 +192,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add RELEASE_VERSION to environment variable
-        run: echo "RELEASE_VERSION=${{ steps.needs.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
+        run: echo "RELEASE_VERSION=${{ needs.get_version.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
 
       - name: Publish to slack channel via bot token
         id: slack
@@ -222,7 +222,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add RELEASE_VERSION to environment variable
-        run: echo "RELEASE_VERSION=${{ steps.needs.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
+        run: echo "RELEASE_VERSION=${{ needs.get_version.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
 
       - name: Publish to slack channel via bot token
         id: slack


### PR DESCRIPTION
Resolve action warnings:
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```


https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/