### PR TITLE
Update RegressionTest to assume UTF-8.

### DIFF
--- a/src/main/java/emissary/core/IBaseDataObjectXmlCodecs.java
+++ b/src/main/java/emissary/core/IBaseDataObjectXmlCodecs.java
@@ -845,8 +845,10 @@ public final class IBaseDataObjectXmlCodecs {
     // https://stackoverflow.com/questions/3770117/what-is-the-range-of-unicode-printable-characters
     public static boolean requiresEncoding(final Reader reader) throws IOException {
         try (BufferedReader bufferedReader = new BufferedReader(reader)) {
-            int c;
-            while ((c = bufferedReader.read()) >= 0) {
+            int i;
+            while ((i = bufferedReader.read()) != -1) {
+                final char c = (char) i;
+
                 if (('\u0000' <= c && c <= '\u0008') ||
                         ('\u000E' <= c && c <= '\u001F') ||
                         ('\u007F' <= c && c <= '\u009F') ||

--- a/src/main/java/emissary/core/IBaseDataObjectXmlCodecs.java
+++ b/src/main/java/emissary/core/IBaseDataObjectXmlCodecs.java
@@ -15,6 +15,7 @@ import org.jdom2.Namespace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -843,17 +844,19 @@ public final class IBaseDataObjectXmlCodecs {
 
     // https://stackoverflow.com/questions/3770117/what-is-the-range-of-unicode-printable-characters
     public static boolean requiresEncoding(final Reader reader) throws IOException {
-        int c;
-        while ((c = reader.read()) >= 0) {
-            if (('\u0000' <= c && c <= '\u0008') ||
-                    ('\u000E' <= c && c <= '\u001F') ||
-                    ('\u007F' <= c && c <= '\u009F') ||
-                    ('\u2000' <= c && c <= '\u200F') ||
-                    ('\u2028' <= c && c <= '\u202F') ||
-                    ('\u205F' <= c && c <= '\u206F') ||
-                    c == '\u3000' || c == '\uFEFF' ||
-                    c == '\uFFFD') { // UTF-8 Error Replacement Character
-                return true;
+        try (BufferedReader bufferedReader = new BufferedReader(reader)) {
+            int c;
+            while ((c = bufferedReader.read()) >= 0) {
+                if (('\u0000' <= c && c <= '\u0008') ||
+                        ('\u000E' <= c && c <= '\u001F') ||
+                        ('\u007F' <= c && c <= '\u009F') ||
+                        ('\u2000' <= c && c <= '\u200F') ||
+                        ('\u2028' <= c && c <= '\u202F') ||
+                        ('\u205F' <= c && c <= '\u206F') ||
+                        c == '\u3000' || c == '\uFEFF' ||
+                        c == '\uFFFD') { // UTF-8 Error Replacement Character
+                    return true;
+                }
             }
         }
 

--- a/src/test/java/emissary/core/IBaseDataObjectXmlHelperTest.java
+++ b/src/test/java/emissary/core/IBaseDataObjectXmlHelperTest.java
@@ -69,8 +69,8 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
         ibdo.setFilename("Filename");
         ibdo.setFileType("FileType");
         ibdo.setFontEncoding("FontEncoding");
-        ibdo.setFooter("Footer".getBytes(StandardCharsets.ISO_8859_1));
-        ibdo.setHeader("Header".getBytes(StandardCharsets.ISO_8859_1));
+        ibdo.setFooter("Footer".getBytes(StandardCharsets.UTF_8));
+        ibdo.setHeader("Header".getBytes(StandardCharsets.UTF_8));
         ibdo.setHeaderEncoding("HeaderEncoding");
         ibdo.setId("Id");
         ibdo.setNumChildren(9);
@@ -84,8 +84,8 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
         ibdo.putParameter("Parameter1Key", "Parameter1Value");
         ibdo.putParameter("Parameter2Key", Arrays.asList("Parameter2Value1", "Parameter2Value2"));
         ibdo.putParameter("Parameter3Key", Arrays.asList(10L, 20L));
-        ibdo.addAlternateView("AlternateView1Key", "AlternateView1Value".getBytes(StandardCharsets.ISO_8859_1));
-        ibdo.addAlternateView("AlternateView11Key", "AlternateView11Value".getBytes(StandardCharsets.ISO_8859_1));
+        ibdo.addAlternateView("AlternateView1Key", "AlternateView1Value".getBytes(StandardCharsets.UTF_8));
+        ibdo.addAlternateView("AlternateView11Key", "AlternateView11Value".getBytes(StandardCharsets.UTF_8));
     }
 
     private static void setAllFieldsNonPrintable(final IBaseDataObject ibdo, final byte[] bytes) {
@@ -99,8 +99,8 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
         ibdo.setFilename("\001Filename");
         ibdo.setFileType("\001FileType");
         ibdo.setFontEncoding("\001FontEncoding");
-        ibdo.setFooter("\001Footer".getBytes(StandardCharsets.ISO_8859_1));
-        ibdo.setHeader("\001Header".getBytes(StandardCharsets.ISO_8859_1));
+        ibdo.setFooter("\001Footer".getBytes(StandardCharsets.UTF_8));
+        ibdo.setHeader("\001Header".getBytes(StandardCharsets.UTF_8));
         ibdo.setHeaderEncoding("\001HeaderEncoding");
         ibdo.setId("\001Id");
         ibdo.setNumChildren(9);
@@ -114,9 +114,9 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
         ibdo.putParameter("\020Parameter1Key", "\020Parameter1Value");
         ibdo.putParameter("\020Parameter2Key", "\020Parameter2Value");
         ibdo.addAlternateView("\200AlternateView1Key",
-                "\200AlternateView1Value".getBytes(StandardCharsets.ISO_8859_1));
+                "\200AlternateView1Value".getBytes(StandardCharsets.UTF_8));
         ibdo.addAlternateView("\200AlternateView11Key",
-                "\200AlternateView11Value".getBytes(StandardCharsets.ISO_8859_1));
+                "\200AlternateView11Value".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -125,7 +125,7 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
         final IBaseDataObject expectedIbdo = new BaseDataObject();
         final List<IBaseDataObject> expectedChildren = new ArrayList<>();
         final List<IBaseDataObject> actualChildren = new ArrayList<>();
-        final byte[] bytes = "Data".getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] bytes = "Data".getBytes(StandardCharsets.UTF_8);
 
         setAllFieldsPrintable(expectedIbdo, bytes);
 
@@ -150,7 +150,7 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
         final IBaseDataObject expectedIbdo = new BaseDataObject();
         final List<IBaseDataObject> expectedChildren = new ArrayList<>();
         final List<IBaseDataObject> actualChildren = new ArrayList<>();
-        final byte[] bytes = "\001Data".getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] bytes = "\001Data".getBytes(StandardCharsets.UTF_8);
 
         setAllFieldsNonPrintable(expectedIbdo, bytes);
 
@@ -164,10 +164,10 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
         final IBaseDataObject sha256ActualIbdo = ibdoFromXmlFromIbdo(expectedIbdo, expectedChildren, initialIbdo,
                 actualChildren, SHA256_ELEMENT_ENCODERS);
 
-        expectedIbdo.setData(ByteUtil.sha256Bytes(bytes).getBytes(StandardCharsets.ISO_8859_1));
+        expectedIbdo.setData(ByteUtil.sha256Bytes(bytes).getBytes(StandardCharsets.UTF_8));
 
         for (Entry<String, byte[]> entry : new TreeMap<>(expectedIbdo.getAlternateViews()).entrySet()) {
-            expectedIbdo.addAlternateView(entry.getKey(), ByteUtil.sha256Bytes(entry.getValue()).getBytes(StandardCharsets.ISO_8859_1));
+            expectedIbdo.addAlternateView(entry.getKey(), ByteUtil.sha256Bytes(entry.getValue()).getBytes(StandardCharsets.UTF_8));
         }
 
         final String sha256Diff = PlaceComparisonHelper.checkDifferences(expectedIbdo, sha256ActualIbdo, expectedChildren,
@@ -180,7 +180,7 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
     void testLengthAttributeDefault() throws Exception {
         final IBaseDataObject ibdo = new BaseDataObject();
         final List<IBaseDataObject> children = new ArrayList<>();
-        final byte[] bytes = "Data".getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] bytes = "Data".getBytes(StandardCharsets.UTF_8);
 
         setAllFieldsPrintable(ibdo, bytes);
 
@@ -201,7 +201,7 @@ class IBaseDataObjectXmlHelperTest extends UnitTest {
     void testLengthAttributeHash() throws Exception {
         final IBaseDataObject ibdo = new BaseDataObject();
         final List<IBaseDataObject> children = new ArrayList<>();
-        final byte[] bytes = "Data".getBytes(StandardCharsets.ISO_8859_1);
+        final byte[] bytes = "Data".getBytes(StandardCharsets.UTF_8);
 
         setAllFieldsNonPrintable(ibdo, bytes);
 

--- a/src/test/java/emissary/test/core/junit5/RegressionTest.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTest.java
@@ -182,7 +182,7 @@ public abstract class RegressionTest extends ExtractionTest {
         // touch up alternate views to match how their bytes would have encoded into the answer file
         for (Entry<String, byte[]> entry : new TreeMap<>(payload.getAlternateViews()).entrySet()) {
             Optional<String> viewSha256 = hashBytesIfNonPrintable(entry.getValue());
-            viewSha256.ifPresent(s -> payload.addAlternateView(entry.getKey(), s.getBytes(StandardCharsets.ISO_8859_1)));
+            viewSha256.ifPresent(s -> payload.addAlternateView(entry.getKey(), s.getBytes(StandardCharsets.UTF_8)));
         }
 
         // touch up primary view if necessary
@@ -198,10 +198,8 @@ public abstract class RegressionTest extends ExtractionTest {
 
         if (attachments != null) {
             for (final IBaseDataObject attachment : attachments) {
-                if (ByteUtil.hasNonPrintableValues(attachment.data())) {
-                    Optional<String> attachmentSha256 = hashBytesIfNonPrintable(attachment.data());
-                    attachmentSha256.ifPresent(s -> attachment.setData(s.getBytes(StandardCharsets.UTF_8)));
-                }
+                Optional<String> attachmentSha256 = hashBytesIfNonPrintable(attachment.data());
+                attachmentSha256.ifPresent(s -> attachment.setData(s.getBytes(StandardCharsets.UTF_8)));
             }
         }
     }
@@ -233,7 +231,7 @@ public abstract class RegressionTest extends ExtractionTest {
      * @return a value optionally containing the generated hash
      */
     protected Optional<String> hashBytesIfNonPrintable(byte[] bytes) {
-        if (ArrayUtils.isNotEmpty(bytes) && ByteUtil.hasNonPrintableValues(bytes)) {
+        if (ArrayUtils.isNotEmpty(bytes) && IBaseDataObjectXmlCodecs.requiresEncoding(bytes)) {
             return Optional.ofNullable(ByteUtil.sha256Bytes(bytes));
         }
 

--- a/src/test/java/emissary/test/core/junit5/RegressionTest.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTest.java
@@ -198,8 +198,10 @@ public abstract class RegressionTest extends ExtractionTest {
 
         if (attachments != null) {
             for (final IBaseDataObject attachment : attachments) {
-                Optional<String> attachmentSha256 = hashBytesIfNonPrintable(attachment.data());
-                attachmentSha256.ifPresent(s -> attachment.setData(s.getBytes(StandardCharsets.UTF_8)));
+                if (ByteUtil.hasNonPrintableValues(attachment.data())) {
+                    Optional<String> attachmentSha256 = hashBytesIfNonPrintable(attachment.data());
+                    attachmentSha256.ifPresent(s -> attachment.setData(s.getBytes(StandardCharsets.UTF_8)));
+                }
             }
         }
     }
@@ -231,7 +233,7 @@ public abstract class RegressionTest extends ExtractionTest {
      * @return a value optionally containing the generated hash
      */
     protected Optional<String> hashBytesIfNonPrintable(byte[] bytes) {
-        if (ArrayUtils.isNotEmpty(bytes) && IBaseDataObjectXmlCodecs.requiresEncoding(bytes)) {
+        if (ArrayUtils.isNotEmpty(bytes) && ByteUtil.containsNonIndexableBytes(bytes)) {
             return Optional.ofNullable(ByteUtil.sha256Bytes(bytes));
         }
 


### PR DESCRIPTION
This PR updates RegressionTest to assume all byte arrays are UTF-8 and not process them as ASCII (i.e. ISO_8859_1). The main benefit of this is that valid UTF-8 is output in the XML directly instead of being hashed or BASE64'd.

NOTE: This is a potentially "breaking" change that might require XML files to be regenerated.