### PR TITLE
Fixing starting offset of listIndexOf method in KeywordScanner

### DIFF
--- a/src/main/java/emissary/util/search/KeywordScanner.java
+++ b/src/main/java/emissary/util/search/KeywordScanner.java
@@ -159,7 +159,7 @@ public class KeywordScanner {
         if ((start >= this.dataLength) || (stop > this.dataLength) || (patternArg == null)) {
             return List.of();
         }
-        int newStart = 0;
+        int newStart = start;
         int actualStart;
         int position = 0;
         this.pattern = patternArg;

--- a/src/test/java/emissary/util/search/ByteMatcherTest.java
+++ b/src/test/java/emissary/util/search/ByteMatcherTest.java
@@ -116,6 +116,12 @@ class ByteMatcherTest extends UnitTest {
         assertEquals(findTestCaseInsensitive, this.bl.indexListIgnoreCase("test", 0));
         assertEquals(findTestCaseInsensitive, this.bl.indexListIgnoreCase("test", 0, LIST_DATA.length()));
 
+        // Test startOffset and endOffset
+        List<Integer> testStartOffs = List.of(26, 47, 53);
+        List<Integer> testEndOffs = List.of(26, 47);
+        assertEquals(testStartOffs, this.bl.indexListIgnoreCase("test".getBytes(), 15, LIST_DATA.length()));
+        assertEquals(testEndOffs, this.bl.listIndexOf("test".getBytes(), 15, 52));
+
     }
 
     @Test

--- a/src/test/java/emissary/util/search/KeywordScannerTest.java
+++ b/src/test/java/emissary/util/search/KeywordScannerTest.java
@@ -111,6 +111,12 @@ class KeywordScannerTest extends UnitTest {
         assertEquals(findIs, lks.listIndexOf("is".getBytes(), 0));
         assertEquals(findIs, lks.listIndexOf("is".getBytes(), 0, LIST_DATA.length));
 
+        List<Integer> startOffset = List.of(21, 39, 42);
+        assertEquals(startOffset, lks.listIndexOf("is".getBytes(), 6));
+        assertEquals(startOffset, lks.listIndexOf("is".getBytes(), 6, LIST_DATA.length));
+
+        List<Integer> endOffset = List.of(2, 5, 21);
+        assertEquals(endOffset, lks.listIndexOf("is".getBytes(), 0, 38));
     }
 
     @Test


### PR DESCRIPTION
Forgot to assign the starting offset to the newStart variable in KeywordScanner. Fixed that and added test.