### PR TITLE
Deprecate IBaseDataObjectHelper.clone() that allows partial clones.

### DIFF
--- a/src/main/java/emissary/core/IBaseDataObjectHelper.java
+++ b/src/main/java/emissary/core/IBaseDataObjectHelper.java
@@ -52,12 +52,12 @@ public final class IBaseDataObjectHelper {
      * 
      * A "fullClone" duplicates all attributes.
      * 
-     * @deprecated
+     * @deprecated prefer {@link #clone(IBaseDataObject)}
      * @param iBaseDataObject the IBaseDataObject to be cloned.
      * @param fullClone specifies if all fields should be cloned.
      * @return the clone of the IBaseDataObject passed in.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public static IBaseDataObject clone(final IBaseDataObject iBaseDataObject, final boolean fullClone) {
         Validate.notNull(iBaseDataObject, "Required: iBaseDataObject not null");
 

--- a/src/main/java/emissary/core/IBaseDataObjectHelper.java
+++ b/src/main/java/emissary/core/IBaseDataObjectHelper.java
@@ -38,14 +38,26 @@ public final class IBaseDataObjectHelper {
     private IBaseDataObjectHelper() {}
 
     /**
+     * Clones an IBaseDataObject.
+     * 
+     * @param iBaseDataObject the IBaseDataObject to be cloned.
+     * @return the clone of the IBaseDataObject passed in.
+     */
+    public static IBaseDataObject clone(final IBaseDataObject iBaseDataObject) {
+        return clone(iBaseDataObject, true);
+    }
+
+    /**
      * Clones an IBaseDataObject equivalently to emissary.core.BaseDataObject.clone(), which duplicates some attributes.
      * 
      * A "fullClone" duplicates all attributes.
      * 
+     * @deprecated
      * @param iBaseDataObject the IBaseDataObject to be cloned.
      * @param fullClone specifies if all fields should be cloned.
      * @return the clone of the IBaseDataObject passed in.
      */
+    @Deprecated
     public static IBaseDataObject clone(final IBaseDataObject iBaseDataObject, final boolean fullClone) {
         Validate.notNull(iBaseDataObject, "Required: iBaseDataObject not null");
 

--- a/src/main/java/emissary/core/IBaseDataObjectHelper.java
+++ b/src/main/java/emissary/core/IBaseDataObjectHelper.java
@@ -57,7 +57,7 @@ public final class IBaseDataObjectHelper {
      * @param fullClone specifies if all fields should be cloned.
      * @return the clone of the IBaseDataObject passed in.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated
     public static IBaseDataObject clone(final IBaseDataObject iBaseDataObject, final boolean fullClone) {
         Validate.notNull(iBaseDataObject, "Required: iBaseDataObject not null");
 

--- a/src/test/java/emissary/core/IBaseDataObjectHelperTest.java
+++ b/src/test/java/emissary/core/IBaseDataObjectHelperTest.java
@@ -109,6 +109,19 @@ class IBaseDataObjectHelperTest extends UnitTest {
     }
 
     @Test
+    void testOneArgClone() {
+        final IBaseDataObject originalIbdo = new BaseDataObject(new byte[123], "Filename", "form", "filetype");
+        final IBaseDataObject clonedIbdo = IBaseDataObjectHelper.clone(originalIbdo);
+        final List<String> differences = new ArrayList<>();
+        final DiffCheckConfiguration diffCheckConfiguration =
+                DiffCheckConfiguration.configure().enableData().enableInternalId().enableTimestamp().enableTransformHistory().build();
+
+        IBaseDataObjectDiffHelper.diff(originalIbdo, clonedIbdo, differences, diffCheckConfiguration);
+
+        assertEquals(0, differences.size());
+    }
+
+    @Test
     void testCloneArguments() {
         assertNotNull(IBaseDataObjectHelper.clone(new BaseDataObject(), false));
         checkThrowsNull(() -> IBaseDataObjectHelper.clone(null, false));


### PR DESCRIPTION
This PR deprecates the IBaseDataObjectHelper.clone() method that allows for partial clones. Partial clones were implemented to allow cloning that matched the now deprecated BaseDataObject.clone() method. A search of the code bases did not show any instance where IBaseDataObjectHelper.clone() was called for a partial clone except for in the IBaseDataObjectHelperTest class. Therefore, only full clones seem to be needed and partial clones should be removed.