### PR TITLE
initialize static instance of EmissaryServer

### DIFF
--- a/src/main/java/emissary/admin/Startup.java
+++ b/src/main/java/emissary/admin/Startup.java
@@ -14,6 +14,7 @@ import emissary.directory.KeyManipulator;
 import emissary.pickup.PickUpPlace;
 import emissary.place.CoordinationPlace;
 import emissary.place.IServiceProviderPlace;
+import emissary.server.EmissaryServer;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -290,7 +291,7 @@ public class Startup {
 
         final long start = System.currentTimeMillis();
         final Map<String, String> dirStarts = new HashMap<>();
-        EmissaryNode emissaryNode = new EmissaryNode();
+        EmissaryNode emissaryNode = EmissaryServer.getInstance().getNode();
         for (final String thePlaceLocation : hostParameters) {
 
             final String host = placeHost(thePlaceLocation);

--- a/src/main/java/emissary/command/ServerCommand.java
+++ b/src/main/java/emissary/command/ServerCommand.java
@@ -124,12 +124,8 @@ public class ServerCommand extends ServiceCommand {
 
     @Override
     protected void startService() {
-        try {
-            LOG.info("Running Emissary Server");
-            new EmissaryServer(this).startServer();
-        } catch (EmissaryException e) {
-            LOG.error("Unable to start server", e);
-        }
+        LOG.info("Running Emissary Server");
+        EmissaryServer.init(this).startServer();
     }
 
     @Override

--- a/src/main/java/emissary/directory/EmissaryNode.java
+++ b/src/main/java/emissary/directory/EmissaryNode.java
@@ -84,11 +84,16 @@ public class EmissaryNode {
 
     protected boolean strictStartupMode = false;
 
+    public EmissaryNode() {
+        this(DEFAULT_NODE_MODE);
+    }
+
     /**
      * Construct the node. The node name and port are from system properties. The node type is based on the os.name in this
      * implementation
      */
-    public EmissaryNode() {
+    public EmissaryNode(String nodeMode) {
+        this.nodeMode = nodeMode;
         this.nodeName = System.getProperty(NODE_NAME_PROPERTY);
         if (this.nodeName == null) {
             // Use IP Address for default node name since it is
@@ -104,7 +109,6 @@ public class EmissaryNode {
         this.nodeScheme = System.getProperty(NODE_SCHEME_PROPERTY, "http");
         this.nodePort = Integer.getInteger(NODE_PORT_PROPERTY, -1).intValue();
         this.nodeType = System.getProperty("os.name", DEFAULT_NODE_TYPE).toLowerCase(Locale.getDefault()).replace(' ', '_');
-        this.nodeMode = System.getProperty("node.mode", DEFAULT_NODE_MODE).toLowerCase(Locale.getDefault());
         this.nodeServiceType = System.getProperty(NODE_SERVICE_TYPE_PROPERTY, DEFAULT_NODE_SERVICE_TYPE);
         this.strictStartupMode = Boolean.parseBoolean(System.getProperty(STRICT_STARTUP_MODE, String.valueOf(false)));
     }
@@ -198,14 +202,14 @@ public class EmissaryNode {
     }
 
     /**
-     * Get the peer configuration stream for this noed
+     * Get the peer configuration stream for this node
      */
     public Configurator getPeerConfigurator() throws IOException {
         if (isStandalone()) {
             // return a configurator here with just standalone, don't actually read the peer.cfg
             // This is a hack until we can TODO: refactor all this so standalone doesn't need peers
             // maybe even warn if there is a peer.cfg
-            logger.debug("Node is standalone, ignoring any peer.cfg and only constructing one rendevous peer with the local node");
+            logger.debug("Node is standalone, ignoring any peer.cfg and only constructing one rendezvous peer with the local node");
             Configurator cfg = new ServiceConfigGuide();
             cfg.addEntry("RENDEZVOUS_PEER", this.asUrlKey());
             return cfg;

--- a/src/main/java/emissary/pickup/WorkSpace.java
+++ b/src/main/java/emissary/pickup/WorkSpace.java
@@ -195,13 +195,13 @@ public class WorkSpace implements Runnable {
             this.outbound = new PriorityQueue<>(11, this.feedCommand.getSort());
         }
 
-        configure();
         startJetty();
+        register();
         initializeService();
     }
 
     protected void startJetty() {
-        if (!EmissaryServer.isStarted()) {
+        if (!EmissaryServer.isInitialized() || !EmissaryServer.getInstance().isServerRunning()) {
             // TODO investigate passing the feedCommand object directly to the serverCommand
             List<String> args = new ArrayList<>();
             args.add("-b");
@@ -226,7 +226,7 @@ public class WorkSpace implements Runnable {
             try {
                 // To ensure the feed command starts correctly, depends on a node-{feedCommand.getPort}.cfg file
                 ServerCommand cmd = BaseCommand.parse(ServerCommand.class, args);
-                Server server = new EmissaryServer(cmd).startServer();
+                Server server = EmissaryServer.init(cmd).startServer();
                 final boolean jettyStatus = server.isStarted();
                 if (!jettyStatus) {
                     logger.error("Cannot start the Workspace due to EmissaryServer not starting!");
@@ -295,13 +295,10 @@ public class WorkSpace implements Runnable {
     public void shutDown() {
         stop();
         if (this.jettyStartedHere) {
-            final EmissaryNode node = new EmissaryNode();
+            final EmissaryNode node = EmissaryServer.getInstance().getNode();
             if (node.isValid()) {
                 try {
-                    final EmissaryServer s = EmissaryServer.lookup();
-                    s.getServer().stop();
-                } catch (NamespaceException ex) {
-                    logger.error("Cannot find jetty server", ex);
+                    EmissaryServer.getInstance().stop();
                 } catch (Exception ex) {
                     logger.error("Jetty cannot be shutdown", ex);
                 }
@@ -525,8 +522,8 @@ public class WorkSpace implements Runnable {
     /**
      * Configure the Processor. The *.cfg file is optional
      */
-    protected void configure() {
-        final EmissaryNode node = new EmissaryNode();
+    protected void register() {
+        final EmissaryNode node = EmissaryServer.getInstance().getNode();
         if (node.isValid()) {
             this.workSpaceUrl = node.getNodeScheme() + "://" + node.getNodeName() + ":" + node.getNodePort() + "/" + this.workSpaceName;
         } else {

--- a/src/main/java/emissary/pickup/WorkSpace.java
+++ b/src/main/java/emissary/pickup/WorkSpace.java
@@ -292,6 +292,7 @@ public class WorkSpace implements Runnable {
     /**
      * Shut down services that were started here
      */
+    @SuppressWarnings("CatchingUnchecked")
     public void shutDown() {
         stop();
         if (this.jettyStartedHere) {

--- a/src/main/java/emissary/place/ServiceProviderPlace.java
+++ b/src/main/java/emissary/place/ServiceProviderPlace.java
@@ -332,14 +332,14 @@ public abstract class ServiceProviderPlace implements IServiceProviderPlace,
      * @return true if it worked
      */
     private boolean localizeDirectory(@Nullable String theDir) {
-        // Get a local (non proxy) copy of the directory if possible!
+        // Get a local (non-proxy) copy of the directory if possible!
         // Looking up both if nothing is provided
         if (theDir == null) {
             try {
                 localDirPlace = DirectoryPlace.lookup();
                 dirPlace = localDirPlace.toString();
             } catch (EmissaryException ex) {
-                if (EmissaryServer.exists() && !(this instanceof DirectoryPlace)) {
+                if (EmissaryServer.getInstance().isServerRunning() && !(this instanceof DirectoryPlace)) {
                     logger.warn("Unable to find DirectoryPlace in local namespace", ex);
                     return false;
                 }
@@ -422,7 +422,7 @@ public abstract class ServiceProviderPlace implements IServiceProviderPlace,
             keys.add(placeLocation); // save as first in list
             locationPart = KeyManipulator.getServiceLocation(placeLocation);
         } else if (!placeLocation.contains("://")) {
-            EmissaryNode node = new EmissaryNode();
+            EmissaryNode node = EmissaryServer.getInstance().getNode();
             locationPart = "http://" + node.getNodeName() + ":" + node.getNodePort() + "/" + placeLocation;
         }
 

--- a/src/main/java/emissary/server/EmissaryServer.java
+++ b/src/main/java/emissary/server/EmissaryServer.java
@@ -92,6 +92,7 @@ public class EmissaryServer {
 
     private final EmissaryNode emissaryNode;
 
+    @SuppressWarnings("NonFinalStaticField")
     private static EmissaryServer emissaryServer;
 
     private EmissaryServer(ServerCommand cmd) {

--- a/src/main/java/emissary/server/EmissaryServer.java
+++ b/src/main/java/emissary/server/EmissaryServer.java
@@ -92,24 +92,39 @@ public class EmissaryServer {
 
     private final EmissaryNode emissaryNode;
 
-    public EmissaryServer(ServerCommand cmd) throws EmissaryException {
-        this(cmd, new EmissaryNode());
+    private static EmissaryServer emissaryServer;
+
+    private EmissaryServer(ServerCommand cmd) {
+        this.cmd = cmd;
+        this.emissaryNode = new EmissaryNode(cmd.getMode());
     }
 
-    @VisibleForTesting
-    public EmissaryServer(ServerCommand cmd, EmissaryNode node) throws EmissaryException {
+    // there should be a better way to set a custom peer.cfg than this
+    private EmissaryServer(ServerCommand cmd, EmissaryNode node) {
         this.cmd = cmd;
-        // See if we are an emissary node, but first setup node type
-        if (cmd.getMode() != null) {
-            System.setProperty("node.mode", cmd.getMode()); // TODO: clean this crap up
-        }
-        emissaryNode = node;
+        this.emissaryNode = node;
+    }
 
-        if (!emissaryNode.isValid()) {
-            LOG.error("Not an emissary node, no emissary services required.");
-            LOG.error("Try setting -D{}=value to configure an emissary node", EmissaryNode.NODE_NAME_PROPERTY);
-            throw new EmissaryException("Not an emissary node, no emissary services required");
+    public static EmissaryServer init(ServerCommand cmd) {
+        emissaryServer = new EmissaryServer(cmd);
+        return emissaryServer;
+    }
+
+    // there should be a better way to set a custom peer.cfg than this
+    public static EmissaryServer init(ServerCommand cmd, EmissaryNode node) {
+        emissaryServer = new EmissaryServer(cmd, node);
+        return emissaryServer;
+    }
+
+    public static boolean isInitialized() {
+        return emissaryServer != null;
+    }
+
+    public static EmissaryServer getInstance() {
+        if (emissaryServer == null) {
+            throw new AssertionError("EmissaryServer has not yet been instantiated!");
         }
+        return emissaryServer;
     }
 
     public EmissaryNode getNode() {
@@ -263,7 +278,7 @@ public class EmissaryServer {
     }
 
     /**
-     * Stop the server running under the default name
+     * Stop the server
      */
     public static void stopServer() {
         stopServer(false);
@@ -272,22 +287,13 @@ public class EmissaryServer {
     /**
      * Stop the server running under the default name
      *
-     * @param quiet be quiet about failures if true
-     */
-    public static void stopServer(final boolean quiet) {
-        stopServer(false, quiet);
-    }
-
-    /**
-     * Stop the server running under the default name
-     *
      * @param force force shutdown
      * @param quiet be quiet about failures if true
      */
+    @Deprecated
     public static void stopServer(final boolean force, final boolean quiet) {
         stopServer(getDefaultNamespaceName(), force, quiet);
     }
-
 
     /**
      * Stop the server if it is running and remove it from the namespace
@@ -295,6 +301,7 @@ public class EmissaryServer {
      * @param name the namespace name of the server
      * @param quiet be quiet about failures if true
      */
+    @Deprecated
     public static void stopServer(final String name, final boolean quiet) {
         stopServer(name, false, quiet);
     }
@@ -306,10 +313,20 @@ public class EmissaryServer {
      * @param force force shutdown
      * @param quiet be quiet about failures if true
      */
+    @Deprecated
     public static void stopServer(final String name, final boolean force, final boolean quiet) {
+        stopServer(force);
+    }
+
+    /**
+     * Stop the server with an optional force flag
+     *
+     * @param force force shutdown
+     */
+    public static void stopServer(final boolean force) {
         // TODO pull these out to methods and test them
 
-        LOG.info("Beginning shutdown of EmissaryServer {}", name);
+        LOG.info("Beginning shutdown of EmissaryServer");
         logThreadDump("Thread dump before anything");
 
         try {
@@ -392,28 +409,25 @@ public class EmissaryServer {
         logThreadDump("Thread dump before stopping jetty server");
 
         try {
-            EmissaryServer s = EmissaryServer.lookup(name);
-            s.getServer().stop();
-        } catch (NamespaceException e) {
-            LOG.error("Unable to lookup {} ", name, e);
+            EmissaryServer.getInstance().getServer().stop();
         } catch (InterruptedException e) {
             LOG.warn("Interrupted! Expected?");
             Thread.currentThread().interrupt();
         } catch (Exception e) {
-            LOG.warn("Unable to stop server {} ", name, e);
+            LOG.warn("Unable to stop EmissaryServer", e);
         }
 
-        LOG.debug("Unbinding name: {}", name);
-        Namespace.unbind(name);
+        LOG.debug("Unbinding name: {}", getDefaultNamespaceName());
+        Namespace.unbind(getDefaultNamespaceName());
         Namespace.clear();
-        LOG.info("Emissary named {} completely stopped.", name);
+        LOG.info("EmissaryServer completely stopped");
     }
 
     /**
      * Forcibly stop the server running under the default name
      */
     public static void stopServerForce() {
-        stopServer(true, false);
+        stopServer(true);
     }
 
     @SuppressWarnings("unchecked")
@@ -459,7 +473,7 @@ public class EmissaryServer {
      * Non-static way to stop a server
      */
     public void stop() {
-        stopServer(getNamespaceName(), false);
+        stopServer(false);
     }
 
     /**
@@ -469,7 +483,7 @@ public class EmissaryServer {
         return this.server;
     }
 
-
+    @Deprecated
     public synchronized String getNamespaceName() {
         if (this.nameSpaceName == null) {
             this.nameSpaceName = getDefaultNamespaceName();
@@ -477,6 +491,7 @@ public class EmissaryServer {
         return this.nameSpaceName;
     }
 
+    @Deprecated
     public static String getDefaultNamespaceName() {
         return DEFAULT_NAMESPACE_NAME;
     }
@@ -485,7 +500,9 @@ public class EmissaryServer {
      * Check if server is running
      *
      * @return true if it is in the namespace and is started
+     * @deprecated use {@link #isServerRunning()}
      */
+    @Deprecated
     public static boolean isStarted() {
         return isStarted(getDefaultNamespaceName());
     }
@@ -496,6 +513,7 @@ public class EmissaryServer {
      * @param name the namespace name to use as a key
      * @return true if it is in the namespace and is started
      */
+    @Deprecated
     public static boolean isStarted(final String name) {
         boolean started = false;
         try {
@@ -511,6 +529,7 @@ public class EmissaryServer {
         return started;
     }
 
+    @Deprecated
     public static boolean exists() {
         try {
             EmissaryServer.lookup();
@@ -521,13 +540,15 @@ public class EmissaryServer {
         return false;
     }
 
+    @Deprecated
     public static EmissaryServer lookup() throws NamespaceException {
         return lookup(getDefaultNamespaceName());
     }
 
     /**
-     * Retreive instance from namespace using default name
+     * Retrieve instance from namespace using default name
      */
+    @Deprecated
     public static EmissaryServer lookup(final String name) throws NamespaceException {
         return (EmissaryServer) Namespace.lookup(name);
     }
@@ -571,7 +592,6 @@ public class EmissaryServer {
 
         LOG.debug("Binding {} ", DEFAULT_NAMESPACE_NAME);
         Namespace.bind(getDefaultNamespaceName(), this);
-
     }
 
     private ContextHandler buildStaticHandler() {

--- a/src/test/java/emissary/server/EmissaryServerIT.java
+++ b/src/test/java/emissary/server/EmissaryServerIT.java
@@ -25,7 +25,7 @@ class EmissaryServerIT extends UnitTest {
     @Test
     void testThreadPoolStuff() throws Exception {
         ServerCommand cmd = ServerCommand.parse(ServerCommand.class, "-h", "host1", "-p", "3001");
-        EmissaryServer server = new EmissaryServer(cmd);
+        EmissaryServer server = EmissaryServer.init(cmd);
         Server jettyServer = server.configureServer();
         QueuedThreadPool pool = (QueuedThreadPool) jettyServer.getThreadPool();
         assertEquals(10, pool.getMinThreads());
@@ -38,7 +38,7 @@ class EmissaryServerIT extends UnitTest {
     @Test
     void testSSLWorks() throws Exception {
         ServerCommand cmd = ServerCommand.parse(ServerCommand.class, "-p", "3443", "--ssl", "--disableSniHostCheck");
-        EmissaryServer server = new EmissaryServer(cmd);
+        EmissaryServer server = EmissaryServer.init(cmd);
         try {
             server.startServer();
             EmissaryClient client = new EmissaryClient();
@@ -56,7 +56,7 @@ class EmissaryServerIT extends UnitTest {
     @Test
     void testInvisPlacesOnStrictStartUp() throws EmissaryException {
         ServerCommand cmd = ServerCommand.parse(ServerCommand.class, "--strict");
-        EmissaryServer server = new EmissaryServer(cmd);
+        EmissaryServer server = EmissaryServer.init(cmd);
         EmissaryNode node = new EmissaryNode();
         String location = "http://" + node.getNodeName() + ":" + node.getNodePort();
         Startup.getInvisPlaces().add(location + "/PlaceStartUnannouncedTest");

--- a/src/test/java/emissary/server/api/PeersIT.java
+++ b/src/test/java/emissary/server/api/PeersIT.java
@@ -30,7 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PeersIT extends EndpointTestBase {
 
-    public static final String DIRNAME = "http://" + TestEmissaryNode.TEST_NODE_PORT + "/DirectoryPlace";
+    public static final int TEST_PORT = 123456;
+    public static final String TEST_NODE = "localhost";
+    public static final String TEST_NODE_PORT = TEST_NODE + ":" + TEST_PORT;
+    public static final String DIRNAME = "http://" + TEST_NODE_PORT + "/DirectoryPlace";
     public static final String SELF = "*.*.*.http://localhost:9999/DirectoryPlace";
     public static final String PEER1 = "*.*.*.http://remoteHost:8888/DirectoryPlace";
     public static final String PEER2 = "*.*.*.http://remoteHost2:8888/DirectoryPlace";
@@ -38,16 +41,15 @@ class PeersIT extends EndpointTestBase {
 
     @BeforeEach
     public void setup() throws Exception {
-        EmissaryNode emissaryNode = new TestEmissaryNode();
-        DirectoryPlace directoryPlace = new DirectoryPlace(DIRNAME, emissaryNode);
+        String projectBase = System.getenv(ConfigUtil.PROJECT_BASE_ENV);
+        ServerCommand cmd = ServerCommand.parse(ServerCommand.class, "-b ", projectBase, "-m", "cluster", "-p", "123456");
+        cmd.setupServer();
+        EmissaryServer server = EmissaryServer.init(cmd, new TestEmissaryNode());
+        Namespace.bind("EmissaryServer", server);
+
+        DirectoryPlace directoryPlace = new DirectoryPlace(DIRNAME, server.getNode());
         directoryPlace.addPeerDirectories(PEERS, false);
         Namespace.bind(DIRNAME, directoryPlace);
-
-        String projectBase = System.getenv(ConfigUtil.PROJECT_BASE_ENV);
-        ServerCommand cmd = ServerCommand.parse(ServerCommand.class, "-b ", projectBase, "-m", "cluster");
-        cmd.setupServer();
-        EmissaryServer server = new EmissaryServer(cmd, emissaryNode);
-        Namespace.bind("EmissaryServer", server);
     }
 
     @AfterEach
@@ -66,7 +68,7 @@ class PeersIT extends EndpointTestBase {
         PeersResponseEntity entity = response.readEntity(PeersResponseEntity.class);
         assertEquals(0, entity.getErrors().size());
         assertTrue(CollectionUtils.isEmpty(entity.getCluster()));
-        assertEquals(TestEmissaryNode.TEST_NODE_PORT, entity.getLocal().getHost());
+        assertEquals(TEST_NODE_PORT, entity.getLocal().getHost());
         assertTrue(entity.getLocal().getPeers().containsAll(PEERS));
     }
 
@@ -105,9 +107,6 @@ class PeersIT extends EndpointTestBase {
     }
 
     static class TestEmissaryNode extends EmissaryNode {
-        public static final int TEST_PORT = 123456;
-        public static final String TEST_NODE = "localhost";
-        public static final String TEST_NODE_PORT = TEST_NODE + ":" + TEST_PORT;
 
         public TestEmissaryNode() {
             nodeNameIsDefault = true;

--- a/src/test/java/emissary/test/core/junit5/FunctionalTest.java
+++ b/src/test/java/emissary/test/core/junit5/FunctionalTest.java
@@ -83,7 +83,7 @@ public abstract class FunctionalTest extends UnitTest {
         try {
             ServerCommand cmd = ServerCommand.parse(ServerCommand.class, args);
 
-            jserver = new EmissaryServer(cmd);
+            jserver = EmissaryServer.init(cmd);
             jetty = jserver.startServer();
         } catch (Exception ignored) {
             // Ignore
@@ -160,7 +160,7 @@ public abstract class FunctionalTest extends UnitTest {
         if (jserver != null && jserver.isServerRunning()) {
             jserver.stop();
             jetty = null;
-            assertFalse(EmissaryServer.isStarted(), "Server did not stop and unbind");
+            assertFalse(EmissaryServer.getInstance().isServerRunning(), "Server did not stop and unbind");
             jserver = null;
         }
 

--- a/src/test/java/emissary/test/core/junit5/UnitTest.java
+++ b/src/test/java/emissary/test/core/junit5/UnitTest.java
@@ -3,6 +3,7 @@ package emissary.test.core.junit5;
 import emissary.command.ServerCommand;
 import emissary.config.ConfigUtil;
 import emissary.core.EmissaryException;
+import emissary.server.EmissaryServer;
 import emissary.test.util.ThreadDump;
 import emissary.util.io.ResourceReader;
 
@@ -110,7 +111,9 @@ public abstract class UnitTest {
         }
         // setup the environment stuff
         try {
-            ServerCommand.parse(ServerCommand.class, "-m", "cluster").setupCommand();
+            ServerCommand command = ServerCommand.parse(ServerCommand.class, "-m", "cluster");
+            command.setupCommand();
+            EmissaryServer.init(command);
         } catch (EmissaryException e) {
             fail("Unable to setup Emissary environment", e);
         }


### PR DESCRIPTION
- removes the need for node.mode system property (get from command or default value)
- no longer need to check namespace binding to determine state
- deprecate stop/status methods for future cleanup

Pulled out of https://github.com/NationalSecurityAgency/emissary/pull/900 but stops short of changing mode to enum and changing command validator.