### PR TITLE
fix pmd sourceEncoding parameter warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -884,7 +884,7 @@
             <format>xml</format>
             <includeTests>true</includeTests>
             <minimumTokens>100</minimumTokens>
-            <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
+            <inputEncoding>${project.build.sourceEncoding}</inputEncoding>
             <targetJdk>${maven.compiler.target}</targetJdk>
           </configuration>
           <executions>


### PR DESCRIPTION
```
[WARNING] Parameter 'sourceEncoding' is unknown for plugin 'maven-pmd-plugin:3.20.0:check (default)'
[WARNING] Parameter 'sourceEncoding' is unknown for plugin 'maven-pmd-plugin:3.20.0:pmd (pmd)'
```