### PR TITLE
Adding a utility to provide test data for specific unicode handling issues.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <dep.guava.version>32.1.2-jre</dep.guava.version>
     <dep.httpclient.version>5.2.1</dep.httpclient.version>
     <dep.httpcore.version>5.2.1</dep.httpcore.version>
+    <dep.icu4j.version>73.2</dep.icu4j.version>
     <dep.jackson.version>2.15.2</dep.jackson.version>
     <dep.jakarta.xml.bind-api.version>3.0.1</dep.jakarta.xml.bind-api.version>
     <dep.janino.version>3.1.12</dep.janino.version>
@@ -171,6 +172,11 @@
             <artifactId>error_prone_annotations</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.ibm.icu</groupId>
+        <artifactId>icu4j</artifactId>
+        <version>${dep.icu4j.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
@@ -521,6 +527,11 @@
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.icu</groupId>
+      <artifactId>icu4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
     <dep.guava.version>32.1.2-jre</dep.guava.version>
     <dep.httpclient.version>5.2.1</dep.httpclient.version>
     <dep.httpcore.version>5.2.1</dep.httpcore.version>
-    <dep.icu4j.version>73.2</dep.icu4j.version>
     <dep.jackson.version>2.15.2</dep.jackson.version>
     <dep.jakarta.xml.bind-api.version>3.0.1</dep.jakarta.xml.bind-api.version>
     <dep.janino.version>3.1.12</dep.janino.version>
@@ -172,11 +171,6 @@
             <artifactId>error_prone_annotations</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.ibm.icu</groupId>
-        <artifactId>icu4j</artifactId>
-        <version>${dep.icu4j.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
@@ -527,11 +521,6 @@
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.ibm.icu</groupId>
-      <artifactId>icu4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -739,14 +739,12 @@
           <version>${plugin.maven-checkstyle.version}</version>
           <configuration>
             <configLocation>${checkstyleFormatter}</configLocation>
-            <!-- this combination of these two configurations (failOnViolation=true 
-              and violationSeverity=error) means any checks with severity=error will fail 
-              the build -->
-            <!-- TODO enforce more checkstyle categories as the build gets 
-              cleaned up -->
-            <!-- As you fix checkstyle warning categories, change the severity 
-              of that category to "error" so it will fail the build if new violations of 
-              that category get introduced. -->
+            <!-- this combination of these two configurations
+              (failOnViolation=true and violationSeverity=error) means
+              any checks with severity=error will fail the build -->
+            <!-- TODO enforce more checkstyle categories as the	build gets cleaned up -->
+            <!-- As you fix checkstyle warning categories, change the severity of that category
+              to "error" so it will fail the build if new violations of that category get introduced. -->
             <failOnViolation>true</failOnViolation>
             <violationSeverity>error</violationSeverity>
             <includeTestSourceDirectory>true</includeTestSourceDirectory>
@@ -910,7 +908,7 @@
             <execution>
               <goals>
                 <goal>check</goal>
-                <!--<goal>cpd-check</goal> -->
+                <!--<goal>cpd-check</goal>-->
               </goals>
               <phase>verify</phase>
             </execution>
@@ -1113,7 +1111,9 @@
                       <limit>
                         <counter>COMPLEXITY</counter>
                         <value>COVEREDRATIO</value>
-                        <!-- <minimum>0.37</minimum> -->
+                        <!--
+                        <minimum>0.37</minimum>
+                        -->
                       </limit>
                     </limits>
                   </rule>
@@ -1511,8 +1511,8 @@
                 <arg>-1</arg>
                 <arg>-Xmaxwarns</arg>
                 <arg>-1</arg>
-                <!--arg>-Werror</arg -->
-                <!--arg>-Xlint:all</arg -->
+                <!--arg>-Werror</arg-->
+                <!--arg>-Xlint:all</arg-->
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>-Xplugin:ErrorProne \
                   -XepAllDisabledChecksAsWarnings \
@@ -1558,13 +1558,11 @@
         <maven.compiler.release>11</maven.compiler.release>
       </properties>
       <build>
-        <!-- different build directory for eclipse, so running maven and 
-          clicking in IDE don't conflict -->
+        <!--  different build directory for eclipse, so running maven and clicking in IDE don't conflict -->
         <directory>${project.basedir}/target-eclipse</directory>
         <pluginManagement>
           <plugins>
-            <!--This plugin's configuration is used to store Eclipse m2e 
-              settings only. It has no influence on the Maven build itself. -->
+            <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
             <plugin>
               <groupId>org.eclipse.m2e</groupId>
               <artifactId>lifecycle-mapping</artifactId>
@@ -1636,30 +1634,26 @@
       <id>netbeans</id>
       <activation>
         <property>
-          <!-- You must add -Dnetbeans.ide as global option to the maven 
-            command for this to work Could not find any property existing when Netbeans 
-            was running the build -->
+          <!-- You must add -Dnetbeans.ide as global option to the maven command for this to work
+               Could not find any property existing when Netbeans was running the build -->
           <name>netbeans.ide</name>
         </property>
       </activation>
       <build>
-        <!-- different build directory for netbeans, so running maven and 
-          clicking in IDE don't conflict -->
+        <!--  different build directory for netbeans, so running maven and clicking in IDE don't conflict -->
         <directory>${project.basedir}/target-netbeans</directory>
       </build>
     </profile>
     <profile>
       <id>intellij</id>
       <activation>
-        <!-- when intellij runs a build, this system property is already 
-          present -->
+        <!-- when intellij runs a build, this system property is already present -->
         <property>
           <name>idea.version</name>
         </property>
       </activation>
       <build>
-        <!-- different build directory for intellij, so running maven and 
-          clicking in IDE don't conflict -->
+        <!--  different build directory for intellij, so running maven and clicking in IDE don't conflict -->
         <directory>${project.basedir}/target-idea</directory>
       </build>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -129,15 +129,15 @@
     <sonar.issue.ignore.multicriteria>e1</sonar.issue.ignore.multicriteria>
     <sonar.issue.ignore.multicriteria.e1.resourceKey>**/*.java</sonar.issue.ignore.multicriteria.e1.resourceKey>
     <sonar.issue.ignore.multicriteria.e1.ruleKey>java:S6212</sonar.issue.ignore.multicriteria.e1.ruleKey>
-    <!-- With Java 8 and the latest version of surefire, user.timezone is 
-      not read correctly. Reevaluate one day. See https://issues.apache.org/jira/browse/SUREFIRE-1176 
-      or http://stackoverflow.com/questions/19121928/java-system-getproperty-user-timezone-does-not-work 
-      The COMPAT locale provider is used because the date formatter parsing has 
-      changed significantly when using the CLDR locale provider, which is the default 
-      in JDK11. https://www.oracle.com/technetwork/java/javase/documentation/java11locales-5069639.html -->
-    <surefire.argline>@{argLine} -Xmx1024m -Xms256m
-      -Djava.locale.providers=COMPAT -Djava.net.preferIPv4Stack=true
-      -Duser.timezone=GMT -Djava.awt.headless=true</surefire.argline>
+    <!-- With Java 8 and the latest version of surefire, user.timezone is not read correctly.  Reevaluate one day.
+         See https://issues.apache.org/jira/browse/SUREFIRE-1176 or
+         http://stackoverflow.com/questions/19121928/java-system-getproperty-user-timezone-does-not-work
+
+         The COMPAT locale provider is used because the date formatter parsing has changed significantly
+         when using the CLDR locale provider, which is the default in JDK11.
+         https://www.oracle.com/technetwork/java/javase/documentation/java11locales-5069639.html
+      -->
+    <surefire.argline>@{argLine} -Xmx1024m -Xms256m -Djava.locale.providers=COMPAT -Djava.net.preferIPv4Stack=true -Duser.timezone=GMT -Djava.awt.headless=true</surefire.argline>
     <surefire.forkCount>.5C</surefire.forkCount>
   </properties>
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <dep.guava.version>32.1.2-jre</dep.guava.version>
     <dep.httpclient.version>5.2.1</dep.httpclient.version>
     <dep.httpcore.version>5.2.1</dep.httpcore.version>
+    <dep.icu4j.version>73.2</dep.icu4j.version>
     <dep.jackson.version>2.15.2</dep.jackson.version>
     <dep.jakarta.xml.bind-api.version>3.0.1</dep.jakarta.xml.bind-api.version>
     <dep.janino.version>3.1.12</dep.janino.version>
@@ -128,15 +129,15 @@
     <sonar.issue.ignore.multicriteria>e1</sonar.issue.ignore.multicriteria>
     <sonar.issue.ignore.multicriteria.e1.resourceKey>**/*.java</sonar.issue.ignore.multicriteria.e1.resourceKey>
     <sonar.issue.ignore.multicriteria.e1.ruleKey>java:S6212</sonar.issue.ignore.multicriteria.e1.ruleKey>
-    <!-- With Java 8 and the latest version of surefire, user.timezone is not read correctly.  Reevaluate one day.
-         See https://issues.apache.org/jira/browse/SUREFIRE-1176 or
-         http://stackoverflow.com/questions/19121928/java-system-getproperty-user-timezone-does-not-work
-
-         The COMPAT locale provider is used because the date formatter parsing has changed significantly
-         when using the CLDR locale provider, which is the default in JDK11.
-         https://www.oracle.com/technetwork/java/javase/documentation/java11locales-5069639.html
-      -->
-    <surefire.argline>@{argLine} -Xmx1024m -Xms256m -Djava.locale.providers=COMPAT -Djava.net.preferIPv4Stack=true -Duser.timezone=GMT -Djava.awt.headless=true</surefire.argline>
+    <!-- With Java 8 and the latest version of surefire, user.timezone is 
+      not read correctly. Reevaluate one day. See https://issues.apache.org/jira/browse/SUREFIRE-1176 
+      or http://stackoverflow.com/questions/19121928/java-system-getproperty-user-timezone-does-not-work 
+      The COMPAT locale provider is used because the date formatter parsing has 
+      changed significantly when using the CLDR locale provider, which is the default 
+      in JDK11. https://www.oracle.com/technetwork/java/javase/documentation/java11locales-5069639.html -->
+    <surefire.argline>@{argLine} -Xmx1024m -Xms256m
+      -Djava.locale.providers=COMPAT -Djava.net.preferIPv4Stack=true
+      -Duser.timezone=GMT -Djava.awt.headless=true</surefire.argline>
     <surefire.forkCount>.5C</surefire.forkCount>
   </properties>
   <dependencyManagement>
@@ -304,6 +305,12 @@
         <version>${dep.jersey.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.ibm.icu</groupId>
+        <artifactId>icu4j</artifactId>
+        <version>${dep.icu4j.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
@@ -524,6 +531,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.ibm.icu</groupId>
+      <artifactId>icu4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
       <artifactId>jersey-test-framework-provider-jetty</artifactId>
       <scope>test</scope>
@@ -727,12 +739,14 @@
           <version>${plugin.maven-checkstyle.version}</version>
           <configuration>
             <configLocation>${checkstyleFormatter}</configLocation>
-            <!-- this combination of these two configurations
-              (failOnViolation=true and violationSeverity=error) means
-              any checks with severity=error will fail the build -->
-            <!-- TODO enforce more checkstyle categories as the	build gets cleaned up -->
-            <!-- As you fix checkstyle warning categories, change the severity of that category
-              to "error" so it will fail the build if new violations of that category get introduced. -->
+            <!-- this combination of these two configurations (failOnViolation=true 
+              and violationSeverity=error) means any checks with severity=error will fail 
+              the build -->
+            <!-- TODO enforce more checkstyle categories as the build gets 
+              cleaned up -->
+            <!-- As you fix checkstyle warning categories, change the severity 
+              of that category to "error" so it will fail the build if new violations of 
+              that category get introduced. -->
             <failOnViolation>true</failOnViolation>
             <violationSeverity>error</violationSeverity>
             <includeTestSourceDirectory>true</includeTestSourceDirectory>
@@ -896,7 +910,7 @@
             <execution>
               <goals>
                 <goal>check</goal>
-                <!--<goal>cpd-check</goal>-->
+                <!--<goal>cpd-check</goal> -->
               </goals>
               <phase>verify</phase>
             </execution>
@@ -1099,9 +1113,7 @@
                       <limit>
                         <counter>COMPLEXITY</counter>
                         <value>COVEREDRATIO</value>
-                        <!--
-                        <minimum>0.37</minimum>
-                        -->
+                        <!-- <minimum>0.37</minimum> -->
                       </limit>
                     </limits>
                   </rule>
@@ -1499,8 +1511,8 @@
                 <arg>-1</arg>
                 <arg>-Xmaxwarns</arg>
                 <arg>-1</arg>
-                <!--arg>-Werror</arg-->
-                <!--arg>-Xlint:all</arg-->
+                <!--arg>-Werror</arg -->
+                <!--arg>-Xlint:all</arg -->
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>-Xplugin:ErrorProne \
                   -XepAllDisabledChecksAsWarnings \
@@ -1546,11 +1558,13 @@
         <maven.compiler.release>11</maven.compiler.release>
       </properties>
       <build>
-        <!--  different build directory for eclipse, so running maven and clicking in IDE don't conflict -->
+        <!-- different build directory for eclipse, so running maven and 
+          clicking in IDE don't conflict -->
         <directory>${project.basedir}/target-eclipse</directory>
         <pluginManagement>
           <plugins>
-            <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+            <!--This plugin's configuration is used to store Eclipse m2e 
+              settings only. It has no influence on the Maven build itself. -->
             <plugin>
               <groupId>org.eclipse.m2e</groupId>
               <artifactId>lifecycle-mapping</artifactId>
@@ -1622,26 +1636,30 @@
       <id>netbeans</id>
       <activation>
         <property>
-          <!-- You must add -Dnetbeans.ide as global option to the maven command for this to work
-               Could not find any property existing when Netbeans was running the build -->
+          <!-- You must add -Dnetbeans.ide as global option to the maven 
+            command for this to work Could not find any property existing when Netbeans 
+            was running the build -->
           <name>netbeans.ide</name>
         </property>
       </activation>
       <build>
-        <!--  different build directory for netbeans, so running maven and clicking in IDE don't conflict -->
+        <!-- different build directory for netbeans, so running maven and 
+          clicking in IDE don't conflict -->
         <directory>${project.basedir}/target-netbeans</directory>
       </build>
     </profile>
     <profile>
       <id>intellij</id>
       <activation>
-        <!-- when intellij runs a build, this system property is already present -->
+        <!-- when intellij runs a build, this system property is already 
+          present -->
         <property>
           <name>idea.version</name>
         </property>
       </activation>
       <build>
-        <!--  different build directory for intellij, so running maven and clicking in IDE don't conflict -->
+        <!-- different build directory for intellij, so running maven and 
+          clicking in IDE don't conflict -->
         <directory>${project.basedir}/target-idea</directory>
       </build>
     </profile>

--- a/src/test/java/emissary/test/util/ComplexUnicodeSamples.java
+++ b/src/test/java/emissary/test/util/ComplexUnicodeSamples.java
@@ -9,10 +9,12 @@ import java.util.Map;
  * <p>
  * Each example contains detailed explanation and links to useful reference materials.
  */
-public class ComplexUnicodeSamples {
+public final class ComplexUnicodeSamples {
+
+    private ComplexUnicodeSamples() {}
 
     /**
-     * Returns a string that contains one graphical unit consists of 5 Unicode scalar values. The user-perceived string
+     * Returns a string that contains one graphical unit that consists of 5 Unicode scalar values. The user-perceived string
      * would be one facepalming emoji. A user would expect hit the arrow key once to jump this one emoji on the screen. The
      * length of the UTF-8 encoded byte array is 17 bytes. One emoji, 17 bytes.
      * <p>
@@ -86,44 +88,11 @@ public class ComplexUnicodeSamples {
         // UTF-32 bytes: 4
         // UTF-16 bytes: 2
         // UTF-8 bytes: 3
-
         sb.append("\uFE0F");
 
         return sb.toString();
     }
 
-    /**
-     * You perceive a single symbol: the flag of Italy. However, this symbol is composed of two Unicode code points: U+1F1EE
-     * (regional indicator symbol letter I) and U+1F1F9 (regional indicator symbol letter T). About 250 flags can be formed
-     * with these regional indicators. The pirate flag 🏴‍☠️, on the other hand, is composed of U+1F3F4 (waving black flag),
-     * U+200D (zero width joiner), U+2620 (skull and crossbones), and U+FE0F (variation selector-16). In Java, you need four
-     * char values to represent the first flag, five for the second.
-     * 
-     * @return an Italy flag emoji.
-     */
-    public static String getFlagOfItaly() {
-
-        StringBuilder sb = new StringBuilder();
-        // SCALAR 1: U+1F1EE REGIONAL INDICATOR SYMBOL LETTER I
-        // Use the lookup for how to represent in java
-        // https://www.fileformat.info/info/unicode/char/1f1ee/index.htm
-        sb.append("\uD83C\uDDEE");
-
-
-        // SCALAR 2: U+1F1F9 REGIONAL INDICATOR SYMBOL LETTER T
-        // https://www.fileformat.info/info/unicode/char/1f1f9/index.htm
-        sb.append("\uD83C\uDDF9");
-
-        return sb.toString();
-    }
-
-    public static String getPirateFlag() {
-        return "";
-    }
-
-    public static String getGClef() {
-        return "";
-    }
 
     /**
      * A utility method that will provide
@@ -220,6 +189,5 @@ public class ComplexUnicodeSamples {
 
         return count;
     }
-
 
 }

--- a/src/test/java/emissary/test/util/ComplexUnicodeSamples.java
+++ b/src/test/java/emissary/test/util/ComplexUnicodeSamples.java
@@ -1,9 +1,104 @@
 package emissary.test.util;
 
+import com.ibm.icu.text.BreakIterator;
+import org.apache.commons.codec.Charsets;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A class that provides some samples where the byte representation of the user-percieved glyph (grapheme) is outside of
+ * normal Basic Multilingual Plane usage.
+ * <p>
+ * The explanations of each example should help the developer evaluate 3rd party libraries and their quality of their
+ * unicode handling.
+ * <p>
+ * Each example provides links to useful reference materials.
+ */
 public class ComplexUnicodeSamples {
+
+    /**
+     * Returns a string that contains one graphical unit consists of 5 Unicode scalar values.
+     * <p>
+     * First, there’s a base character that means a person face palming.
+     * <p>
+     * By default, the person would have a cartoonish yellow color. The next character is an emoji skintone modifier the
+     * changes the color of the person’s skin (and, in practice, also the color of the person’s hair).
+     * <p>
+     * By default, the gender of the person is undefined, and e.g. Apple defaults to what they consider a male appearance
+     * and e.g. Google defaults to what they consider a female appearance. The next two scalar values pick a male-typical
+     * appearance specifically regardless of font and vendor. Instead of being an emoji-specific modifier like the skin
+     * tone, the gender specification uses an emoji-predating gender symbol (MALE SIGN) explicitly ligated using the
+     * 
+     * ZERO WIDTH JOINER with the (skin-toned) face-palming person. (Whether it is a good or a bad idea that the skin tone
+     * and gender specifications use different mechanisms is out of the scope of this post.)
+     * <p>
+     * Finally, VARIATION SELECTOR-16 makes it explicit that we want a multicolor emoji rendering instead of a monochrome
+     * dingbat rendering.
+     * 
+     * @see #demonstrateMetaDataAboutTheseSamples() interesting observations about this sample
+     * @see <a href="https://hsivonen.fi/string-length/">https://hsivonen.fi/string-length/</a>
+     */
+    public static String getFacePalmingMaleControlSkintone() {
+
+        StringBuffer sb = new StringBuffer();
+
+        // U+1F926 FACE PALM
+        // Use the lookup for how to represent in java
+        // https://www.fileformat.info/info/unicode/char/1f926/index.htm
+        // UTF-32 code units: 1
+        // UTF-16 code units: 2
+        // UTF-8 code units: 4
+        // UTF-32 bytes: 4
+        // UTF-16 bytes: 4
+        // UTF-8 bytes: 4
+        sb.append("\uD83E\uDD26");
+
+        // U+1F3FC EMOJI MODIFIER FITZPATRICK TYPE-3
+        // https://www.fileformat.info/info/unicode/char/1f3fc/index.htm
+        // UTF-32 code units: 1
+        // UTF-16 code units: 2
+        // UTF-8 code units: 4
+        // UTF-32 bytes: 4
+        // UTF-16 bytes: 4
+        // UTF-8 bytes: 4
+        sb.append("\uD83C\uDFFC");
+
+        // U+200D ZERO WIDTH JOINER
+        // UTF-32 code units: 1
+        // UTF-16 code units: 1
+        // UTF-8 code units: 3
+        // UTF-32 bytes: 4
+        // UTF-16 bytes: 2
+        // UTF-8 bytes: 3
+        sb.append("\u200D");
+
+        // U+2642 MALE SIGN
+        // UTF-32 code units: 1
+        // UTF-16 code units: 1
+        // UTF-8 code units: 3
+        // UTF-32 bytes: 4
+        // UTF-16 bytes: 2
+        // UTF-8 bytes: 3
+        sb.append("\u2642");
+
+        // U+FE0F VARIATION SELECTOR-16
+        // UTF-32 code units: 1
+        // UTF-16 code units: 1
+        // UTF-8 code units: 3
+        // UTF-32 bytes: 4
+        // UTF-16 bytes: 2
+        // UTF-8 bytes: 3
+
+        sb.append("\uFE0F");
+
+        return sb.toString();
+    }
+
 
     /**
      * A utility method that will provide
@@ -41,5 +136,57 @@ public class ComplexUnicodeSamples {
 
         return xmlWithExp;
     }
+
+
+    /**
+     * Interesting observations
+     * <p>
+     * We’ve seen four different lengths so far:
+     * 
+     * <ul>
+     * <li>Number of UTF-8 code units (17 in this case)</li>
+     * <li>Number of UTF-16 code units (7 in this case)</li>
+     * <li>Number of UTF-32 code units or Unicode scalar values (5 in this case)</li>
+     * <li>Number of extended grapheme clusters (1 in this case)</li>
+     * </ul>
+     * Given a valid Unicode string and a version of Unicode, all of the above are well-defined and it holds that each item
+     * higher on the list is greater or equal than the items lower on the list.
+     * <p>
+     * One of these is not like the others, though: The first three numbers have an unchanging definition for any valid
+     * Unicode string whether it contains currently assigned scalar values or whether it is from the future and contains
+     * unassigned scalar values as far as software written today is aware. Also, computing the first three lengths does not
+     * involve lookups from the Unicode database. However, the last item depends on the Unicode version and involves lookups
+     * from the Unicode database. If a string contains scalar values that are unassigned as far as the copy of the Unicode
+     * database that the program is using is aware, the program will potentially overcount extended grapheme clusters in the
+     * string compared to a program whose copy of the Unicode database is newer and has assignments for those scalar values
+     * (and some of those assignments turn out to be combining characters).
+     */
+    @Test
+    void demonstrateMetaDataAboutTheseSamples() {
+        String facepalm = getFacePalmingMaleControlSkintone();
+
+        assertEquals(17, facepalm.getBytes(StandardCharsets.UTF_8).length);
+        assertEquals(14, facepalm.getBytes(StandardCharsets.UTF_16BE).length);
+        assertEquals(5, facepalm.getBytes(Charsets.toCharset("UTF-32")).length);
+
+        assertEquals(5, facepalm.codePointCount(0, facepalm.length()));
+
+        assertEquals(1, countGraphemes(facepalm));
+    }
+
+
+    public static int countGraphemes(String text) {
+        BreakIterator breakIterator = BreakIterator.getCharacterInstance();
+        breakIterator.setText(text);
+
+        int count = 0;
+        int start = breakIterator.first();
+        for (int end = breakIterator.next(); end != BreakIterator.DONE; start = end, end = breakIterator.next()) {
+            count++;
+        }
+
+        return count;
+    }
+
 
 }

--- a/src/test/java/emissary/test/util/ComplexUnicodeSamples.java
+++ b/src/test/java/emissary/test/util/ComplexUnicodeSamples.java
@@ -1,50 +1,46 @@
 package emissary.test.util;
 
-import org.apache.commons.codec.Charsets;
-import org.junit.jupiter.api.Test;
-
-import java.nio.charset.StandardCharsets;
-import java.text.BreakIterator;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * A class that provides some tricky samples They can be used in testing to make sure our code and the 3rd party
  * libraries we choose can handle unusual cases.
  * <p>
- * Each example contains detailed explanation. and links to useful reference materials.
+ * Each example contains detailed explanation and links to useful reference materials.
  */
 public class ComplexUnicodeSamples {
 
     /**
-     * Returns a string that contains one graphical unit consists of 5 Unicode scalar values.
+     * Returns a string that contains one graphical unit consists of 5 Unicode scalar values. The user-perceived string
+     * would be one facepalming emoji. A user would expect hit the arrow key once to jump this one emoji on the screen. The
+     * length of the UTF-8 encoded byte array is 17 bytes. One emoji, 17 bytes.
      * <p>
-     * First, there’s a base character that means a person face palming.
+     * SCALAR 1: First, there’s a base character that means a person face palming.
      * <p>
-     * By default, the person would have a cartoonish yellow color. The next character is an emoji skintone modifier the
-     * changes the color of the person’s skin (and, in practice, also the color of the person’s hair).
+     * SCALAR 2: By default, the person would have a cartoonish yellow color. The next character is an emoji skintone
+     * modifier the changes the color of the person’s skin (and, in practice, also the color of the person’s hair).
      * <p>
-     * By default, the gender of the person is undefined, and e.g. Apple defaults to what they consider a male appearance
-     * and e.g. Google defaults to what they consider a female appearance. The next two scalar values pick a male-typical
-     * appearance specifically regardless of font and vendor. Instead of being an emoji-specific modifier like the skin
-     * tone, the gender specification uses an emoji-predating gender symbol (MALE SIGN) explicitly ligated using the
+     * SCALAR 3 and 4: By default, the gender of the person is undefined, and e.g. Apple defaults to what they consider a
+     * male appearance and e.g. Google defaults to what they consider a female appearance. The next two scalar values pick a
+     * male-typical appearance specifically regardless of font and vendor. Instead of being an emoji-specific modifier like
+     * the skin tone, the gender specification uses an emoji-predating gender symbol (MALE SIGN) explicitly ligated using
+     * the ZERO WIDTH JOINER with the (skin-toned) face-palming person. (Whether it is a good or a bad idea that the skin
+     * tone and gender specifications use different mechanisms is out of the scope of this post.)
+     * <p>
+     * SCALAR 5: Finally, VARIATION SELECTOR-16 makes it explicit that we want a multicolor emoji rendering instead of a
+     * monochrome dingbat rendering.
      * 
-     * ZERO WIDTH JOINER with the (skin-toned) face-palming person. (Whether it is a good or a bad idea that the skin tone
-     * and gender specifications use different mechanisms is out of the scope of this post.)
-     * <p>
-     * Finally, VARIATION SELECTOR-16 makes it explicit that we want a multicolor emoji rendering instead of a monochrome
-     * dingbat rendering.
+     * @return the Java string containing this one facepalming dude emoji with a not-yellow skin tone.
      * 
-     * @see #demonstrateMetaDataAboutTheseSamples() interesting observations about this sample
+     * @see ComplexUnicodeSamplesTest#demonstrateMetadataAboutFacePalmDude()
      * @see <a href="https://hsivonen.fi/string-length/">https://hsivonen.fi/string-length/</a>
      */
     public static String getFacePalmingMaleControlSkintone() {
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
 
-        // U+1F926 FACE PALM
+        // SCALAR 1: U+1F926 FACE PALM
         // Use the lookup for how to represent in java
         // https://www.fileformat.info/info/unicode/char/1f926/index.htm
         // UTF-32 code units: 1
@@ -55,7 +51,7 @@ public class ComplexUnicodeSamples {
         // UTF-8 bytes: 4
         sb.append("\uD83E\uDD26");
 
-        // U+1F3FC EMOJI MODIFIER FITZPATRICK TYPE-3
+        // SCALAR 2: U+1F3FC EMOJI MODIFIER FITZPATRICK TYPE-3
         // https://www.fileformat.info/info/unicode/char/1f3fc/index.htm
         // UTF-32 code units: 1
         // UTF-16 code units: 2
@@ -65,7 +61,7 @@ public class ComplexUnicodeSamples {
         // UTF-8 bytes: 4
         sb.append("\uD83C\uDFFC");
 
-        // U+200D ZERO WIDTH JOINER
+        // SCALAR 3: U+200D ZERO WIDTH JOINER
         // UTF-32 code units: 1
         // UTF-16 code units: 1
         // UTF-8 code units: 3
@@ -74,7 +70,7 @@ public class ComplexUnicodeSamples {
         // UTF-8 bytes: 3
         sb.append("\u200D");
 
-        // U+2642 MALE SIGN
+        // SCALAR 4: U+2642 MALE SIGN
         // UTF-32 code units: 1
         // UTF-16 code units: 1
         // UTF-8 code units: 3
@@ -83,7 +79,7 @@ public class ComplexUnicodeSamples {
         // UTF-8 bytes: 3
         sb.append("\u2642");
 
-        // U+FE0F VARIATION SELECTOR-16
+        // SCALAR 5: U+FE0F VARIATION SELECTOR-16
         // UTF-32 code units: 1
         // UTF-16 code units: 1
         // UTF-8 code units: 3
@@ -96,6 +92,38 @@ public class ComplexUnicodeSamples {
         return sb.toString();
     }
 
+    /**
+     * You perceive a single symbol: the flag of Italy. However, this symbol is composed of two Unicode code points: U+1F1EE
+     * (regional indicator symbol letter I) and U+1F1F9 (regional indicator symbol letter T). About 250 flags can be formed
+     * with these regional indicators. The pirate flag 🏴‍☠️, on the other hand, is composed of U+1F3F4 (waving black flag),
+     * U+200D (zero width joiner), U+2620 (skull and crossbones), and U+FE0F (variation selector-16). In Java, you need four
+     * char values to represent the first flag, five for the second.
+     * 
+     * @return an Italy flag emoji.
+     */
+    public static String getFlagOfItaly() {
+
+        StringBuilder sb = new StringBuilder();
+        // SCALAR 1: U+1F1EE REGIONAL INDICATOR SYMBOL LETTER I
+        // Use the lookup for how to represent in java
+        // https://www.fileformat.info/info/unicode/char/1f1ee/index.htm
+        sb.append("\uD83C\uDDEE");
+
+
+        // SCALAR 2: U+1F1F9 REGIONAL INDICATOR SYMBOL LETTER T
+        // https://www.fileformat.info/info/unicode/char/1f1f9/index.htm
+        sb.append("\uD83C\uDDF9");
+
+        return sb.toString();
+    }
+
+    public static String getPirateFlag() {
+        return "";
+    }
+
+    public static String getGClef() {
+        return "";
+    }
 
     /**
      * A utility method that will provide
@@ -134,51 +162,59 @@ public class ComplexUnicodeSamples {
         return xmlWithExp;
     }
 
-
     /**
-     * Interesting observations
+     * This will not work properly in versions of java earlier than Java 20.
      * <p>
-     * We’ve seen four different lengths so far:
+     * Once we get to Java 20, this method should work properly.
      * 
-     * <ul>
-     * <li>Number of UTF-8 code units (17 in this case)</li>
-     * <li>Number of UTF-16 code units (7 in this case)</li>
-     * <li>Number of UTF-32 code units or Unicode scalar values (5 in this case)</li>
-     * <li>Number of extended grapheme clusters (1 in this case)</li>
-     * </ul>
-     * Given a valid Unicode string and a version of Unicode, all of the above are well-defined and it holds that each item
-     * higher on the list is greater or equal than the items lower on the list.
      * <p>
-     * One of these is not like the others, though: The first three numbers have an unchanging definition for any valid
-     * Unicode string whether it contains currently assigned scalar values or whether it is from the future and contains
-     * unassigned scalar values as far as software written today is aware. Also, computing the first three lengths does not
-     * involve lookups from the Unicode database. However, the last item depends on the Unicode version and involves lookups
-     * from the Unicode database. If a string contains scalar values that are unassigned as far as the copy of the Unicode
-     * database that the program is using is aware, the program will potentially overcount extended grapheme clusters in the
-     * string compared to a program whose copy of the Unicode database is newer and has assignments for those scalar values
-     * (and some of those assignments turn out to be combining characters).
+     * Character boundary analysis allows users to interact with characters as they expect to, for example, when moving the
+     * cursor through a text string. Character boundary analysis provides correct navigation through character strings,
+     * regardless of how the character is stored. The boundaries returned may be those of supplementary characters,
+     * combining character sequences, or ligature clusters. For example, an accented character might be stored as a base
+     * character and a diacritical mark. What users consider to be a character can differ between languages.
+     * 
+     * @see <a href=
+     *      "https://horstmann.com/unblog/2023-10-03/index.html">https://horstmann.com/unblog/2023-10-03/index.html</a> -
+     *      Scroll to the section titled "Just Use Strings"
+     * 
+     * 
+     * 
+     * @param text - the string to analyze.
+     * @return the count of user-perceived graphemes as based on the character break iterator. In versions of java earlier
+     *         than Java 20, this will not function as expected.
      */
-    @Test
-    void demonstrateMetaDataAboutTheseSamples() {
-        String facepalm = getFacePalmingMaleControlSkintone();
+    public static int countGraphemesUsingJavaBuiltInBreakIterator(String text) {
 
-        assertEquals(17, facepalm.getBytes(StandardCharsets.UTF_8).length);
-        assertEquals(14, facepalm.getBytes(StandardCharsets.UTF_16BE).length);
-        assertEquals(5, facepalm.getBytes(Charsets.toCharset("UTF-32")).length);
-
-        assertEquals(5, facepalm.codePointCount(0, facepalm.length()));
-
-        assertEquals(1, countGraphemes(facepalm));
-    }
-
-
-    public static int countGraphemes(String text) {
-        BreakIterator breakIterator = BreakIterator.getCharacterInstance();
+        java.text.BreakIterator breakIterator = java.text.BreakIterator.getCharacterInstance();
         breakIterator.setText(text);
 
         int count = 0;
-        int start = breakIterator.first();
-        for (int end = breakIterator.next(); end != BreakIterator.DONE; start = end, end = breakIterator.next()) {
+        for (int end = breakIterator.next(); end != java.text.BreakIterator.DONE; end = breakIterator.next()) {
+            count++;
+        }
+
+        return count;
+    }
+
+    /**
+     * Using the industry-standard ICU4J library provided by IBM.
+     * <p>
+     * NOTE: Updating the version of this library might change which unicode database is referenced for these calculations.
+     * We should strive to keep this library as up-to-date as possible.
+     * 
+     * @param text the string to analyze
+     * @return a count of how many user-perceived glyphs/graphemes are present in the string. If you placed a cursor diretly
+     *         to the left (or right for right-to-left string), and pressed the arrow key to traverse the string, how many
+     *         times would you need to press the arrow key to traverse to the right-most end of the string (or leftmost for
+     *         R-to-L strings).
+     */
+    public static int countGraphemesUsingIcu4J(String text) {
+        com.ibm.icu.text.BreakIterator breakIterator = com.ibm.icu.text.BreakIterator.getCharacterInstance();
+        breakIterator.setText(text);
+
+        int count = 0;
+        for (int end = breakIterator.next(); end != com.ibm.icu.text.BreakIterator.DONE; end = breakIterator.next()) {
             count++;
         }
 

--- a/src/test/java/emissary/test/util/ComplexUnicodeSamples.java
+++ b/src/test/java/emissary/test/util/ComplexUnicodeSamples.java
@@ -12,10 +12,10 @@ public class ComplexUnicodeSamples {
      * <p>
      * This map is useful for testing that any XML library we are using is handling unicode correctly.
      * 
-     * @return A map of strings where the key is the XML node containing an XML-escaped surrogate pair unicode value and
-     *         the value is is the properly extracted java string value.
-     * @See <a href=
-     *      "https://github.com/FasterXML/woodstox/pull/174/files">{@link https://github.com/FasterXML/woodstox/pull/174/files}</a>
+     * @return A map of strings where the key is the XML node containing an XML-escaped surrogate pair unicode value and the
+     *         value is is the properly extracted java string value.
+     * @see <a href=
+     *      "https://github.com/FasterXML/woodstox/pull/174/files">https://github.com/FasterXML/woodstox/pull/174/files</a>
      */
     public static Map<String, String> getXmlSamples() {
         // See https://github.com/FasterXML/woodstox/pull/174/files

--- a/src/test/java/emissary/test/util/ComplexUnicodeSamples.java
+++ b/src/test/java/emissary/test/util/ComplexUnicodeSamples.java
@@ -14,23 +14,22 @@ public final class ComplexUnicodeSamples {
     private ComplexUnicodeSamples() {}
 
     /**
-     * Returns a string that contains one graphical unit (in this case an emoji) that consists of 5 Unicode scalar
-     * values. The user-perceived string would be one facepalming emoji. A user would expect hit the arrow key once to
-     * traverse the cursor across this one emoji on the screen. The length of the UTF-8 encoded byte array is 17 bytes.
-     * One emoji, 17 UTF8 bytes.
+     * Returns a string that contains one graphical unit (in this case an emoji) that consists of 5 Unicode scalar values.
+     * The user-perceived string would be one facepalming emoji. A user would expect hit the arrow key once to traverse the
+     * cursor across this one emoji on the screen. The length of the UTF-8 encoded byte array is 17 bytes. One emoji, 17
+     * UTF8 bytes.
      * <p>
      * SCALAR 1: First, there’s a base character that means a person face palming.
      * <p>
      * SCALAR 2: By default, the person would have a cartoonish yellow color. The next character is an emoji skintone
      * modifier the changes the color of the person’s skin (and, in practice, also the color of the person’s hair).
      * <p>
-     * SCALAR 3 and 4: By default, the gender of the person is undefined, and e.g. Apple defaults to what they consider
-     * a male appearance and e.g. Google defaults to what they consider a female appearance. The next two scalar values
-     * pick a male-typical appearance specifically regardless of font and vendor. Instead of being an emoji-specific
-     * modifier like the skin tone, the gender specification uses an emoji-predating gender symbol (MALE SIGN)
-     * explicitly ligated using the ZERO WIDTH JOINER with the (skin-toned) face-palming person. (Whether it is a good
-     * or a bad idea that the skin tone and gender specifications use different mechanisms is out of the scope of this
-     * post.)
+     * SCALAR 3 and 4: By default, the gender of the person is undefined, and e.g. Apple defaults to what they consider a
+     * male appearance and e.g. Google defaults to what they consider a female appearance. The next two scalar values pick a
+     * male-typical appearance specifically regardless of font and vendor. Instead of being an emoji-specific modifier like
+     * the skin tone, the gender specification uses an emoji-predating gender symbol (MALE SIGN) explicitly ligated using
+     * the ZERO WIDTH JOINER with the (skin-toned) face-palming person. (Whether it is a good or a bad idea that the skin
+     * tone and gender specifications use different mechanisms is out of the scope of this post.)
      * <p>
      * SCALAR 5: Finally, VARIATION SELECTOR-16 makes it explicit that we want a multicolor emoji rendering instead of a
      * monochrome dingbat rendering.
@@ -97,11 +96,11 @@ public final class ComplexUnicodeSamples {
 
 
     /**
-     * This map is useful for testing that our code and any 3rd party XML library we are using is handling unicode
-     * within XML correctly.
+     * This map is useful for testing that our code and any 3rd party XML library we are using is handling unicode within
+     * XML correctly.
      * 
-     * @return A map of strings where the key is the XML node containing an XML-escaped surrogate pair unicode value and
-     *         the value is is the properly extracted java string value with un-escaped unicode strings.
+     * @return A map of strings where the key is the XML node containing an XML-escaped surrogate pair unicode value and the
+     *         value is is the properly extracted java string value with un-escaped unicode strings.
      * @see <a href=
      *      "https://github.com/FasterXML/woodstox/pull/174/files">https://github.com/FasterXML/woodstox/pull/174/files</a>
      */
@@ -135,20 +134,19 @@ public final class ComplexUnicodeSamples {
      * <p>
      * Once we get to Java 20, this method should work properly.
      * <p>
-     * Character boundary analysis allows users to interact with characters as they expect to, for example, when moving
-     * the cursor through a text string. Character boundary analysis provides correct navigation through character
-     * strings, regardless of how the character is stored. The boundaries returned may be those of supplementary
-     * characters, combining character sequences, or ligature clusters. For example, an accented character might be
-     * stored as a base character and a diacritical mark. What users consider to be a character can differ between
-     * languages.
+     * Character boundary analysis allows users to interact with characters as they expect to, for example, when moving the
+     * cursor through a text string. Character boundary analysis provides correct navigation through character strings,
+     * regardless of how the character is stored. The boundaries returned may be those of supplementary characters,
+     * combining character sequences, or ligature clusters. For example, an accented character might be stored as a base
+     * character and a diacritical mark. What users consider to be a character can differ between languages.
      * 
      * @see <a href=
-     *      "https://horstmann.com/unblog/2023-10-03/index.html">https://horstmann.com/unblog/2023-10-03/index.html</a>
-     *      - Scroll to the section titled "Just Use Strings"
+     *      "https://horstmann.com/unblog/2023-10-03/index.html">https://horstmann.com/unblog/2023-10-03/index.html</a> -
+     *      Scroll to the section titled "Just Use Strings"
      *
      * @param text - the string to analyze.
-     * @return the count of user-perceived graphemes as based on the character break iterator. In versions of java
-     *         earlier than Java 20, this will not function as expected.
+     * @return the count of user-perceived graphemes as based on the character break iterator. In versions of java earlier
+     *         than Java 20, this will not function as expected.
      */
     public static int countGraphemesUsingJavaBuiltInBreakIterator(String text) {
 
@@ -166,15 +164,14 @@ public final class ComplexUnicodeSamples {
     /**
      * Using the industry-standard ICU4J library provided by IBM.
      * <p>
-     * NOTE: Updating the version of this library might change which unicode database is referenced for these
-     * calculations. We should strive to keep this library as up-to-date as possible in both test and production source
-     * code.
+     * NOTE: Updating the version of this library might change which unicode database is referenced for these calculations.
+     * We should strive to keep this library as up-to-date as possible in both test and production source code.
      * 
      * @param text the string to analyze
-     * @return a count of how many user-perceived glyphs/graphemes are present in the string. If you placed a cursor
-     *         diretly to the left (or right for right-to-left string), and pressed the arrow key to traverse the
-     *         string, how many times would you need to press the arrow key to traverse to the right-most end of the
-     *         string (or leftmost for R-to-L strings).
+     * @return a count of how many user-perceived glyphs/graphemes are present in the string. If you placed a cursor diretly
+     *         to the left (or right for right-to-left string), and pressed the arrow key to traverse the string, how many
+     *         times would you need to press the arrow key to traverse to the right-most end of the string (or leftmost for
+     *         R-to-L strings).
      */
     public static int countGraphemesUsingIcu4J(String text) {
         com.ibm.icu.text.BreakIterator breakIterator = com.ibm.icu.text.BreakIterator.getCharacterInstance();

--- a/src/test/java/emissary/test/util/ComplexUnicodeSamples.java
+++ b/src/test/java/emissary/test/util/ComplexUnicodeSamples.java
@@ -1,23 +1,20 @@
 package emissary.test.util;
 
-import com.ibm.icu.text.BreakIterator;
 import org.apache.commons.codec.Charsets;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.text.BreakIterator;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * A class that provides some samples where the byte representation of the user-percieved glyph (grapheme) is outside of
- * normal Basic Multilingual Plane usage.
+ * A class that provides some tricky samples They can be used in testing to make sure our code and the 3rd party
+ * libraries we choose can handle unusual cases.
  * <p>
- * The explanations of each example should help the developer evaluate 3rd party libraries and their quality of their
- * unicode handling.
- * <p>
- * Each example provides links to useful reference materials.
+ * Each example contains detailed explanation. and links to useful reference materials.
  */
 public class ComplexUnicodeSamples {
 

--- a/src/test/java/emissary/test/util/ComplexUnicodeSamples.java
+++ b/src/test/java/emissary/test/util/ComplexUnicodeSamples.java
@@ -4,8 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A class that provides some tricky samples They can be used in testing to make sure our code and the 3rd party
- * libraries we choose can handle unusual cases.
+ * A class that provides some tricky samples. These samples can be used in testing to make sure our code and the 3rd
+ * party libraries we choose can handle unusual cases.
  * <p>
  * Each example contains detailed explanation and links to useful reference materials.
  */
@@ -14,21 +14,23 @@ public final class ComplexUnicodeSamples {
     private ComplexUnicodeSamples() {}
 
     /**
-     * Returns a string that contains one graphical unit that consists of 5 Unicode scalar values. The user-perceived string
-     * would be one facepalming emoji. A user would expect hit the arrow key once to jump this one emoji on the screen. The
-     * length of the UTF-8 encoded byte array is 17 bytes. One emoji, 17 bytes.
+     * Returns a string that contains one graphical unit (in this case an emoji) that consists of 5 Unicode scalar
+     * values. The user-perceived string would be one facepalming emoji. A user would expect hit the arrow key once to
+     * traverse the cursor across this one emoji on the screen. The length of the UTF-8 encoded byte array is 17 bytes.
+     * One emoji, 17 UTF8 bytes.
      * <p>
      * SCALAR 1: First, there’s a base character that means a person face palming.
      * <p>
      * SCALAR 2: By default, the person would have a cartoonish yellow color. The next character is an emoji skintone
      * modifier the changes the color of the person’s skin (and, in practice, also the color of the person’s hair).
      * <p>
-     * SCALAR 3 and 4: By default, the gender of the person is undefined, and e.g. Apple defaults to what they consider a
-     * male appearance and e.g. Google defaults to what they consider a female appearance. The next two scalar values pick a
-     * male-typical appearance specifically regardless of font and vendor. Instead of being an emoji-specific modifier like
-     * the skin tone, the gender specification uses an emoji-predating gender symbol (MALE SIGN) explicitly ligated using
-     * the ZERO WIDTH JOINER with the (skin-toned) face-palming person. (Whether it is a good or a bad idea that the skin
-     * tone and gender specifications use different mechanisms is out of the scope of this post.)
+     * SCALAR 3 and 4: By default, the gender of the person is undefined, and e.g. Apple defaults to what they consider
+     * a male appearance and e.g. Google defaults to what they consider a female appearance. The next two scalar values
+     * pick a male-typical appearance specifically regardless of font and vendor. Instead of being an emoji-specific
+     * modifier like the skin tone, the gender specification uses an emoji-predating gender symbol (MALE SIGN)
+     * explicitly ligated using the ZERO WIDTH JOINER with the (skin-toned) face-palming person. (Whether it is a good
+     * or a bad idea that the skin tone and gender specifications use different mechanisms is out of the scope of this
+     * post.)
      * <p>
      * SCALAR 5: Finally, VARIATION SELECTOR-16 makes it explicit that we want a multicolor emoji rendering instead of a
      * monochrome dingbat rendering.
@@ -95,14 +97,11 @@ public final class ComplexUnicodeSamples {
 
 
     /**
-     * A utility method that will provide
-     * <a href="https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane">non-BMP</a> values inside an XML
-     * element and the corresponding properly un-escaped values that should have been extracted for that element.
-     * <p>
-     * This map is useful for testing that any XML library we are using is handling unicode correctly.
+     * This map is useful for testing that our code and any 3rd party XML library we are using is handling unicode
+     * within XML correctly.
      * 
-     * @return A map of strings where the key is the XML node containing an XML-escaped surrogate pair unicode value and the
-     *         value is is the properly extracted java string value.
+     * @return A map of strings where the key is the XML node containing an XML-escaped surrogate pair unicode value and
+     *         the value is is the properly extracted java string value with un-escaped unicode strings.
      * @see <a href=
      *      "https://github.com/FasterXML/woodstox/pull/174/files">https://github.com/FasterXML/woodstox/pull/174/files</a>
      */
@@ -135,23 +134,21 @@ public final class ComplexUnicodeSamples {
      * This will not work properly in versions of java earlier than Java 20.
      * <p>
      * Once we get to Java 20, this method should work properly.
-     * 
      * <p>
-     * Character boundary analysis allows users to interact with characters as they expect to, for example, when moving the
-     * cursor through a text string. Character boundary analysis provides correct navigation through character strings,
-     * regardless of how the character is stored. The boundaries returned may be those of supplementary characters,
-     * combining character sequences, or ligature clusters. For example, an accented character might be stored as a base
-     * character and a diacritical mark. What users consider to be a character can differ between languages.
+     * Character boundary analysis allows users to interact with characters as they expect to, for example, when moving
+     * the cursor through a text string. Character boundary analysis provides correct navigation through character
+     * strings, regardless of how the character is stored. The boundaries returned may be those of supplementary
+     * characters, combining character sequences, or ligature clusters. For example, an accented character might be
+     * stored as a base character and a diacritical mark. What users consider to be a character can differ between
+     * languages.
      * 
      * @see <a href=
-     *      "https://horstmann.com/unblog/2023-10-03/index.html">https://horstmann.com/unblog/2023-10-03/index.html</a> -
-     *      Scroll to the section titled "Just Use Strings"
-     * 
-     * 
-     * 
+     *      "https://horstmann.com/unblog/2023-10-03/index.html">https://horstmann.com/unblog/2023-10-03/index.html</a>
+     *      - Scroll to the section titled "Just Use Strings"
+     *
      * @param text - the string to analyze.
-     * @return the count of user-perceived graphemes as based on the character break iterator. In versions of java earlier
-     *         than Java 20, this will not function as expected.
+     * @return the count of user-perceived graphemes as based on the character break iterator. In versions of java
+     *         earlier than Java 20, this will not function as expected.
      */
     public static int countGraphemesUsingJavaBuiltInBreakIterator(String text) {
 
@@ -169,14 +166,15 @@ public final class ComplexUnicodeSamples {
     /**
      * Using the industry-standard ICU4J library provided by IBM.
      * <p>
-     * NOTE: Updating the version of this library might change which unicode database is referenced for these calculations.
-     * We should strive to keep this library as up-to-date as possible.
+     * NOTE: Updating the version of this library might change which unicode database is referenced for these
+     * calculations. We should strive to keep this library as up-to-date as possible in both test and production source
+     * code.
      * 
      * @param text the string to analyze
-     * @return a count of how many user-perceived glyphs/graphemes are present in the string. If you placed a cursor diretly
-     *         to the left (or right for right-to-left string), and pressed the arrow key to traverse the string, how many
-     *         times would you need to press the arrow key to traverse to the right-most end of the string (or leftmost for
-     *         R-to-L strings).
+     * @return a count of how many user-perceived glyphs/graphemes are present in the string. If you placed a cursor
+     *         diretly to the left (or right for right-to-left string), and pressed the arrow key to traverse the
+     *         string, how many times would you need to press the arrow key to traverse to the right-most end of the
+     *         string (or leftmost for R-to-L strings).
      */
     public static int countGraphemesUsingIcu4J(String text) {
         com.ibm.icu.text.BreakIterator breakIterator = com.ibm.icu.text.BreakIterator.getCharacterInstance();

--- a/src/test/java/emissary/test/util/ComplexUnicodeSamples.java
+++ b/src/test/java/emissary/test/util/ComplexUnicodeSamples.java
@@ -1,0 +1,45 @@
+package emissary.test.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ComplexUnicodeSamples {
+
+    /**
+     * A utility method that will provide
+     * <a href="https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane">non-BMP</a> values inside an XML
+     * element and the corresponding properly un-escaped values that should have been extracted for that element.
+     * <p>
+     * This map is useful for testing that any XML library we are using is handling unicode correctly.
+     * 
+     * @return A map of strings where the key is the XML node containing an XML-escaped surrogate pair unicode value and
+     *         the value is is the properly extracted java string value.
+     * @See <a href=
+     *      "https://github.com/FasterXML/woodstox/pull/174/files">{@link https://github.com/FasterXML/woodstox/pull/174/files}</a>
+     */
+    public static Map<String, String> getXmlSamples() {
+        // See https://github.com/FasterXML/woodstox/pull/174/files
+        Map<String, String> xmlWithExp = new HashMap<String, String>();
+        // Numeric surrogate pairs
+        xmlWithExp.put("<root>surrogate pair: &#55356;&#57221;.</root>",
+                "surrogate pair: \uD83C\uDF85.");
+        // Hex and numeric surrogate pairs
+        xmlWithExp.put("<root>surrogate pair: &#xD83C;&#57221;.</root>",
+                "surrogate pair: \uD83C\uDF85.");
+        // Numeric and hex surrogate pairs
+        xmlWithExp.put("<root>surrogate pair: &#55356;&#xDF85;.</root>",
+                "surrogate pair: \uD83C\uDF85.");
+        // Hex surrogate pairs
+        xmlWithExp.put("<root>surrogate pair: &#xD83C;&#xDF85;.</root>",
+                "surrogate pair: \uD83C\uDF85.");
+        // Two surrogate pairs
+        xmlWithExp.put("<root>surrogate pair: &#55356;&#57221;&#55356;&#57220;.</root>",
+                "surrogate pair: \uD83C\uDF85\uD83C\uDF84.");
+        // Surrogate pair and simple entity
+        xmlWithExp.put("<root>surrogate pair: &#55356;&#57221;&#8482;.</root>",
+                "surrogate pair: \uD83C\uDF85\u2122.");
+
+        return xmlWithExp;
+    }
+
+}

--- a/src/test/java/emissary/test/util/ComplexUnicodeSamplesTest.java
+++ b/src/test/java/emissary/test/util/ComplexUnicodeSamplesTest.java
@@ -1,0 +1,117 @@
+package emissary.test.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class ComplexUnicodeSamplesTest {
+
+    /**
+     * Interesting observations about face palm dude emoji.
+     * <p>
+     * We’ve seen four different lengths so far:
+     * 
+     * <ul>
+     * <li>Number of UTF-8 code units (17 in this case)</li>
+     * <li>Number of UTF-16 code units (7 in this case)</li>
+     * <li>Number of UTF-32 code units or Unicode scalar values (5 in this case)</li>
+     * <li>Number of extended grapheme clusters (1 in this case)</li>
+     * </ul>
+     * Given a valid Unicode string and a version of Unicode, all of the above are well-defined and it holds that each item
+     * higher on the list is greater or equal than the items lower on the list.
+     * <p>
+     * One of these is not like the others, though: The first three numbers have an unchanging definition for any valid
+     * Unicode string whether it contains currently assigned scalar values or whether it is from the future and contains
+     * unassigned scalar values as far as software written today is aware. Also, computing the first three lengths does not
+     * involve lookups from the Unicode database. However, the last item depends on the Unicode version and involves lookups
+     * from the Unicode database. If a string contains scalar values that are unassigned as far as the copy of the Unicode
+     * database that the program is using is aware, the program will potentially overcount extended grapheme clusters in the
+     * string compared to a program whose copy of the Unicode database is newer and has assignments for those scalar values
+     * (and some of those assignments turn out to be combining characters).
+     */
+    @Test
+    void demonstrateMetadataAboutFacePalmDude() {
+
+        String facepalm = ComplexUnicodeSamples.getFacePalmingMaleControlSkintone();
+
+        assertEquals(5, facepalm.codePointCount(0, facepalm.length()));
+
+        // ICU4J gets it right
+        assertEquals(1, ComplexUnicodeSamples.countGraphemesUsingIcu4J(facepalm));
+
+        // Java earlier than Java 20 gets it wrong, this test can be updated as we move versions of java
+        // but it's important to know/highlight the difference.
+        assertEquals(4, ComplexUnicodeSamples.countGraphemesUsingJavaBuiltInBreakIterator(facepalm));
+
+        // SCALAR 1 is 4 UTF8 bytes
+        // SCALAR 2 is 4 UTF8 bytes
+        // SCALAR 3 is 3 UTF8 bytes
+        // SCALAR 4 is 3 UTF8 bytes
+        // SCALAR 5 is 3 UTF8 bytes
+        // TOTAL : 17 UTF8 bytes
+        assertEquals(17, facepalm.getBytes(StandardCharsets.UTF_8).length);
+        assertEquals(facepalm, new String(facepalm.getBytes(StandardCharsets.UTF_8)));
+
+        // SCALAR 1 is 4 UTF16 bytes
+        // SCALAR 2 is 4 UTF16 bytes
+        // SCALAR 3 is 2 UTF16 bytes
+        // SCALAR 4 is 2 UTF16 bytes
+        // SCALAR 5 is 2 UTF16 bytes
+        // TOTAL : 14 UTF16 bytes if no BOM is needed
+        // Java typically defaults to UTF-16BE
+        assertEquals(14, facepalm.getBytes(StandardCharsets.UTF_16BE).length);
+        assertEquals(facepalm, new String(facepalm.getBytes(StandardCharsets.UTF_16BE), StandardCharsets.UTF_16BE));
+        assertEquals(14, facepalm.getBytes(StandardCharsets.UTF_16LE).length);
+        assertEquals(facepalm, new String(facepalm.getBytes(StandardCharsets.UTF_16LE), StandardCharsets.UTF_16LE));
+
+        // When the endianness isn't specified, 2 bytes are used for the byte order marker
+        // The BOM is a special character (U+FEFF) used to indicate the endianness (byte order)
+        // of a UTF-16 encoded file or stream. In UTF-16, the BOM can be either:
+        // FE FF (Big Endian)
+        // FF FE (Little Endian)
+        assertEquals(16, facepalm.getBytes(StandardCharsets.UTF_16).length);
+        assertEquals(facepalm, new String(facepalm.getBytes(StandardCharsets.UTF_16), StandardCharsets.UTF_16));
+
+        // 5 UTF-32 characters at 4 bytes per character
+        assertEquals(20, facepalm.getBytes(Charset.forName("UTF-32")).length);
+        assertEquals(facepalm, new String(facepalm.getBytes(Charset.forName("UTF-32")), Charset.forName("UTF-32")));
+
+        // single byte encoding is not going to produce what you want
+        assertEquals(5, facepalm.getBytes(StandardCharsets.ISO_8859_1).length);
+        assertNotEquals(facepalm, new String(facepalm.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.ISO_8859_1));
+
+
+    }
+
+    @Test
+    void demonstrateMetadataAboutFlagOfItaly() {
+        String flagOfItaly = ComplexUnicodeSamples.getFlagOfItaly();
+
+        // ICU4J gets it right
+        assertEquals(1, ComplexUnicodeSamples.countGraphemesUsingIcu4J(flagOfItaly));
+
+        // Java gets it wrong
+        assertEquals(2, ComplexUnicodeSamples.countGraphemesUsingJavaBuiltInBreakIterator(flagOfItaly));
+
+        // 4 UTF-8 characters at 2 bytes per character
+        assertEquals(8, flagOfItaly.getBytes(StandardCharsets.UTF_8).length);
+
+        // TODO: explain
+        assertEquals(10, flagOfItaly.getBytes(StandardCharsets.UTF_16).length);
+        assertEquals(8, flagOfItaly.getBytes(StandardCharsets.UTF_16BE).length);
+        assertEquals(8, flagOfItaly.getBytes(StandardCharsets.UTF_16LE).length);
+
+        // 2 UTF-32 characters at 4 bytes per character
+        assertEquals(8, flagOfItaly.getBytes(Charset.forName("UTF-32")).length);
+
+        assertEquals(2, flagOfItaly.getBytes(StandardCharsets.ISO_8859_1).length);
+
+        assertEquals(2, flagOfItaly.codePointCount(0, flagOfItaly.length()));
+    }
+
+
+}

--- a/src/test/java/emissary/test/util/ComplexUnicodeSamplesTest.java
+++ b/src/test/java/emissary/test/util/ComplexUnicodeSamplesTest.java
@@ -1,6 +1,9 @@
 package emissary.test.util;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -38,14 +41,6 @@ class ComplexUnicodeSamplesTest {
 
         String facepalm = ComplexUnicodeSamples.getFacePalmingMaleControlSkintone();
 
-        assertEquals(5, facepalm.codePointCount(0, facepalm.length()));
-
-        // ICU4J gets it right
-        assertEquals(1, ComplexUnicodeSamples.countGraphemesUsingIcu4J(facepalm));
-
-        // Java earlier than Java 20 gets it wrong, this test can be updated as we move versions of java
-        // but it's important to know/highlight the difference.
-        assertEquals(4, ComplexUnicodeSamples.countGraphemesUsingJavaBuiltInBreakIterator(facepalm));
 
         // SCALAR 1 is 4 UTF8 bytes
         // SCALAR 2 is 4 UTF8 bytes
@@ -85,33 +80,61 @@ class ComplexUnicodeSamplesTest {
         assertNotEquals(facepalm, new String(facepalm.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.ISO_8859_1));
 
 
+        assertEquals(5, facepalm.codePointCount(0, facepalm.length()));
+
+        // ICU4J BreakIterator gets it right
+        assertEquals(1, ComplexUnicodeSamples.countGraphemesUsingIcu4J(facepalm));
+
+        // See
+        // demonstrateMetadataAboutFacePalmDudeForJava20()
+        // and
+        // demonstrateMetadataAboutFacePalmDudePriorToJava20()
+        // to see how using the intrinsic java BreakIterator doesn't
+        // get it right until Java 20.
+
+
+        // Normalizer2 nfcDecomp = Normalizer2.getInstance(null, "nfc", Normalizer2.Mode.DECOMPOSE);
+        // Normalizer2 nfdDecomp = Normalizer2.getInstance(null, "nfd", Normalizer2.Mode.DECOMPOSE);
+        //
+        // StringBuilder a = new StringBuilder();
+        // nfcDecomp.normalize(facepalm, a);
+        // System.out.println(a);
+        //
+        // StringBuilder b = new StringBuilder();
+        // nfdDecomp.normalize(facepalm, b);
+        // System.out.println(b);
     }
 
     @Test
-    void demonstrateMetadataAboutFlagOfItaly() {
-        String flagOfItaly = ComplexUnicodeSamples.getFlagOfItaly();
-
-        // ICU4J gets it right
-        assertEquals(1, ComplexUnicodeSamples.countGraphemesUsingIcu4J(flagOfItaly));
-
-        // Java gets it wrong
-        assertEquals(2, ComplexUnicodeSamples.countGraphemesUsingJavaBuiltInBreakIterator(flagOfItaly));
-
-        // 4 UTF-8 characters at 2 bytes per character
-        assertEquals(8, flagOfItaly.getBytes(StandardCharsets.UTF_8).length);
-
-        // TODO: explain
-        assertEquals(10, flagOfItaly.getBytes(StandardCharsets.UTF_16).length);
-        assertEquals(8, flagOfItaly.getBytes(StandardCharsets.UTF_16BE).length);
-        assertEquals(8, flagOfItaly.getBytes(StandardCharsets.UTF_16LE).length);
-
-        // 2 UTF-32 characters at 4 bytes per character
-        assertEquals(8, flagOfItaly.getBytes(Charset.forName("UTF-32")).length);
-
-        assertEquals(2, flagOfItaly.getBytes(StandardCharsets.ISO_8859_1).length);
-
-        assertEquals(2, flagOfItaly.codePointCount(0, flagOfItaly.length()));
+    @EnabledForJreRange(min = JRE.JAVA_20, disabledReason = "This test only valid for Java 20 and later.")
+    void demonstrateMetadataAboutFacePalmDudeForJava20() {
+        String facepalm = ComplexUnicodeSamples.getFacePalmingMaleControlSkintone();
+        assertEquals(1, ComplexUnicodeSamples.countGraphemesUsingJavaBuiltInBreakIterator(facepalm));
     }
 
+    @Test
+    @DisabledForJreRange(min = JRE.JAVA_20, disabledReason = "This test only valid for Java versions up to not including Java 20.")
+    void demonstrateMetadataAboutFacePalmDudePriorToJava20() {
+        String facepalm = ComplexUnicodeSamples.getFacePalmingMaleControlSkintone();
+        assertEquals(4, ComplexUnicodeSamples.countGraphemesUsingJavaBuiltInBreakIterator(facepalm));
+        // it should be 1, but it's wrong until Java 20.
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_17, disabledReason = "This test only valid for Java 17 and later.")
+    void demonstrateMetadataAboutFacePalmDudeForJava17AndLater() {
+        String facepalm = ComplexUnicodeSamples.getFacePalmingMaleControlSkintone();
+        int j = 27;
+        assertEquals(j, facepalm.repeat(j).split("\\b{g}").length);
+    }
+
+    @Test
+    @DisabledForJreRange(min = JRE.JAVA_17, disabledReason = "This test only valid for Java versions up to not including Java 17.")
+    void demonstrateMetadataAboutFacePalmDudePriorToJava17() {
+        String facepalm = ComplexUnicodeSamples.getFacePalmingMaleControlSkintone();
+        int j = 27;
+        assertEquals(j * 3, facepalm.repeat(j).split("\\b{g}").length);
+        // it should be 27, but it's wrong until Java 17
+    }
 
 }

--- a/src/test/java/emissary/test/util/ComplexUnicodeSamplesTest.java
+++ b/src/test/java/emissary/test/util/ComplexUnicodeSamplesTest.java
@@ -1,5 +1,6 @@
 package emissary.test.util;
 
+import com.ibm.icu.text.Normalizer2;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledForJreRange;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
@@ -10,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ComplexUnicodeSamplesTest {
 
@@ -40,7 +42,6 @@ class ComplexUnicodeSamplesTest {
     void demonstrateMetadataAboutFacePalmDude() {
 
         String facepalm = ComplexUnicodeSamples.getFacePalmingMaleControlSkintone();
-
 
         // SCALAR 1 is 4 UTF8 bytes
         // SCALAR 2 is 4 UTF8 bytes
@@ -93,16 +94,17 @@ class ComplexUnicodeSamplesTest {
         // get it right until Java 20.
 
 
-        // Normalizer2 nfcDecomp = Normalizer2.getInstance(null, "nfc", Normalizer2.Mode.DECOMPOSE);
-        // Normalizer2 nfdDecomp = Normalizer2.getInstance(null, "nfd", Normalizer2.Mode.DECOMPOSE);
-        //
-        // StringBuilder a = new StringBuilder();
-        // nfcDecomp.normalize(facepalm, a);
-        // System.out.println(a);
-        //
-        // StringBuilder b = new StringBuilder();
-        // nfdDecomp.normalize(facepalm, b);
-        // System.out.println(b);
+        // It's already normalized in it's natural form.
+        Normalizer2 nfcDecomp = Normalizer2.getInstance(null, "nfc", Normalizer2.Mode.DECOMPOSE);
+        Normalizer2 nfkcDecomp = Normalizer2.getInstance(null, "nfkc", Normalizer2.Mode.DECOMPOSE);
+        assertTrue(nfcDecomp.isNormalized(facepalm));
+        assertTrue(nfkcDecomp.isNormalized(facepalm));
+
+        Normalizer2 nfcComp = Normalizer2.getInstance(null, "nfc", Normalizer2.Mode.COMPOSE);
+        Normalizer2 nfkcComp = Normalizer2.getInstance(null, "nfkc", Normalizer2.Mode.COMPOSE);
+        assertTrue(nfcComp.isNormalized(facepalm));
+        assertTrue(nfkcComp.isNormalized(facepalm));
+
     }
 
     @Test
@@ -136,5 +138,6 @@ class ComplexUnicodeSamplesTest {
         assertEquals(j * 3, facepalm.repeat(j).split("\\b{g}").length);
         // it should be 27, but it's wrong until Java 17
     }
+
 
 }


### PR DESCRIPTION
There are a few places where we need more robust testing that we aren't making false assumptions about what the byte array contains and how (we attempt) to do clever things with it.  When our code or the 3rd party libraries we use are defaulting to baseless assumptions about how we can  move around in the bytes, we end up mangling the data in ways that isn't always obvious.  This helper class and the explaining test should allow us to test more edge cases, and avoid using dependencies that don't handle Unicode well.   I envision adding more samples as we come across more cases that keep tripping us up, but for now I need the XML map for one of my tickets, and I have plans for the emoji string for a couple of other tests. 

The entirety of this change should be test only, used from the emissary test jar.  I picked the icu4j version for consistency but I'd really like to always use the latest, it should be at the top of our list of dependencies to keep updated once we start using the icu4j utilities more often (as we should be).