### PR TITLE
deprecate SUFFIXES_HTML_ESCAPE constant parameter

### DIFF
--- a/src/main/java/emissary/core/constants/Parameters.java
+++ b/src/main/java/emissary/core/constants/Parameters.java
@@ -17,6 +17,7 @@ public class Parameters {
     // Common parameter prefixes
 
     // Common parameter suffixes
+    @Deprecated
     public static final String SUFFIXES_HTML_ESCAPE = "_HTML_ESCAPE";
 
     private Parameters() {}


### PR DESCRIPTION
due to HtmlEscapePlace being deprecated, deprecate this constant as well