### PR TITLE
TempFileNames constructor is now public, not package-private

### DIFF
--- a/src/main/java/emissary/util/shell/TempFileNames.java
+++ b/src/main/java/emissary/util/shell/TempFileNames.java
@@ -26,7 +26,7 @@ public class TempFileNames {
      * @param inFileEnding input file ending
      * @param outFileEnding output file ending
      */
-    TempFileNames(String tmpDir, String placeName, String inFileEnding, String outFileEnding) {
+    public TempFileNames(String tmpDir, String placeName, String inFileEnding, String outFileEnding) {
         base = Long.toString(System.nanoTime());
         tempDir = FileManipulator.mkTempFile(tmpDir, placeName);
         in = base + inFileEnding;


### PR DESCRIPTION
Unintentional oversight when it was first added.  No need for it to be package-private, and this change makes it more approachable when mocking Executrix interactions. 