### PR TITLE
Performance improvement for InputStreamChannelFactory.

### DIFF
--- a/src/main/java/emissary/core/channels/InputStreamChannelFactory.java
+++ b/src/main/java/emissary/core/channels/InputStreamChannelFactory.java
@@ -35,7 +35,7 @@ public class InputStreamChannelFactory {
             Validate.notNull(inputStreamFactory, "Required: inputStream not null");
 
             if (size < 0) {
-                long tempSize = -1;
+                long tempSize = SIZE_IS_UNKNOWN;
                 IOException tempIoException = null;
 
                 try (InputStream is = inputStreamFactory.create()) {

--- a/src/main/java/emissary/core/channels/InputStreamChannelFactory.java
+++ b/src/main/java/emissary/core/channels/InputStreamChannelFactory.java
@@ -34,6 +34,7 @@ public class InputStreamChannelFactory {
         public InputStreamChannelFactoryImpl(final long size, final InputStreamFactory inputStreamFactory) {
             Validate.notNull(inputStreamFactory, "Required: inputStream not null");
 
+            // If the size is unknown then calculate it and save any IOException that occurs.
             if (size < 0) {
                 long tempSize = SIZE_IS_UNKNOWN;
                 IOException tempIoException = null;

--- a/src/main/java/emissary/core/channels/InputStreamChannelFactory.java
+++ b/src/main/java/emissary/core/channels/InputStreamChannelFactory.java
@@ -98,7 +98,6 @@ public class InputStreamChannelFactory {
             if (inputStream == null) {
                 inputStream = BoundedInputStream.builder()
                         .setInputStream(inputStreamFactory.create())
-                        .setPropagateClose(false)
                         .get();
             }
 

--- a/src/main/java/emissary/core/channels/InputStreamChannelFactory.java
+++ b/src/main/java/emissary/core/channels/InputStreamChannelFactory.java
@@ -1,6 +1,6 @@
 package emissary.core.channels;
 
-import org.apache.commons.io.input.CountingInputStream;
+import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.lang3.Validate;
 
 import java.io.IOException;
@@ -27,18 +27,36 @@ public class InputStreamChannelFactory {
 
     private static class InputStreamChannelFactoryImpl implements SeekableByteChannelFactory {
         private final long size;
+        @Nullable
+        private final IOException ioException;
         private final InputStreamFactory inputStreamFactory;
 
         public InputStreamChannelFactoryImpl(final long size, final InputStreamFactory inputStreamFactory) {
             Validate.notNull(inputStreamFactory, "Required: inputStream not null");
 
-            this.size = size;
+            if (size < 0) {
+                long tempSize = -1;
+                IOException tempIoException = null;
+
+                try (InputStream is = inputStreamFactory.create()) {
+                    tempSize = SeekableByteChannelHelper.available(is);
+                } catch (IOException e) {
+                    tempIoException = e;
+                }
+
+                this.size = tempSize;
+                ioException = tempIoException;
+            } else {
+                this.size = size;
+                this.ioException = null;
+            }
+
             this.inputStreamFactory = inputStreamFactory;
         }
 
         @Override
         public SeekableByteChannel create() {
-            return new InputStreamChannel(size, inputStreamFactory);
+            return new InputStreamChannel(size, inputStreamFactory, ioException);
         }
     }
 
@@ -47,14 +65,14 @@ public class InputStreamChannelFactory {
          * The InputStreamFactory used to get InputStream instances.
          */
         private final InputStreamFactory inputStreamFactory;
+        private final long size;
+        private final IOException ioException;
 
         /**
          * The current InputStream instance.
          */
         @Nullable
-        private CountingInputStream inputStream;
-
-        private long size;
+        private BoundedInputStream inputStream;
 
         /**
          * Create a new InputStreamChannel instance with a fixed size and data source
@@ -62,35 +80,39 @@ public class InputStreamChannelFactory {
          * @param size of the InputStreamChannel
          * @param inputStreamFactory data source
          */
-        public InputStreamChannel(final long size, final InputStreamFactory inputStreamFactory) {
+        public InputStreamChannel(final long size, final InputStreamFactory inputStreamFactory, final IOException ioException) {
             Validate.notNull(inputStreamFactory, "Required: inputStreamFactory not null!");
+
             this.size = size;
             this.inputStreamFactory = inputStreamFactory;
+            this.ioException = ioException;
         }
 
         @Override
         protected final int readImpl(final ByteBuffer byteBuffer) throws IOException {
-            if (inputStream != null && position() < inputStream.getByteCount()) {
+            if (inputStream != null && position() < inputStream.getCount()) {
                 inputStream.close();
                 inputStream = null;
             }
 
             if (inputStream == null) {
-                inputStream = new CountingInputStream(inputStreamFactory.create());
+                inputStream = BoundedInputStream.builder()
+                        .setInputStream(inputStreamFactory.create())
+                        .setPropagateClose(false)
+                        .get();
             }
 
             // Actually perform the read
-            return SeekableByteChannelHelper.getFromInputStream(inputStream, byteBuffer, position() - inputStream.getByteCount());
+            return SeekableByteChannelHelper.getFromInputStream(inputStream, byteBuffer, position() - inputStream.getCount());
         }
 
 
         @Override
         protected long sizeImpl() throws IOException {
-            if (size < 0) {
-                try (InputStream is = inputStreamFactory.create()) {
-                    size = SeekableByteChannelHelper.available(is);
-                }
+            if (ioException != null) {
+                throw ioException;
             }
+
             return size;
         }
 

--- a/src/test/java/emissary/core/channels/InputStreamChannelFactoryTest.java
+++ b/src/test/java/emissary/core/channels/InputStreamChannelFactoryTest.java
@@ -12,6 +12,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.StandardCharsets;
 
+import static emissary.core.channels.InputStreamChannelFactory.SIZE_IS_UNKNOWN;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -153,6 +154,23 @@ class InputStreamChannelFactoryTest extends UnitTest {
             assertEquals(sbcLength, sbc.size());
             sbc.read(buff);
             assertEquals(sbcLength, buff.position());
+        }
+    }
+
+    @Test
+    void testExceptionInputStreamFactory() throws Exception {
+        final InputStreamFactory isf = new InputStreamFactory() {
+            @Override
+            public InputStream create() throws IOException {
+                throw new IOException("This InputStreamFactory only throws IOExceptions!");
+            }
+        };
+        final SeekableByteChannelFactory sbcf = InputStreamChannelFactory.create(SIZE_IS_UNKNOWN, isf);
+        final ByteBuffer byteBuffer = ByteBuffer.allocate(100);
+
+        try (SeekableByteChannel sbc = sbcf.create()) {
+            assertThrows(IOException.class, sbc::size);
+            assertThrows(IOException.class, () -> sbc.read(byteBuffer));
         }
     }
 }


### PR DESCRIPTION
This PR improves the performance of InputStreamChannelFactory by calculating the size of the InputStream once within the factory instead each time a SeekableByteChannel is created. Additionally, the deprecated CountingInputStream was replaced with BoundedInputStream.