### PR TITLE
Add optional RegressionTest encoders that always hash.

### DIFF
--- a/src/test/java/emissary/test/core/junit5/RegressionTest.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTest.java
@@ -242,7 +242,7 @@ public abstract class RegressionTest extends ExtractionTest {
      * @return a value optionally containing the generated hash
      */
     protected Optional<String> hashBytesIfNonPrintable(byte[] bytes, final boolean alwaysHash) {
-        if (alwaysHash || (ArrayUtils.isNotEmpty(bytes) && ByteUtil.containsNonIndexableBytes(bytes))) {
+        if (ArrayUtils.isNotEmpty(bytes) && (alwaysHash || ByteUtil.containsNonIndexableBytes(bytes))) {
             return Optional.ofNullable(ByteUtil.sha256Bytes(bytes));
         }
 


### PR DESCRIPTION
This PR adds an optional encoder set that will always hash SeekableByteChannels and alternate view byte arrays without regard to whether the data is "printable". They can be used by any class that extends RegressionTest by overriding the getEncoders() method and returning IBaseDataObjectXmlCodecs.ALWAYS_SHA256_ELEMENT_ENCODERS.