### PR TITLE
split service provider place up 

### DIFF
--- a/src/main/java/emissary/directory/DirectoryServiceProviderPlace.java
+++ b/src/main/java/emissary/directory/DirectoryServiceProviderPlace.java
@@ -1,0 +1,659 @@
+package emissary.directory;
+
+import emissary.config.Configurator;
+import emissary.core.EmissaryException;
+import emissary.core.IBaseDataObject;
+import emissary.core.Namespace;
+import emissary.place.IServiceProviderPlace;
+import emissary.server.EmissaryServer;
+import emissary.server.mvc.adapters.DirectoryAdapter;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+import static emissary.core.constants.Configurations.PLACE_NAME;
+import static emissary.core.constants.Configurations.SERVICE_COST;
+import static emissary.core.constants.Configurations.SERVICE_DESCRIPTION;
+import static emissary.core.constants.Configurations.SERVICE_KEY;
+import static emissary.core.constants.Configurations.SERVICE_NAME;
+import static emissary.core.constants.Configurations.SERVICE_PROXY;
+import static emissary.core.constants.Configurations.SERVICE_PROXY_DENY;
+import static emissary.core.constants.Configurations.SERVICE_QUALITY;
+import static emissary.core.constants.Configurations.SERVICE_TYPE;
+
+/**
+ * Concrete instances of ServiceProviderPlace can be created by the emissary.admin.PlaceStarter and registered with the
+ * emissary.directory.IDirectoryPlace to make their respective services available and a specified cost and quality
+ * throughout the system.
+ */
+public abstract class DirectoryServiceProviderPlace implements IServiceProviderPlace {
+
+    /**
+     * A <i><b>local</b></i> reference to the directory that this place resides in. Every JVM that contains 'places' must
+     * have a local directory
+     *
+     * @see DirectoryPlace
+     */
+    @Nullable
+    protected String dirPlace;
+    @Nullable
+    protected IDirectoryPlace localDirPlace = null;
+
+    /**
+     * set of keys for this place read from configG. Each of the values defined by
+     * SERVICE_PROXY.SERCVICE_TYPE.SERVICE_NAME.PLACE_LOCATION$EXPENSE from the config file or KEY values from the config
+     * file.
+     */
+    protected List<String> keys = new ArrayList<>();
+
+    /**
+     * List of denied places in SERVICE_PROXY_DENY
+     */
+    protected List<String> denyList = new ArrayList<>();
+
+    // Items that are going to be deprecated, but here now to
+    // make the transition easier, for compatibility
+    @Nullable
+    protected String myKey = null;
+    protected int serviceCost = -1;
+    protected int serviceQuality = -1;
+    @Nullable
+    protected String placeName = null;
+
+    /**
+     * Text description of what the place does, usually from config file
+     */
+    @Nullable
+    protected String serviceDescription;
+
+    protected String placeLocation;
+
+    /**
+     * Dynamic context logger uses run-time classname as category
+     */
+    protected Logger logger;
+
+    private static final String UNUSED_PROXY = "UNUSABLE-XyZZy";
+
+    protected abstract Configurator getConfigurator();
+
+    /**
+     * Help the constructor get the place running
+     *
+     * @param theDir name of our directory
+     */
+    protected void setupPlace(@Nullable String theDir, String placeLocation) throws IOException {
+
+        // Customize the logger to the runtime class
+        logger = LoggerFactory.getLogger(this.getClass());
+
+        // The order of the following initialization calls
+        // is touchy. NPE all over if you mess up here.
+
+        // Set ServicePlace config items
+        configureServicePlace(placeLocation);
+
+        // Backwards compatibility setup items
+        DirectoryEntry firstentry = new DirectoryEntry(keys.get(0));
+        myKey = firstentry.getKey();
+        serviceCost = firstentry.getCost();
+        serviceQuality = firstentry.getQuality();
+        placeName = firstentry.getServiceLocation();
+
+
+        // configure directory references
+        if (!(this instanceof DirectoryPlace)) {
+            localizeDirectory(theDir);
+            logger.debug("Our localizedDirectory is {}", dirPlace);
+        } else {
+            logger.debug("Not localizing directory since we are a directory");
+        }
+
+        // Bind to the namespace before registering
+        // our keys. This allows incoming traffic to find
+        // us as soon as they see the keys
+        for (String key : keys) {
+            String bindKey = KeyManipulator.getServiceLocation(key);
+            logger.debug("Binding myself into the namespace as {}", bindKey);
+            Namespace.bind(bindKey, this);
+        }
+
+        // Register with the directory
+        // This pushes all our keys out to the directory which
+        // sends them on in turn to peers, &c. in the p2p network
+        register();
+
+    }
+
+    /**
+     * Get a local reference to the directory.
+     *
+     * @param theDir key for the directory to use, if null will look up default name
+     * @return true if it worked
+     */
+    private boolean localizeDirectory(@Nullable String theDir) {
+        // Get a local (non proxy) copy of the directory if possible!
+        // Looking up both if nothing is provided
+        if (theDir == null) {
+            try {
+                localDirPlace = DirectoryPlace.lookup();
+                dirPlace = localDirPlace.toString();
+            } catch (EmissaryException ex) {
+                if (EmissaryServer.exists() && !(this instanceof DirectoryPlace)) {
+                    logger.warn("Unable to find DirectoryPlace in local namespace", ex);
+                    return false;
+                }
+            }
+        } else {
+            dirPlace = theDir;
+            localDirPlace = null;
+            try {
+                String myUrl = KeyManipulator.getServiceHostUrl(keys.get(0));
+                String dirUrl = KeyManipulator.getServiceHostUrl(dirPlace);
+                if (StringUtils.equals(dirUrl, myUrl)) {
+                    localDirPlace = (IDirectoryPlace) Namespace.lookup(KeyManipulator.getServiceLocation(theDir));
+                } else {
+                    logger.debug("Not localizing directory since dirPlace {} is not equal to myUrl {}", dirPlace, myUrl);
+                }
+            } catch (EmissaryException ex) {
+                logger.error("Exception attempting to get local reference to directory", ex);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Set the logger to use, allows easier mocking among other things
+     *
+     * @param l the logger instance to use
+     */
+    public void setLogger(Logger l) {
+        this.logger = l;
+    }
+
+    /**
+     * Return an encapsulation of our key and cost structure Only good for the top key on the list
+     *
+     * @return a DirectoryEntry for this place
+     */
+    @Override
+    public DirectoryEntry getDirectoryEntry() {
+        return new DirectoryEntry(keys.get(0), serviceDescription, serviceCost, serviceQuality);
+    }
+
+    /**
+     * Configuration items read here are:
+     *
+     * <ul>
+     * <li>PLACE_NAME: place name portion of key, required</li>
+     * <li>SERVICE_NAME: service name portion of key, required</li>
+     * <li>SERVICE_TYPE: service type portion of key, required</li>
+     * <li>SERVICE_DESCRIPTION: description of place, required</li>
+     * <li>SERVICE_COST: cost of service provided, required</li>
+     * <li>SERVICE_QUALITY: quality of service provided, required</li>
+     * <li>SERVICE_PROXY: list of service proxy types for key</li>
+     * <li>SERVICE_KEY: full 4 part keys with expense</li>
+     * </ul>
+     *
+     * @param placeLocation the specified placeLocation or a full four part key to register with
+     */
+    protected void configureServicePlace(@Nullable String placeLocation) throws IOException {
+        Configurator configG = getConfigurator();
+        serviceDescription = configG.findStringEntry(SERVICE_DESCRIPTION);
+        if (serviceDescription == null || serviceDescription.length() == 0) {
+            serviceDescription = "Description not available";
+        }
+
+        if (placeLocation == null) {
+            placeLocation = this.getClass().getSimpleName();
+        }
+
+        String locationPart = placeLocation;
+        if (KeyManipulator.isKeyComplete(placeLocation)) {
+            keys.add(placeLocation); // save as first in list
+            locationPart = KeyManipulator.getServiceLocation(placeLocation);
+        } else if (!placeLocation.contains("://")) {
+            EmissaryNode node = new EmissaryNode();
+            locationPart = "http://" + node.getNodeName() + ":" + node.getNodePort() + "/" + placeLocation;
+        }
+
+
+        // Build keys the old fashioned way from parts specified in the config
+        String placeName = configG.findStringEntry(PLACE_NAME);
+        String serviceName = configG.findStringEntry(SERVICE_NAME);
+        String serviceType = configG.findStringEntry(SERVICE_TYPE);
+        int serviceCost = configG.findIntEntry(SERVICE_COST, -1);
+        int serviceQuality = configG.findIntEntry(SERVICE_QUALITY, -1);
+
+        // Bah.
+        if (placeName != null && placeName.length() == 0) {
+            placeName = null;
+        }
+        if (serviceName != null && serviceName.length() == 0) {
+            serviceName = null;
+        }
+        if (serviceType != null && serviceType.length() == 0) {
+            serviceType = null;
+        }
+
+        if (placeName != null && serviceName != null && serviceType != null && serviceCost > -1 && serviceQuality > -1) {
+            // pick up the proxies(save full 4-tuple keys!)
+            for (String sp : configG.findEntries(SERVICE_PROXY)) {
+                DirectoryEntry de = new DirectoryEntry(sp, serviceName, serviceType, locationPart, serviceDescription, serviceCost, serviceQuality);
+                keys.add(de.getFullKey());
+            }
+            // pick up the denied proxies(save full 4-tuple keys!)
+            for (String sp : configG.findEntries(SERVICE_PROXY_DENY)) {
+                DirectoryEntry de = new DirectoryEntry(sp, serviceName, serviceType, locationPart, serviceDescription, serviceCost, serviceQuality);
+                denyList.add(de.getDataType());
+            }
+        } else {
+            // May be configured the new way, but warn if there is a mixture of
+            // null and non-null items using the old-fashioned way. Perhaps the
+            // user just missed one of them
+            int nullCount = 0;
+            if (placeName == null) {
+                nullCount++;
+            }
+            if (serviceName == null) {
+                nullCount++;
+            }
+            if (serviceType == null) {
+                nullCount++;
+            }
+            if (serviceCost == -1) {
+                nullCount++;
+            }
+            if (serviceQuality == -1) {
+                nullCount++;
+            }
+
+            if (nullCount > 0 && nullCount < 5) {
+                throw new IOException(
+                        "Missing configuration items. Please check SERVICE_NAME, SERVICE_TYPE, PLACE_NAME, SERVICE_COST, SERVICE_QUALITY");
+
+            }
+        }
+
+        // Now build any keys the new way
+        for (String k : configG.findEntries(SERVICE_KEY)) {
+            if (KeyManipulator.isKeyComplete(k)) {
+                keys.add(k);
+            } else {
+                logger.warn("SERVICE_KEY '{}' is missing parts and cannot be used", k);
+            }
+        }
+
+        // Make sure some keys were defined one way or the other
+        if (keys.isEmpty()) {
+            throw new IOException("NO keys were defined. Please configure at least one "
+                    + "SERVICE_KEY or SERVICE_NAME/SERVICE_TYPE/SERVICE_PROXY group");
+        }
+    }
+
+    /**
+     * Delegate nextKey to our directory
+     *
+     * @param dataId key to entryMap in directory, dataType::serviceType
+     * @param lastEntry place agent visited last, this is not stateless
+     * @return List of DirectoryEntry with next places to go
+     */
+    @Override
+    @Nullable
+    public List<DirectoryEntry> nextKeys(final String dataId, final IBaseDataObject payload, final DirectoryEntry lastEntry) {
+        if (localDirPlace != null) {
+            return localDirPlace.nextKeys(dataId, payload, lastEntry);
+        }
+        logger.error("No local directory in place {} with dir={}", keys.get(0), dirPlace);
+        return null;
+    }
+
+    /**
+     * Convenience method a lot of places use. Removes all items from the current form stack that this place has proxies for
+     *
+     * @param d a data object whose current form will be expunged of my proxies
+     * @return count of how many items removed
+     */
+    protected int nukeMyProxies(IBaseDataObject d) {
+        List<String> nukem = new ArrayList<>();
+        int sz = d.currentFormSize();
+        Set<String> serviceProxies = getProxies();
+
+        if (serviceProxies.contains("*")) {
+            d.replaceCurrentForm(null); // clear it out
+            return sz;
+        }
+
+        // listem
+        for (int i = 0; i < sz; i++) {
+            String form = d.currentFormAt(i);
+            if (serviceProxies.contains(form)) {
+                nukem.add(form);
+            } else {
+                // cardem
+                WildcardEntry wc = new WildcardEntry(form);
+                if (!Collections.disjoint(wc.asSet(), serviceProxies)) {
+                    nukem.add(form);
+                }
+            }
+        }
+
+        // nukem
+        for (String f : nukem) {
+            int pos = d.searchCurrentForm(f);
+            if (pos != -1) {
+                d.deleteCurrentFormAt(pos);
+            }
+        }
+
+        return nukem.size();
+    }
+
+    /**
+     * Return a set of the service proxies
+     *
+     * @return set of string values
+     */
+    @Override
+    public Set<String> getProxies() {
+        Set<String> s = new TreeSet<>();
+        for (String k : keys) {
+            s.add(KeyManipulator.getDataType(k));
+        }
+        s.remove(UNUSED_PROXY);
+        return s;
+    }
+
+    /**
+     * Get the keys that this place instance is registered with
+     */
+    @Override
+    public Set<String> getKeys() {
+        Set<String> s = new TreeSet<>();
+        for (String k : keys) {
+            if (!k.startsWith(UNUSED_PROXY)) {
+                s.add(k);
+            }
+        }
+        return s;
+    }
+
+    /**
+     * Return the first service proxy on the list
+     *
+     * @return SERVICE_PROXY value from first key on list
+     */
+    @Override
+    public String getPrimaryProxy() {
+        String s = KeyManipulator.getDataType(keys.get(0));
+        if (s.equals(UNUSED_PROXY)) {
+            s = "";
+        }
+        return s;
+    }
+
+
+    /**
+     * Key for string form
+     */
+    @Override
+    public String toString() {
+        return keys.get(0) + "[" + keys.size() + "]";
+    }
+
+    /**
+     * Fulfill IServiceProviderPlace
+     */
+    @Override
+    public String getKey() {
+        return KeyManipulator.removeExpense(keys.get(0));
+    }
+
+    /**
+     * Add a service proxy to a running place. Duplicates are ignored.
+     *
+     * @param serviceProxy the new proxy string to add
+     */
+    @Override
+    public void addServiceProxy(String serviceProxy) {
+        // Add new one to the top key in the list
+        DirectoryEntry de = new DirectoryEntry(keys.get(0));
+        boolean keyAdded = false;
+        if (!de.getDataType().equals(serviceProxy)) {
+            // Clear out the placeholder
+            if (de.getDataType().equals(UNUSED_PROXY)) {
+                keys.remove(0);
+            }
+
+            de.setDataType(serviceProxy);
+
+            if (!keys.contains(de.getFullKey())) {
+                keys.add(de.getFullKey());
+
+                // Register the new proxy in the directory
+                logger.debug("Registering new key {}", de.getKey());
+                register(de.getFullKey());
+                keyAdded = true;
+            }
+        }
+
+        if (!keyAdded) {
+            logger.debug("Duplicate service proxy {} ignored", serviceProxy);
+        }
+    }
+
+    /**
+     * Add another key to the place
+     *
+     * @param key the key to add
+     */
+    @Override
+    public void addKey(String key) {
+        if (KeyManipulator.isValid(key)) {
+            DirectoryEntry de = new DirectoryEntry(keys.get(0));
+            if (de.getDataType().equals(UNUSED_PROXY)) {
+                keys.remove(0);
+            }
+
+            logger.debug("Adding and registering new key {}", key);
+            keys.add(key);
+            register(key);
+        } else {
+            logger.warn("Invalid key cannot be added: {}", key);
+        }
+    }
+
+    /**
+     * Register a single service proxy key
+     *
+     * @param key the new key to register
+     */
+    protected void register(String key) {
+        logger.debug("Registering key {}", key);
+        // Cannot register if we have no directory
+        // If we are the directory, its no problem though
+        if (dirPlace == null) {
+            if (!(this instanceof IDirectoryPlace)) {
+                logger.debug("Directory is null: cannot register anything. Illegal configuration.");
+            }
+            return;
+        }
+
+        // Register place and all proxies by building up a list
+        // of our interests to send to the directory
+        List<String> keylist = new ArrayList<>();
+        keylist.add(key);
+        registerWithDirectory(keylist);
+    }
+
+    /**
+     * Register our interest in all of our serviceProxies Sends only one message to the directory to cover all service
+     * proxies (a scalability issue for large systems)
+     */
+    protected void register() {
+        logger.debug("Registering: {}", this);
+
+        // Cannot register if we have no directory
+        // If we are the directory, its no problem though
+        if (dirPlace == null) {
+            if (!(this instanceof IDirectoryPlace)) {
+                logger.debug("Directory is null: cannot register anything. Illegal configuration.");
+            }
+            return;
+        }
+
+        // Register place and all proxies by building up a list
+        // of our current interests to send to the directory
+        registerWithDirectory(new ArrayList<>(keys));
+    }
+
+    /**
+     * Register keys with the directory
+     *
+     * @param keylist the keys to register
+     */
+    protected void registerWithDirectory(List<String> keylist) {
+        try {
+            if (localDirPlace == null) {
+                // This should never happen, we require a local
+                // directory on every JVM...
+                logger.error("Key registration requires a DirectoryPlace in every Emissary Node");
+            } else {
+                logger.debug("Registering my {} keys {}", keylist.size(), keylist);
+                localDirPlace.addPlaces(keylist);
+            }
+        } catch (RuntimeException e) {
+            logger.warn("Register ERROR for keys {}", keylist, e);
+        }
+    }
+
+
+    /**
+     * Deregister keys from the directory
+     *
+     * @param keys the keys to register
+     */
+    protected void deregisterFromDirectory(List<String> keys) {
+        try {
+            if (localDirPlace == null && dirPlace != null) {
+                // This should never happen, we require a local
+                // directory on every JVM...
+                logger.debug("Deregistering my {} proxies {} from remote dir {}", keys.size(), keys, dirPlace);
+                DirectoryAdapter da = new DirectoryAdapter();
+                da.outboundRemovePlaces(dirPlace, keys, false);
+            } else if (localDirPlace != null) {
+                logger.debug("Deregistering my {} proxies {}", keys.size(), keys);
+                localDirPlace.removePlaces(keys);
+            }
+        } catch (RuntimeException e) {
+            logger.warn("Deregister ERROR keys={}", keys, e);
+        }
+    }
+
+    /**
+     * Remove a service proxy from the running place. Proxy strings not found registered will be ignored Will remove all
+     * keys that match the supplied proxy
+     *
+     * @param serviceProxy the proxy string to remove
+     */
+    @Override
+    public void removeServiceProxy(String serviceProxy) {
+        // List of keys to deregister
+        List<String> keylist = new ArrayList<>();
+
+        // nb. no enhanced for loop due to remove
+        for (Iterator<String> i = keys.iterator(); i.hasNext();) {
+            String k = i.next();
+            String kproxy = KeyManipulator.getDataType(k);
+            if (kproxy.equals(serviceProxy)) {
+                keylist.add(KeyManipulator.removeExpense(k));
+                i.remove();
+            }
+        }
+        if (!keylist.isEmpty()) {
+            deregisterFromDirectory(keylist);
+        } else {
+            logger.debug("Unknown service proxy {} ignored", serviceProxy);
+        }
+
+        // Make sure we leave something on the keys list
+        if (keys.isEmpty() && !keylist.isEmpty()) {
+            DirectoryEntry de = new DirectoryEntry(keylist.get(0));
+            de.setCost(serviceCost);
+            de.setQuality(serviceQuality);
+            de.setDataType(UNUSED_PROXY);
+            keys.add(de.getFullKey());
+        }
+    }
+
+    /**
+     * Remove and deregister a key
+     *
+     * @param key the full key (with expense) to deregister
+     */
+    @Override
+    public void removeKey(String key) {
+        String keyWithOutExpense = KeyManipulator.removeExpense(key);
+
+        if (keys.remove(key)) {
+            List<String> keylist = new ArrayList<>();
+            keylist.add(keyWithOutExpense);
+            deregisterFromDirectory(keylist);
+
+            if (keys.isEmpty()) {
+                DirectoryEntry de = new DirectoryEntry(key);
+                de.setDataType(UNUSED_PROXY);
+                keys.add(de.getFullKey());
+            }
+        } else {
+            logger.debug("Key specified for removal not found: {}", key);
+        }
+    }
+
+    /**
+     * Stop all threads if any. Can be overridden by, deregister from directory, and remove from the namespace. derived
+     * classes if needed
+     */
+    @Override
+    public void shutDown() {
+        logger.debug("Called shutDown()");
+
+        // Remove from directory a list of keys without expense
+        deregisterFromDirectory(keys.stream().map(KeyManipulator::removeExpense).collect(Collectors.toList()));
+
+        // Unbind from namespace
+        unbindFromNamespace();
+    }
+
+    protected void unbindFromNamespace() {
+        keys.stream().map(KeyManipulator::getServiceLocation).forEach(Namespace::unbind);
+    }
+
+    /**
+     * Return the place name
+     *
+     * @return string key of this place
+     */
+    @Override
+    public String getPlaceName() {
+        return KeyManipulator.getServiceClassname(keys.get(0));
+    }
+
+    @Override
+    public boolean isDenied(String s) {
+        return denyList.contains(s);
+    }
+
+}

--- a/src/main/java/emissary/place/ServiceProviderPlace.java
+++ b/src/main/java/emissary/place/ServiceProviderPlace.java
@@ -1,9 +1,7 @@
 package emissary.place;
 
 import emissary.config.ConfigEntry;
-import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
-import emissary.core.EmissaryException;
 import emissary.core.Family;
 import emissary.core.Form;
 import emissary.core.HDMobileAgent;
@@ -13,21 +11,13 @@ import emissary.core.Namespace;
 import emissary.core.NamespaceException;
 import emissary.core.ResourceException;
 import emissary.core.ResourceWatcher;
-import emissary.directory.DirectoryEntry;
-import emissary.directory.DirectoryPlace;
-import emissary.directory.EmissaryNode;
-import emissary.directory.IDirectoryPlace;
-import emissary.directory.KeyManipulator;
-import emissary.directory.WildcardEntry;
+import emissary.directory.DirectoryServiceProviderPlace;
 import emissary.kff.KffDataObjectHandler;
 import emissary.log.MDCConstants;
 import emissary.parser.SessionParser;
-import emissary.server.EmissaryServer;
-import emissary.server.mvc.adapters.DirectoryAdapter;
 import emissary.util.JMXUtil;
 
 import com.codahale.metrics.Timer;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -37,31 +27,17 @@ import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
-import static emissary.core.constants.Configurations.PLACE_NAME;
 import static emissary.core.constants.Configurations.PLACE_RESOURCE_LIMIT_MILLIS;
-import static emissary.core.constants.Configurations.SERVICE_COST;
-import static emissary.core.constants.Configurations.SERVICE_DESCRIPTION;
-import static emissary.core.constants.Configurations.SERVICE_KEY;
-import static emissary.core.constants.Configurations.SERVICE_NAME;
-import static emissary.core.constants.Configurations.SERVICE_PROXY;
-import static emissary.core.constants.Configurations.SERVICE_PROXY_DENY;
-import static emissary.core.constants.Configurations.SERVICE_QUALITY;
-import static emissary.core.constants.Configurations.SERVICE_TYPE;
 
 /**
  * Concrete instances of ServiceProviderPlace can be created by the emissary.admin.PlaceStarter and registered with the
  * emissary.directory.IDirectoryPlace to make their respective services available and a specified cost and quality
  * throughout the system.
  */
-public abstract class ServiceProviderPlace implements IServiceProviderPlace,
-        ServiceProviderPlaceMBean {
+public abstract class ServiceProviderPlace extends DirectoryServiceProviderPlace implements IServiceProviderPlace, ServiceProviderPlaceMBean {
 
     /**
      * Container for all configuration parameters read from the configuration file for this place. The net result is that
@@ -73,61 +49,15 @@ public abstract class ServiceProviderPlace implements IServiceProviderPlace,
     protected Configurator configG;
 
     /**
-     * A <i><b>local</b></i> reference to the directory that this place resides in. Every JVM that contains 'places' must
-     * have a local directory
-     *
-     * @see emissary.directory.DirectoryPlace
-     */
-    @Nullable
-    protected String dirPlace;
-    @Nullable
-    protected IDirectoryPlace localDirPlace = null;
-
-    /**
-     * set of keys for this place read from configG. Each of the values defined by
-     * SERVICE_PROXY.SERCVICE_TYPE.SERVICE_NAME.PLACE_LOCATION$EXPENSE from the config file or KEY values from the config
-     * file.
-     */
-    protected List<String> keys = new ArrayList<>();
-
-    /**
-     * List of denied places in SERVICE_PROXY_DENY
-     */
-    protected List<String> denyList = new ArrayList<>();
-
-    // Items that are going to be deprecated, but here now to
-    // make the transition easier, for compatibility
-    @Nullable
-    protected String myKey = null;
-    protected int serviceCost = -1;
-    protected int serviceQuality = -1;
-    @Nullable
-    protected String placeName = null;
-
-    /**
-     * Text description of what the place does, usually from config file
-     */
-    @Nullable
-    protected String serviceDescription;
-
-    /**
      * Static context logger
      */
     protected static final Logger slogger = LoggerFactory.getLogger(ServiceProviderPlace.class);
-
-    /**
-     * Dynamic context logger uses run-time classname as category
-     */
-    protected Logger logger;
 
     /**
      * Set up handler for rehashing
      */
     @Nullable
     protected KffDataObjectHandler kff = null;
-
-    private static final String DOT = ".";
-    private static final String UNUSED_PROXY = "UNUSABLE-XyZZy";
 
     /**
      * These are used to track process vs processHD implementations to know whether one can proxy for the other one
@@ -218,53 +148,9 @@ public abstract class ServiceProviderPlace implements IServiceProviderPlace,
         this(configStream, null, placeLocation);
     }
 
-    /**
-     * Load the configurator
-     *
-     * @param configStream the stream to use or null to auto configure
-     */
-    protected Configurator loadConfigurator(@Nullable InputStream configStream, String placeLocation) throws IOException {
-        // Read the configuration stream
-        if (configStream != null) {
-            // Use supplied stream
-            return ConfigUtil.getConfigInfo(configStream);
-        }
-        return loadConfigurator(placeLocation);
-    }
-
-    /**
-     * Load the configurator
-     *
-     * @param configFileName the file name to use or null to auto configure
-     */
-    protected Configurator loadConfigurator(@Nullable String configFileName, String placeLocation) throws IOException {
-        // Read the configuration stream
-        if (configFileName != null) {
-            // Use supplied stream
-            return ConfigUtil.getConfigInfo(configFileName);
-        }
-        return loadConfigurator(placeLocation);
-    }
-
-    /**
-     * Load the configurator, figuring out whence automatically
-     */
-    protected Configurator loadConfigurator(@Nullable String placeLocation) throws IOException {
-        if (placeLocation == null) {
-            placeLocation = this.getClass().getSimpleName();
-        }
-
-        // Extract config data stream name from place location
-        // and try finding config info with and without the
-        // package name of this class (in that order)
-        String myPackage = this.getClass().getPackage().getName();
-        List<String> configLocs = new ArrayList<>();
-        // Dont use KeyManipulator for this, only works when hostname/fqdn has dots
-        int pos = placeLocation.lastIndexOf("/");
-        String serviceClass = pos > -1 ? placeLocation.substring(pos + 1) : placeLocation;
-        configLocs.add(myPackage + DOT + serviceClass + ConfigUtil.CONFIG_FILE_ENDING);
-        configLocs.add(serviceClass + ConfigUtil.CONFIG_FILE_ENDING);
-        return ConfigUtil.getConfigInfo(configLocs);
+    @Override
+    protected Configurator getConfigurator() {
+        return this.configG;
     }
 
     /**
@@ -272,51 +158,14 @@ public abstract class ServiceProviderPlace implements IServiceProviderPlace,
      *
      * @param theDir name of our directory
      */
+    @Override
     protected void setupPlace(@Nullable String theDir, String placeLocation) throws IOException {
-
-        // Customize the logger to the runtime class
-        logger = LoggerFactory.getLogger(this.getClass());
-
-        // The order of the following initialization calls
-        // is touchy. NPE all over if you mess up here.
-
-        // Set ServicePlace config items
-        configureServicePlace(placeLocation);
-
-        // Backwards compatibility setup items
-        DirectoryEntry firstentry = new DirectoryEntry(keys.get(0));
-        myKey = firstentry.getKey();
-        serviceCost = firstentry.getCost();
-        serviceQuality = firstentry.getQuality();
-        placeName = firstentry.getServiceLocation();
-
-
-        // configure directory references
-        if (!(this instanceof DirectoryPlace)) {
-            localizeDirectory(theDir);
-            logger.debug("Our localizedDirectory is {}", dirPlace);
-        } else {
-            logger.debug("Not localizing directory since we are a directory");
-        }
+        super.setupPlace(theDir, placeLocation);
 
         // Set up kff if we need it
         if (this instanceof RehashingPlace || this instanceof MultiFileServerPlace) {
             initKff();
         }
-
-        // Bind to the namespace before registering
-        // our keys. This allows incoming traffic to find
-        // us as soon as they see the keys
-        for (String key : keys) {
-            String bindKey = KeyManipulator.getServiceLocation(key);
-            logger.debug("Binding myself into the namespace as {}", bindKey);
-            Namespace.bind(bindKey, this);
-        }
-
-        // Register with the directory
-        // This pushes all our keys out to the directory which
-        // sends them on in turn to peers, &c. in the p2p network
-        register();
 
         // register MBean with JMX
         JMXUtil.registerMBean(this);
@@ -326,195 +175,12 @@ public abstract class ServiceProviderPlace implements IServiceProviderPlace,
     }
 
     /**
-     * Get a local reference to the directory.
-     *
-     * @param theDir key for the directory to use, if null will look up default name
-     * @return true if it worked
-     */
-    private boolean localizeDirectory(@Nullable String theDir) {
-        // Get a local (non-proxy) copy of the directory if possible!
-        // Looking up both if nothing is provided
-        if (theDir == null) {
-            try {
-                localDirPlace = DirectoryPlace.lookup();
-                dirPlace = localDirPlace.toString();
-            } catch (EmissaryException ex) {
-                if (EmissaryServer.getInstance().isServerRunning() && !(this instanceof DirectoryPlace)) {
-                    logger.warn("Unable to find DirectoryPlace in local namespace", ex);
-                    return false;
-                }
-            }
-        } else {
-            dirPlace = theDir;
-            localDirPlace = null;
-            try {
-                String myUrl = KeyManipulator.getServiceHostUrl(keys.get(0));
-                String dirUrl = KeyManipulator.getServiceHostUrl(dirPlace);
-                if (StringUtils.equals(dirUrl, myUrl)) {
-                    localDirPlace = (IDirectoryPlace) Namespace.lookup(KeyManipulator.getServiceLocation(theDir));
-                } else {
-                    logger.debug("Not localizing directory since dirPlace {} is not equal to myUrl {}", dirPlace, myUrl);
-                }
-            } catch (EmissaryException ex) {
-                logger.error("Exception attempting to get local reference to directory", ex);
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
      * Initialize the Kff Handler with our policy settings
      */
     protected synchronized void initKff() {
         kff =
                 new KffDataObjectHandler(KffDataObjectHandler.TRUNCATE_KNOWN_DATA, KffDataObjectHandler.SET_FORM_WHEN_KNOWN,
                         KffDataObjectHandler.SET_FILE_TYPE);
-    }
-
-    /**
-     * Set the logger to use, allows easier mocking among other things
-     *
-     * @param l the logger instance to use
-     */
-    public void setLogger(Logger l) {
-        this.logger = l;
-    }
-
-    /**
-     * Return an encapsulation of our key and cost structure Only good for the top key on the list
-     *
-     * @return a DirectoryEntry for this place
-     */
-    @Override
-    public DirectoryEntry getDirectoryEntry() {
-        return new DirectoryEntry(keys.get(0), serviceDescription, serviceCost, serviceQuality);
-    }
-
-    /**
-     * Configuration items read here are:
-     *
-     * <ul>
-     * <li>PLACE_NAME: place name portion of key, required</li>
-     * <li>SERVICE_NAME: service name portion of key, required</li>
-     * <li>SERVICE_TYPE: service type portion of key, required</li>
-     * <li>SERVICE_DESCRIPTION: description of place, required</li>
-     * <li>SERVICE_COST: cost of service provided, required</li>
-     * <li>SERVICE_QUALITY: quality of service provided, required</li>
-     * <li>SERVICE_PROXY: list of service proxy types for key</li>
-     * <li>SERVICE_KEY: full 4 part keys with expense</li>
-     * </ul>
-     *
-     * @param placeLocation the specified placeLocation or a full four part key to register with
-     */
-    protected void configureServicePlace(@Nullable String placeLocation) throws IOException {
-        serviceDescription = configG.findStringEntry(SERVICE_DESCRIPTION);
-        if (serviceDescription == null || serviceDescription.length() == 0) {
-            serviceDescription = "Description not available";
-        }
-
-        if (placeLocation == null) {
-            placeLocation = this.getClass().getSimpleName();
-        }
-
-        String locationPart = placeLocation;
-        if (KeyManipulator.isKeyComplete(placeLocation)) {
-            keys.add(placeLocation); // save as first in list
-            locationPart = KeyManipulator.getServiceLocation(placeLocation);
-        } else if (!placeLocation.contains("://")) {
-            EmissaryNode node = EmissaryServer.getInstance().getNode();
-            locationPart = "http://" + node.getNodeName() + ":" + node.getNodePort() + "/" + placeLocation;
-        }
-
-
-        // Build keys the old fashioned way from parts specified in the config
-        String placeName = configG.findStringEntry(PLACE_NAME);
-        String serviceName = configG.findStringEntry(SERVICE_NAME);
-        String serviceType = configG.findStringEntry(SERVICE_TYPE);
-        int serviceCost = configG.findIntEntry(SERVICE_COST, -1);
-        int serviceQuality = configG.findIntEntry(SERVICE_QUALITY, -1);
-
-        // Bah.
-        if (placeName != null && placeName.length() == 0) {
-            placeName = null;
-        }
-        if (serviceName != null && serviceName.length() == 0) {
-            serviceName = null;
-        }
-        if (serviceType != null && serviceType.length() == 0) {
-            serviceType = null;
-        }
-
-        if (placeName != null && serviceName != null && serviceType != null && serviceCost > -1 && serviceQuality > -1) {
-            // pick up the proxies(save full 4-tuple keys!)
-            for (String sp : configG.findEntries(SERVICE_PROXY)) {
-                DirectoryEntry de = new DirectoryEntry(sp, serviceName, serviceType, locationPart, serviceDescription, serviceCost, serviceQuality);
-                keys.add(de.getFullKey());
-            }
-            // pick up the denied proxies(save full 4-tuple keys!)
-            for (String sp : configG.findEntries(SERVICE_PROXY_DENY)) {
-                DirectoryEntry de = new DirectoryEntry(sp, serviceName, serviceType, locationPart, serviceDescription, serviceCost, serviceQuality);
-                denyList.add(de.getDataType());
-            }
-        } else {
-            // May be configured the new way, but warn if there is a mixture of
-            // null and non-null items using the old-fashioned way. Perhaps the
-            // user just missed one of them
-            int nullCount = 0;
-            if (placeName == null) {
-                nullCount++;
-            }
-            if (serviceName == null) {
-                nullCount++;
-            }
-            if (serviceType == null) {
-                nullCount++;
-            }
-            if (serviceCost == -1) {
-                nullCount++;
-            }
-            if (serviceQuality == -1) {
-                nullCount++;
-            }
-
-            if (nullCount > 0 && nullCount < 5) {
-                throw new IOException(
-                        "Missing configuration items. Please check SERVICE_NAME, SERVICE_TYPE, PLACE_NAME, SERVICE_COST, SERVICE_QUALITY");
-
-            }
-        }
-
-        // Now build any keys the new way
-        for (String k : configG.findEntries(SERVICE_KEY)) {
-            if (KeyManipulator.isKeyComplete(k)) {
-                keys.add(k);
-            } else {
-                logger.warn("SERVICE_KEY '{}' is missing parts and cannot be used", k);
-            }
-        }
-
-        // Make sure some keys were defined one way or the other
-        if (keys.isEmpty()) {
-            throw new IOException("NO keys were defined. Please configure at least one "
-                    + "SERVICE_KEY or SERVICE_NAME/SERVICE_TYPE/SERVICE_PROXY group");
-        }
-    }
-
-    /**
-     * Delegate nextKey to our directory
-     *
-     * @param dataId key to entryMap in directory, dataType::serviceType
-     * @param lastEntry place agent visited last, this is not stateless
-     * @return List of DirectoryEntry with next places to go
-     */
-    @Override
-    @Nullable
-    public List<DirectoryEntry> nextKeys(final String dataId, final IBaseDataObject payload, final DirectoryEntry lastEntry) {
-        if (localDirPlace != null) {
-            return localDirPlace.nextKeys(dataId, payload, lastEntry);
-        }
-        logger.error("No local directory in place {} with dir={}", keys.get(0), dirPlace);
-        return null;
     }
 
     /**
@@ -684,338 +350,6 @@ public abstract class ServiceProviderPlace implements IServiceProviderPlace,
     }
 
     /**
-     * Convenience method a lot of places use. Removes all items from the current form stack that this place has proxies for
-     *
-     * @param d a data object whose current form will be expunged of my proxies
-     * @return count of how many items removed
-     */
-    protected int nukeMyProxies(IBaseDataObject d) {
-        List<String> nukem = new ArrayList<>();
-        int sz = d.currentFormSize();
-        Set<String> serviceProxies = getProxies();
-
-        if (serviceProxies.contains("*")) {
-            d.replaceCurrentForm(null); // clear it out
-            return sz;
-        }
-
-        // listem
-        for (int i = 0; i < sz; i++) {
-            String form = d.currentFormAt(i);
-            if (serviceProxies.contains(form)) {
-                nukem.add(form);
-            } else {
-                // cardem
-                WildcardEntry wc = new WildcardEntry(form);
-                if (!Collections.disjoint(wc.asSet(), serviceProxies)) {
-                    nukem.add(form);
-                }
-            }
-        }
-
-        // nukem
-        for (String f : nukem) {
-            int pos = d.searchCurrentForm(f);
-            if (pos != -1) {
-                d.deleteCurrentFormAt(pos);
-            }
-        }
-
-        return nukem.size();
-    }
-
-    /**
-     * Return a set of the service proxies
-     *
-     * @return set of string values
-     */
-    @Override
-    public Set<String> getProxies() {
-        Set<String> s = new TreeSet<>();
-        for (String k : keys) {
-            s.add(KeyManipulator.getDataType(k));
-        }
-        s.remove(UNUSED_PROXY);
-        return s;
-    }
-
-    /**
-     * Get the keys that this place instance is registered with
-     */
-    @Override
-    public Set<String> getKeys() {
-        Set<String> s = new TreeSet<>();
-        for (String k : keys) {
-            if (!k.startsWith(UNUSED_PROXY)) {
-                s.add(k);
-            }
-        }
-        return s;
-    }
-
-    /**
-     * Return the first service proxy on the list
-     *
-     * @return SERVICE_PROXY value from first key on list
-     */
-    @Override
-    public String getPrimaryProxy() {
-        String s = KeyManipulator.getDataType(keys.get(0));
-        if (s.equals(UNUSED_PROXY)) {
-            s = "";
-        }
-        return s;
-    }
-
-
-    /**
-     * Key for string form
-     */
-    @Override
-    public String toString() {
-        return keys.get(0) + "[" + keys.size() + "]";
-    }
-
-    /**
-     * Fulfill IServiceProviderPlace
-     */
-    @Override
-    public String getKey() {
-        return KeyManipulator.removeExpense(keys.get(0));
-    }
-
-    /**
-     * Add a service proxy to a running place. Duplicates are ignored.
-     *
-     * @param serviceProxy the new proxy string to add
-     */
-    @Override
-    public void addServiceProxy(String serviceProxy) {
-        // Add new one to the top key in the list
-        DirectoryEntry de = new DirectoryEntry(keys.get(0));
-        boolean keyAdded = false;
-        if (!de.getDataType().equals(serviceProxy)) {
-            // Clear out the placeholder
-            if (de.getDataType().equals(UNUSED_PROXY)) {
-                keys.remove(0);
-            }
-
-            de.setDataType(serviceProxy);
-
-            if (!keys.contains(de.getFullKey())) {
-                keys.add(de.getFullKey());
-
-                // Register the new proxy in the directory
-                logger.debug("Registering new key {}", de.getKey());
-                register(de.getFullKey());
-                keyAdded = true;
-            }
-        }
-
-        if (!keyAdded) {
-            logger.debug("Duplicate service proxy {} ignored", serviceProxy);
-        }
-    }
-
-    /**
-     * Add another key to the place
-     *
-     * @param key the key to add
-     */
-    @Override
-    public void addKey(String key) {
-        if (KeyManipulator.isValid(key)) {
-            DirectoryEntry de = new DirectoryEntry(keys.get(0));
-            if (de.getDataType().equals(UNUSED_PROXY)) {
-                keys.remove(0);
-            }
-
-            logger.debug("Adding and registering new key {}", key);
-            keys.add(key);
-            register(key);
-        } else {
-            logger.warn("Invalid key cannot be added: {}", key);
-        }
-    }
-
-    /**
-     * Register a single service proxy key
-     *
-     * @param key the new key to register
-     */
-    protected void register(String key) {
-        logger.debug("Registering key {}", key);
-        // Cannot register if we have no directory
-        // If we are the directory, its no problem though
-        if (dirPlace == null) {
-            if (!(this instanceof IDirectoryPlace)) {
-                logger.debug("Directory is null: cannot register anything. Illegal configuration.");
-            }
-            return;
-        }
-
-        // Register place and all proxies by building up a list
-        // of our interests to send to the directory
-        List<String> keylist = new ArrayList<>();
-        keylist.add(key);
-        registerWithDirectory(keylist);
-    }
-
-    /**
-     * Register our interest in all of our serviceProxies Sends only one message to the directory to cover all service
-     * proxies (a scalability issue for large systems)
-     */
-    protected void register() {
-        logger.debug("Registering: {}", this);
-
-        // Cannot register if we have no directory
-        // If we are the directory, its no problem though
-        if (dirPlace == null) {
-            if (!(this instanceof IDirectoryPlace)) {
-                logger.debug("Directory is null: cannot register anything. Illegal configuration.");
-            }
-            return;
-        }
-
-        // Register place and all proxies by building up a list
-        // of our current interests to send to the directory
-        registerWithDirectory(new ArrayList<>(keys));
-    }
-
-    /**
-     * Register keys with the directory
-     *
-     * @param keylist the keys to register
-     */
-    protected void registerWithDirectory(List<String> keylist) {
-        try {
-            if (localDirPlace == null) {
-                // This should never happen, we require a local
-                // directory on every JVM...
-                logger.error("Key registration requires a DirectoryPlace in every Emissary Node");
-            } else {
-                logger.debug("Registering my {} keys {}", keylist.size(), keylist);
-                localDirPlace.addPlaces(keylist);
-            }
-        } catch (RuntimeException e) {
-            logger.warn("Register ERROR for keys {}", keylist, e);
-        }
-    }
-
-
-    /**
-     * Deregister keys from the directory
-     *
-     * @param keys the keys to register
-     */
-    protected void deregisterFromDirectory(List<String> keys) {
-        try {
-            if (localDirPlace == null && dirPlace != null) {
-                // This should never happen, we require a local
-                // directory on every JVM...
-                logger.debug("Deregistering my {} proxies {} from remote dir {}", keys.size(), keys, dirPlace);
-                DirectoryAdapter da = new DirectoryAdapter();
-                da.outboundRemovePlaces(dirPlace, keys, false);
-            } else if (localDirPlace != null) {
-                logger.debug("Deregistering my {} proxies {}", keys.size(), keys);
-                localDirPlace.removePlaces(keys);
-            }
-        } catch (RuntimeException e) {
-            logger.warn("Deregister ERROR keys={}", keys, e);
-        }
-    }
-
-
-    /**
-     * Remove a service proxy from the running place. Proxy strings not found registered will be ignored Will remove all
-     * keys that match the supplied proxy
-     *
-     * @param serviceProxy the proxy string to remove
-     */
-    @Override
-    public void removeServiceProxy(String serviceProxy) {
-        // List of keys to deregister
-        List<String> keylist = new ArrayList<>();
-
-        // nb. no enhanced for loop due to remove
-        for (Iterator<String> i = keys.iterator(); i.hasNext();) {
-            String k = i.next();
-            String kproxy = KeyManipulator.getDataType(k);
-            if (kproxy.equals(serviceProxy)) {
-                keylist.add(KeyManipulator.removeExpense(k));
-                i.remove();
-            }
-        }
-        if (!keylist.isEmpty()) {
-            deregisterFromDirectory(keylist);
-        } else {
-            logger.debug("Unknown service proxy {} ignored", serviceProxy);
-        }
-
-        // Make sure we leave something on the keys list
-        if (keys.isEmpty() && !keylist.isEmpty()) {
-            DirectoryEntry de = new DirectoryEntry(keylist.get(0));
-            de.setCost(serviceCost);
-            de.setQuality(serviceQuality);
-            de.setDataType(UNUSED_PROXY);
-            keys.add(de.getFullKey());
-        }
-    }
-
-    /**
-     * Remove and deregister a key
-     *
-     * @param key the full key (with expense) to deregister
-     */
-    @Override
-    public void removeKey(String key) {
-        String keyWithOutExpense = KeyManipulator.removeExpense(key);
-
-        if (keys.remove(key)) {
-            List<String> keylist = new ArrayList<>();
-            keylist.add(keyWithOutExpense);
-            deregisterFromDirectory(keylist);
-
-            if (keys.isEmpty()) {
-                DirectoryEntry de = new DirectoryEntry(key);
-                de.setDataType(UNUSED_PROXY);
-                keys.add(de.getFullKey());
-            }
-        } else {
-            logger.debug("Key specified for removal not found: {}", key);
-        }
-    }
-
-    /**
-     * Stop all threads if any. Can be overridden by, deregister from directory, and remove from the namespace. derived
-     * classes if needed
-     */
-    @Override
-    public void shutDown() {
-        logger.debug("Called shutDown()");
-
-        // Remove from directory a list of keys without expense
-        deregisterFromDirectory(keys.stream().map(KeyManipulator::removeExpense).collect(Collectors.toList()));
-
-        // Unbind from namespace
-        unbindFromNamespace();
-    }
-
-    protected void unbindFromNamespace() {
-        keys.stream().map(KeyManipulator::getServiceLocation).forEach(Namespace::unbind);
-    }
-
-    /**
-     * Return the place name
-     *
-     * @return string key of this place
-     */
-    @Override
-    public String getPlaceName() {
-        return KeyManipulator.getServiceClassname(keys.get(0));
-    }
-
-    /**
      * Get custom resource limitation in millis if specified
      *
      * @return -2 if not specified, or long millis if specified
@@ -1118,11 +452,6 @@ public abstract class ServiceProviderPlace implements IServiceProviderPlace,
 
         // Nothing found?
         return null;
-    }
-
-    @Override
-    public boolean isDenied(String s) {
-        return denyList.contains(s);
     }
 
     /**


### PR DESCRIPTION
…into classes that load framework specific configs vs place specific confs

The main idea is to be able to create a place and not have it register as a directory entry. We should have a mechanism that should be able to create the place and then register it independently. This way, if we need to recreate/refresh the place, we do not interfere with the framework routing -- that can be handled separately. This is step one to split up the framework code from the place code. This pr aims to split the two ideas into distinct abstract classes while still being backwards compatible. Upon integration, there should be no changes to the current output. 