### PR TITLE
adding analyze goal to maven-dependency-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1130,6 +1130,16 @@
         <version>${plugin.maven-dependency.version}</version>
         <executions>
           <execution>
+            <id>analyze</id>
+            <goals>
+              <goal>analyze-only</goal>
+            </goals>
+            <configuration>
+              <ignoreNonCompile>true</ignoreNonCompile>
+              <failOnWarning>false</failOnWarning>
+            </configuration>
+          </execution>
+          <execution>
             <goals>
               <goal>unpack</goal>
             </goals>


### PR DESCRIPTION
This analyzes the project to find dependencies that are: used and declared; used and undeclared; unused and declared. This check occurs during the `verify` lifecycle phase for maven.

I have it set to currently **NOT** fail on warnings (and this obviously can be changed).
Can also be made to ignore certain groups of warnings (for example, https://maven.apache.org/plugins/maven-dependency-plugin/analyze-only-mojo.html#ignoredusedundeclareddependencies) or individual warnings for dependencies.