### PR TITLE
add ability to check ID_LIKE for ubuntu in OSReleaseUtil

### DIFF
--- a/src/main/java/emissary/util/os/OSReleaseUtil.java
+++ b/src/main/java/emissary/util/os/OSReleaseUtil.java
@@ -92,7 +92,7 @@ public class OSReleaseUtil {
         return isOsName(osReleasePath, "rhel");
     }
 
-    // // checks against ID in /etc/os-release
+    // checks against ID in /etc/os-release
     private static boolean isOsName(Path osReleasePath, String osName) {
         if (Files.exists(osReleasePath)) {
             try (Stream<String> lines = Files.lines(osReleasePath)) {

--- a/src/main/java/emissary/util/os/OSReleaseUtil.java
+++ b/src/main/java/emissary/util/os/OSReleaseUtil.java
@@ -63,7 +63,7 @@ public class OSReleaseUtil {
     }
 
     static boolean isUbuntu(Path osReleasePath) {
-        return isOsName(osReleasePath, "ubuntu");
+        return isOsName(osReleasePath, "ubuntu") || isOsLike(osReleasePath, "ubuntu");
     }
 
     /**
@@ -92,15 +92,23 @@ public class OSReleaseUtil {
         return isOsName(osReleasePath, "rhel");
     }
 
+    // // checks against ID in /etc/os-release
     private static boolean isOsName(Path osReleasePath, String osName) {
         if (Files.exists(osReleasePath)) {
             try (Stream<String> lines = Files.lines(osReleasePath)) {
-                if (osName.equals("ubuntu")) {
-                    return lines.filter(line -> line.startsWith("ID=") || line.startsWith("ID_LIKE="))
-                            .anyMatch(entry -> StringUtils.containsIgnoreCase(entry, osName));
-                } else {
-                    return lines.filter(line -> line.startsWith("ID=")).anyMatch(entry -> StringUtils.containsIgnoreCase(entry, osName));
-                }
+                return lines.filter(line -> line.startsWith("ID=")).anyMatch(entry -> StringUtils.containsIgnoreCase(entry, osName));
+            } catch (IOException ignored) {
+                // ignore
+            }
+        }
+        return false;
+    }
+
+    // checks against ID_LIKE in /etc/os-release
+    private static boolean isOsLike(Path osReleasePath, String osName) {
+        if (Files.exists(osReleasePath)) {
+            try (Stream<String> lines = Files.lines(osReleasePath)) {
+                return lines.filter(line -> line.startsWith("ID_LIKE=")).anyMatch(entry -> StringUtils.containsIgnoreCase(entry, osName));
             } catch (IOException ignored) {
                 // ignore
             }

--- a/src/main/java/emissary/util/os/OSReleaseUtil.java
+++ b/src/main/java/emissary/util/os/OSReleaseUtil.java
@@ -95,7 +95,12 @@ public class OSReleaseUtil {
     private static boolean isOsName(Path osReleasePath, String osName) {
         if (Files.exists(osReleasePath)) {
             try (Stream<String> lines = Files.lines(osReleasePath)) {
-                return lines.filter(line -> line.startsWith("ID=")).anyMatch(entry -> StringUtils.containsIgnoreCase(entry, osName));
+                if (osName.equals("ubuntu")) {
+                    return lines.filter(line -> line.startsWith("ID=") || line.startsWith("ID_LIKE="))
+                            .anyMatch(entry -> StringUtils.containsIgnoreCase(entry, osName));
+                } else {
+                    return lines.filter(line -> line.startsWith("ID=")).anyMatch(entry -> StringUtils.containsIgnoreCase(entry, osName));
+                }
             } catch (IOException ignored) {
                 // ignore
             }

--- a/src/test/java/emissary/util/os/OSReleaseUtilTest.java
+++ b/src/test/java/emissary/util/os/OSReleaseUtilTest.java
@@ -19,6 +19,8 @@ class OSReleaseUtilTest {
     static Path rhel8Path;
     @SuppressWarnings("NonFinalStaticField")
     static Path ubuntu20Path;
+    @SuppressWarnings("NonFinalStaticField")
+    static Path pop22Path;
 
     @BeforeAll
     static void getResources() throws Exception {
@@ -27,6 +29,7 @@ class OSReleaseUtilTest {
         centos7Path = Path.of(rr.getResource(rr.getResourceName(OSReleaseUtil.class.getPackage(), "centos7")).toURI());
         rhel8Path = Path.of(rr.getResource(rr.getResourceName(OSReleaseUtil.class.getPackage(), "rhel8")).toURI());
         ubuntu20Path = Path.of(rr.getResource(rr.getResourceName(OSReleaseUtil.class.getPackage(), "ubuntu20")).toURI());
+        pop22Path = Path.of(rr.getResource(rr.getResourceName(OSReleaseUtil.class.getPackage(), "pop22")).toURI());
     }
 
     @Test
@@ -34,6 +37,7 @@ class OSReleaseUtilTest {
         assertEquals("7", OSReleaseUtil.getVersionId(centos7Path));
         assertEquals("8.10", OSReleaseUtil.getVersionId(rhel8Path));
         assertEquals("20.04", OSReleaseUtil.getVersionId(ubuntu20Path));
+        assertEquals("22.04", OSReleaseUtil.getVersionId(pop22Path));
     }
 
     @Test
@@ -41,6 +45,7 @@ class OSReleaseUtilTest {
         assertEquals("7", OSReleaseUtil.getMajorReleaseVersion(centos7Path));
         assertEquals("8", OSReleaseUtil.getMajorReleaseVersion(rhel8Path));
         assertEquals("20", OSReleaseUtil.getMajorReleaseVersion(ubuntu20Path));
+        assertEquals("22", OSReleaseUtil.getMajorReleaseVersion(pop22Path));
     }
 
     @Test
@@ -48,6 +53,7 @@ class OSReleaseUtilTest {
         assertFalse(OSReleaseUtil.isUbuntu(centos7Path));
         assertFalse(OSReleaseUtil.isUbuntu(rhel8Path));
         assertTrue(OSReleaseUtil.isUbuntu(ubuntu20Path));
+        assertTrue(OSReleaseUtil.isUbuntu(pop22Path));
     }
 
     @Test
@@ -55,6 +61,7 @@ class OSReleaseUtilTest {
         assertTrue(OSReleaseUtil.isCentOs(centos7Path));
         assertFalse(OSReleaseUtil.isCentOs(rhel8Path));
         assertFalse(OSReleaseUtil.isCentOs(ubuntu20Path));
+        assertFalse(OSReleaseUtil.isCentOs(pop22Path));
     }
 
     @Test
@@ -62,5 +69,6 @@ class OSReleaseUtilTest {
         assertFalse(OSReleaseUtil.isRhel(centos7Path));
         assertTrue(OSReleaseUtil.isRhel(rhel8Path));
         assertFalse(OSReleaseUtil.isRhel(ubuntu20Path));
+        assertFalse(OSReleaseUtil.isCentOs(pop22Path));
     }
 }

--- a/src/test/java/emissary/util/os/OSReleaseUtilTest.java
+++ b/src/test/java/emissary/util/os/OSReleaseUtilTest.java
@@ -69,6 +69,6 @@ class OSReleaseUtilTest {
         assertFalse(OSReleaseUtil.isRhel(centos7Path));
         assertTrue(OSReleaseUtil.isRhel(rhel8Path));
         assertFalse(OSReleaseUtil.isRhel(ubuntu20Path));
-        assertFalse(OSReleaseUtil.isCentOs(pop22Path));
+        assertFalse(OSReleaseUtil.isRhel(pop22Path));
     }
 }

--- a/src/test/resources/emissary/util/os/pop22
+++ b/src/test/resources/emissary/util/os/pop22
@@ -1,0 +1,13 @@
+NAME="Pop!_OS"
+VERSION="22.04 LTS"
+ID=pop
+ID_LIKE="ubuntu debian"
+PRETTY_NAME="Pop!_OS 22.04 LTS"
+VERSION_ID="22.04"
+HOME_URL="https://pop.system76.com"
+SUPPORT_URL="https://support.system76.com"
+BUG_REPORT_URL="https://github.com/pop-os/pop/issues"
+PRIVACY_POLICY_URL="https://system76.com/privacy"
+VERSION_CODENAME=jammy
+UBUNTU_CODENAME=jammy
+LOGO=distributor-logo-pop-os


### PR DESCRIPTION
done for the scenario where ubuntu is not the ID of the OS, but the `ID_LIKE=ubuntu` (see src/test/resources/emissary/util/os/pop22 for example)