### PR TITLE
adding ability to ExtractionTest to have OS specific answers in test answer files

### DIFF
--- a/src/test/java/emissary/test/core/junit5/ExtractionTest.java
+++ b/src/test/java/emissary/test/core/junit5/ExtractionTest.java
@@ -19,7 +19,6 @@ import org.jdom2.DataConversionException;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -55,17 +54,18 @@ public abstract class ExtractionTest extends UnitTest {
                     KffDataObjectHandler.SET_FILE_TYPE);
     @Nullable
     protected IServiceProviderPlace place = null;
-    @SuppressWarnings("NonFinalStaticField")
-    private static String systemOsRelease = "";
+    @Nullable
+    private static final String SYSTEM_OS_RELEASE;
 
-    @BeforeAll
-    public static void setSystemOsInfo() {
+    static {
         if (OSReleaseUtil.isUbuntu()) {
-            systemOsRelease = "ubuntu";
+            SYSTEM_OS_RELEASE = "ubuntu";
         } else if (OSReleaseUtil.isCentOs()) {
-            systemOsRelease = "centos";
+            SYSTEM_OS_RELEASE = "centos";
         } else if (OSReleaseUtil.isRhel()) {
-            systemOsRelease = "rhel";
+            SYSTEM_OS_RELEASE = "rhel";
+        } else {
+            SYSTEM_OS_RELEASE = null;
         }
     }
 
@@ -433,7 +433,7 @@ public abstract class ExtractionTest extends UnitTest {
                 case "ubuntu":
                 case "centos":
                 case "rhel":
-                    return os.equals(systemOsRelease);
+                    return os.equals(SYSTEM_OS_RELEASE);
                 default:
                     fail("specified OS needs to match ubuntu, centos, or rhel. Provided OS=" + os);
             }

--- a/src/test/java/emissary/test/core/junit5/ExtractionTest.java
+++ b/src/test/java/emissary/test/core/junit5/ExtractionTest.java
@@ -54,6 +54,8 @@ public abstract class ExtractionTest extends UnitTest {
                     KffDataObjectHandler.SET_FILE_TYPE);
     @Nullable
     protected IServiceProviderPlace place = null;
+    @SuppressWarnings("NonFinalStaticField")
+    private static String systemOsRelease = "";
 
     @BeforeEach
     public void setUpPlace() throws Exception {
@@ -417,11 +419,23 @@ public abstract class ExtractionTest extends UnitTest {
             String os = specifiedOs.getValue();
             switch (os) {
                 case "ubuntu":
-                    return OSReleaseUtil.isUbuntu();
+                    if (systemOsRelease.isEmpty() && OSReleaseUtil.isUbuntu()) {
+                        systemOsRelease = "ubuntu";
+                        return true;
+                    }
+                    return os.equals(systemOsRelease);
                 case "centos":
-                    return OSReleaseUtil.isCentOs();
+                    if (systemOsRelease.isEmpty() && OSReleaseUtil.isCentOs()) {
+                        systemOsRelease = "centos";
+                        return true;
+                    }
+                    return os.equals(systemOsRelease);
                 case "rhel":
-                    return OSReleaseUtil.isRhel();
+                    if (systemOsRelease.isEmpty() && OSReleaseUtil.isRhel()) {
+                        systemOsRelease = "rhel";
+                        return true;
+                    }
+                    return os.equals(systemOsRelease);
                 default:
                     fail("specified OS needs to match ubuntu, centos, or rhel. Provided OS=" + os);
             }

--- a/src/test/java/emissary/test/core/junit5/ExtractionTest.java
+++ b/src/test/java/emissary/test/core/junit5/ExtractionTest.java
@@ -19,6 +19,7 @@ import org.jdom2.DataConversionException;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -56,6 +57,17 @@ public abstract class ExtractionTest extends UnitTest {
     protected IServiceProviderPlace place = null;
     @SuppressWarnings("NonFinalStaticField")
     private static String systemOsRelease = "";
+
+    @BeforeAll
+    public static void setSystemOsInfo() {
+        if (OSReleaseUtil.isUbuntu()) {
+            systemOsRelease = "ubuntu";
+        } else if (OSReleaseUtil.isCentOs()) {
+            systemOsRelease = "centos";
+        } else if (OSReleaseUtil.isRhel()) {
+            systemOsRelease = "rhel";
+        }
+    }
 
     @BeforeEach
     public void setUpPlace() throws Exception {
@@ -419,22 +431,8 @@ public abstract class ExtractionTest extends UnitTest {
             String os = specifiedOs.getValue();
             switch (os) {
                 case "ubuntu":
-                    if (systemOsRelease.isEmpty() && OSReleaseUtil.isUbuntu()) {
-                        systemOsRelease = "ubuntu";
-                        return true;
-                    }
-                    return os.equals(systemOsRelease);
                 case "centos":
-                    if (systemOsRelease.isEmpty() && OSReleaseUtil.isCentOs()) {
-                        systemOsRelease = "centos";
-                        return true;
-                    }
-                    return os.equals(systemOsRelease);
                 case "rhel":
-                    if (systemOsRelease.isEmpty() && OSReleaseUtil.isRhel()) {
-                        systemOsRelease = "rhel";
-                        return true;
-                    }
                     return os.equals(systemOsRelease);
                 default:
                     fail("specified OS needs to match ubuntu, centos, or rhel. Provided OS=" + os);

--- a/src/test/resources/emissary/test/core/junit5/OsSpecificTest.xml
+++ b/src/test/resources/emissary/test/core/junit5/OsSpecificTest.xml
@@ -1,0 +1,27 @@
+<result>
+    <answers>
+        <dataLength os-release="ubuntu">22</dataLength>
+        <dataLength os-release="centos">51</dataLength>
+        <dataLength os-release="rhel">20</dataLength>
+        
+        <meta matchMode="equals">
+            <name>Test</name>
+            <value>Test</value>
+        </meta>
+        <meta matchMode="equals" os-release="ubuntu">
+            <name>ubuntu-test</name>
+            <value>ubuntu-test</value>
+        </meta>
+        <meta matchMode="equals" os-release="centos">
+            <name>centos-test</name>
+            <value>centos-test</value>
+        </meta>
+        <meta matchMode="equals" os-release="rhel">
+            <name>rhel-test</name>
+            <value>rhel-test</value>
+        </meta>>
+        <data matchMode="contains" os-release="FAKE-OS">
+            <value>this should not be checked</value>
+        </data>
+    </answers>
+</result>


### PR DESCRIPTION
This adds the ability to have specific `os-release` attributes in answer file elements so they will only be checked on that specified OS. If not, that element will not be checked in ExtractionTest's `checkAnswers()` method.

The current elements this `verifyOS()` check is applied to are:
- dataLength
- meta
- nometa
- data
- view
- noview

(Had to alter the original `dataLength` check, because the old check did not assume multiple dataLength tags in the answer file. With this we are assuming data lengths could be different across different OS, meaning multiple tags _could_ be possible)