### PR TITLE
Reverse New/Old IBDO output to match input order in PlaceComparisonHelper.

### DIFF
--- a/src/main/java/emissary/util/PlaceComparisonHelper.java
+++ b/src/main/java/emissary/util/PlaceComparisonHelper.java
@@ -130,10 +130,8 @@ public class PlaceComparisonHelper {
         try {
             ibdoForOldPlace.deleteParameter(DisposeHelper.KEY);
             ibdoForNewPlace.deleteParameter(DisposeHelper.KEY);
-            IBaseDataObjectDiffHelper.diff(ibdoForNewPlace, ibdoForOldPlace, parentDifferences,
-                    options);
-            IBaseDataObjectDiffHelper.diff(newResults, oldResults, identifier, childDifferences,
-                    options);
+            IBaseDataObjectDiffHelper.diff(ibdoForOldPlace, ibdoForNewPlace, parentDifferences, options);
+            IBaseDataObjectDiffHelper.diff(oldResults, newResults, identifier, childDifferences, options);
         } finally {
             // Make sure we put the runnables back on if an error occurs during the diff
             ibdoForOldPlace.setParameter(DisposeHelper.KEY, oldRunnables);

--- a/src/test/java/emissary/place/ComparisonPlaceTest.java
+++ b/src/test/java/emissary/place/ComparisonPlaceTest.java
@@ -59,14 +59,14 @@ class ComparisonPlaceTest extends UnitTest {
 
     @Test
     void testProcessPlaceAChanges() throws Exception {
-        final String logMessage = "COMPARISONPLACETEST: PDiff: meta are not equal-Differing Keys: [KEY] : []";
+        final String logMessage = "COMPARISONPLACETEST: PDiff: meta are not equal-Differing Keys: [] : [KEY]";
 
         testComparisonPlace(PROCESS_PLACE_A_CHANGES, logMessage);
     }
 
     @Test
     void testProcessPlaceBChanges() throws Exception {
-        final String logMessage = "COMPARISONPLACETEST: PDiff: meta are not equal-Differing Keys: [] : [KEY]";
+        final String logMessage = "COMPARISONPLACETEST: PDiff: meta are not equal-Differing Keys: [KEY] : []";
 
         testComparisonPlace(PROCESS_PLACE_B_CHANGES, logMessage);
     }
@@ -78,16 +78,16 @@ class ComparisonPlaceTest extends UnitTest {
 
     @Test
     void testProcessHDPlaceAChanges() throws Exception {
-        final String logMessage = "COMPARISONPLACETEST: PDiff: meta are not equal-Differing Keys: [KEY] : []\n" +
-                "COMPARISONPLACETEST: CDiff: COMPARISONPLACETEST : 0 : meta are not equal-Differing Keys: [KEY] : []";
+        final String logMessage = "COMPARISONPLACETEST: PDiff: meta are not equal-Differing Keys: [] : [KEY]\n" +
+                "COMPARISONPLACETEST: CDiff: COMPARISONPLACETEST : 0 : meta are not equal-Differing Keys: [] : [KEY]";
 
         testComparisonPlace(PROCESSHD_PLACE_A_CHANGES, logMessage);
     }
 
     @Test
     void testProcessHDPlaceBChanges() throws Exception {
-        final String logMessage = "COMPARISONPLACETEST: PDiff: meta are not equal-Differing Keys: [] : [KEY]\n" +
-                "COMPARISONPLACETEST: CDiff: COMPARISONPLACETEST : 0 : meta are not equal-Differing Keys: [] : [KEY]";
+        final String logMessage = "COMPARISONPLACETEST: PDiff: meta are not equal-Differing Keys: [KEY] : []\n" +
+                "COMPARISONPLACETEST: CDiff: COMPARISONPLACETEST : 0 : meta are not equal-Differing Keys: [KEY] : []";
 
         testComparisonPlace(PROCESSHD_PLACE_B_CHANGES, logMessage);
     }


### PR DESCRIPTION
I noticed that the New/Old output order for PlaceComparisonHelper was reversed compared to the input order. This PR makes them match.