### PR TITLE
allow RegressionTest getEncoders/getDecoders to vary per "resource"

### DIFF
--- a/src/test/java/emissary/test/core/junit5/RegressionTest.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTest.java
@@ -147,8 +147,19 @@ public abstract class RegressionTest extends ExtractionTest {
      * 
      * @return the XML element decoders.
      */
+    @Deprecated
     protected ElementDecoders getDecoders() {
         return IBaseDataObjectXmlCodecs.DEFAULT_ELEMENT_DECODERS;
+    }
+
+    /**
+     * This method returns the XML element decoders.
+     * 
+     * @param resource the "resource" currently be tested.
+     * @return the XML element decoders.
+     */
+    protected ElementDecoders getDecoders(final String resource) {
+        return getDecoders();
     }
 
     /**
@@ -156,8 +167,19 @@ public abstract class RegressionTest extends ExtractionTest {
      * 
      * @return the XML element encoders.
      */
+    @Deprecated
     protected ElementEncoders getEncoders() {
         return IBaseDataObjectXmlCodecs.SHA256_ELEMENT_ENCODERS;
+    }
+
+    /**
+     * This method returns the XML element encoders.
+     * 
+     * @param resource the "resource" currently be tested.
+     * @return the XML element encoders.
+     */
+    protected ElementEncoders getEncoders(final String resource) {
+        return getEncoders();
     }
 
     /**
@@ -175,7 +197,7 @@ public abstract class RegressionTest extends ExtractionTest {
             checkAnswersPreHookLogEvents(actualSimplifiedLogEvents);
         }
 
-        if (!IBaseDataObjectXmlCodecs.SHA256_ELEMENT_ENCODERS.equals(getEncoders())) {
+        if (!IBaseDataObjectXmlCodecs.SHA256_ELEMENT_ENCODERS.equals(getEncoders(tname))) {
             return;
         }
 
@@ -301,7 +323,7 @@ public abstract class RegressionTest extends ExtractionTest {
         tweakFinalLogEventsBeforeSerialisation(resource, finalLogEvents);
 
         // Generate the full XML (setup & answers from before & after)
-        RegressionTestUtil.writeAnswerXml(resource, initialIbdo, finalIbdo, finalResults, finalLogEvents, getEncoders(),
+        RegressionTestUtil.writeAnswerXml(resource, initialIbdo, finalIbdo, finalResults, finalLogEvents, getEncoders(resource),
                 super.answerFileClassRef);
     }
 
@@ -331,13 +353,13 @@ public abstract class RegressionTest extends ExtractionTest {
 
     @Override
     protected void setupPayload(final IBaseDataObject payload, final Document answers) {
-        RegressionTestUtil.setupPayload(payload, answers, getDecoders());
+        RegressionTestUtil.setupPayload(payload, answers, getDecoders(payload.getFilename()));
     }
 
     @Override
     protected void checkAnswers(final Document answers, final IBaseDataObject payload,
             final List<IBaseDataObject> attachments, final String tname) {
-        RegressionTestUtil.checkAnswers(answers, payload, actualSimplifiedLogEvents, attachments, place.getClass().getName(), getDecoders(),
+        RegressionTestUtil.checkAnswers(answers, payload, actualSimplifiedLogEvents, attachments, place.getClass().getName(), getDecoders(tname),
                 generateAnswers());
     }
 }

--- a/src/test/java/emissary/test/core/junit5/RegressionTest.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTest.java
@@ -149,8 +149,19 @@ public abstract class RegressionTest extends ExtractionTest {
      * 
      * @return the XML element decoders.
      */
+    @Deprecated
     protected ElementDecoders getDecoders() {
         return DEFAULT_ELEMENT_DECODERS;
+    }
+
+    /**
+     * This method returns the XML element decoders.
+     * 
+     * @param resource the "resource" currently be tested.
+     * @return the XML element decoders.
+     */
+    protected ElementDecoders getDecoders(final String resource) {
+        return getDecoders();
     }
 
     /**
@@ -158,8 +169,19 @@ public abstract class RegressionTest extends ExtractionTest {
      * 
      * @return the XML element encoders.
      */
+    @Deprecated
     protected ElementEncoders getEncoders() {
         return SHA256_ELEMENT_ENCODERS;
+    }
+
+    /**
+     * This method returns the XML element encoders.
+     * 
+     * @param resource the "resource" currently be tested.
+     * @return the XML element encoders.
+     */
+    protected ElementEncoders getEncoders(final String resource) {
+        return getEncoders();
     }
 
     /**
@@ -179,9 +201,9 @@ public abstract class RegressionTest extends ExtractionTest {
 
         final boolean alwaysHash;
 
-        if (SHA256_ELEMENT_ENCODERS.equals(getEncoders())) {
+        if (SHA256_ELEMENT_ENCODERS.equals(getEncoders(tname))) {
             alwaysHash = false;
-        } else if (ALWAYS_SHA256_ELEMENT_ENCODERS.equals(getEncoders())) {
+        } else if (ALWAYS_SHA256_ELEMENT_ENCODERS.equals(getEncoders(tname))) {
             alwaysHash = true;
         } else {
             return;
@@ -310,7 +332,7 @@ public abstract class RegressionTest extends ExtractionTest {
         tweakFinalLogEventsBeforeSerialisation(resource, finalLogEvents);
 
         // Generate the full XML (setup & answers from before & after)
-        RegressionTestUtil.writeAnswerXml(resource, initialIbdo, finalIbdo, finalResults, finalLogEvents, getEncoders(),
+        RegressionTestUtil.writeAnswerXml(resource, initialIbdo, finalIbdo, finalResults, finalLogEvents, getEncoders(resource),
                 super.answerFileClassRef);
     }
 
@@ -340,13 +362,13 @@ public abstract class RegressionTest extends ExtractionTest {
 
     @Override
     protected void setupPayload(final IBaseDataObject payload, final Document answers) {
-        RegressionTestUtil.setupPayload(payload, answers, getDecoders());
+        RegressionTestUtil.setupPayload(payload, answers, getDecoders(payload.getFilename()));
     }
 
     @Override
     protected void checkAnswers(final Document answers, final IBaseDataObject payload,
             final List<IBaseDataObject> attachments, final String tname) {
-        RegressionTestUtil.checkAnswers(answers, payload, actualSimplifiedLogEvents, attachments, place.getClass().getName(), getDecoders(),
+        RegressionTestUtil.checkAnswers(answers, payload, actualSimplifiedLogEvents, attachments, place.getClass().getName(), getDecoders(tname),
                 generateAnswers());
     }
 }


### PR DESCRIPTION
This PR adds the actual "resource" (i.e. test file) being tested to the getEncoders()/getDecoders() calls.  This allows classes extending RegressionTest and overriding getEncoders()/getDecoders() to know which "resource" is being tested and return different Encoders/Decoders for different "resources". The methods without the "resource" parameter are deprecated for future deletion.