### PR TITLE
resourcewatcher :: add configurable actions to places that hit a max time limit

### DIFF
--- a/src/main/java/emissary/core/TimedResource.java
+++ b/src/main/java/emissary/core/TimedResource.java
@@ -1,11 +1,14 @@
 package emissary.core;
 
 import emissary.place.IServiceProviderPlace;
+import emissary.server.EmissaryServer;
 
 import com.codahale.metrics.Timer;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.ReentrantLock;
 import javax.annotation.Nullable;
 
@@ -22,8 +25,10 @@ public class TimedResource implements AutoCloseable {
     private final IMobileAgent agent;
     private final int payloadCount;
     private final long allowedDuration;
+    private final long maxAllowedDuration;
     private final String placeName;
     private final long started;
+    private final Action action;
 
     @Nullable
     private final Timer.Context timerContext;
@@ -36,6 +41,8 @@ public class TimedResource implements AutoCloseable {
         isClosed = true;
         started = -1;
         allowedDuration = -1;
+        maxAllowedDuration = -1;
+        action = Action.NOTIFY;
         agent = null;
         payloadCount = -1;
         placeName = "NOOP";
@@ -43,25 +50,36 @@ public class TimedResource implements AutoCloseable {
     }
 
     public TimedResource(final IMobileAgent agent, final IServiceProviderPlace place, final long allowedDuration, final Timer timer) {
+        this(agent, place, allowedDuration, timer, -1);
+    }
+
+    public TimedResource(final IMobileAgent agent, final IServiceProviderPlace place, final long allowedDuration, final Timer timer,
+            final long maxAllowedDuration) {
+        this(agent, place, allowedDuration, timer, maxAllowedDuration, Action.NOTIFY);
+    }
+
+    public TimedResource(final IMobileAgent agent, final IServiceProviderPlace place, final long allowedDuration, final Timer timer,
+            final long maxAllowedDuration, final Action action) {
         this.started = System.currentTimeMillis();
         this.agent = agent;
         this.payloadCount = agent.payloadCount();
         this.placeName = place.getPlaceName();
         this.timerContext = timer.time();
         this.allowedDuration = allowedDuration;
-
+        this.maxAllowedDuration = maxAllowedDuration;
+        this.action = action;
     }
 
     // checks the state of the current place, returns true if it's closed
     protected boolean checkState(long now) {
         if (allowedDuration > 0 && (now - started) > (allowedDuration * payloadCount)) {
-            interruptAgent();
+            interruptAgent(now);
         }
         return isClosed;
     }
 
     // test visibility
-    void interruptAgent() {
+    void interruptAgent(long now) {
         // don't grab the lock if we're done
         if (isClosed) {
             return;
@@ -69,8 +87,11 @@ public class TimedResource implements AutoCloseable {
         lock.lock();
         try {
             if (!isClosed) {
-                LOG.debug("Found agent that needs interrupting {} in place {}", agent.getName(), placeName);
-                agent.interrupt();
+                if (maxAllowedDuration > 0 && (now - started) > (maxAllowedDuration * payloadCount)) {
+                    action.run(agent, placeName);
+                } else {
+                    Action.RECOVER.run(agent, placeName);
+                }
             }
         } catch (RuntimeException e) {
             LOG.error("Unable to interrupt agent {}: {}", agent.getName(), e.getMessage(), e);
@@ -90,6 +111,55 @@ public class TimedResource implements AutoCloseable {
             isClosed = true;
         } finally {
             lock.unlock();
+        }
+    }
+
+    public enum Action {
+        NOTIFY {
+            @Override
+            public void run(final IMobileAgent agent, final String placeName) {
+                LOG.warn("Found agent that is possibly locked -- {} in place {}", agent.getName(), placeName);
+            }
+        },
+        RECOVER {
+            @Override
+            public void run(final IMobileAgent agent, final String placeName) {
+                LOG.debug("Found agent that needs interrupting {} in place {}", agent.getName(), placeName);
+                agent.interrupt();
+            }
+        },
+        STOP {
+            @Override
+            public void run(final IMobileAgent agent, final String placeName) {
+                LOG.error("Found unrecoverable agent, initiating graceful shutdown -- {} in place {}", agent.getName(), placeName);
+                var unused = CompletableFuture.runAsync(EmissaryServer::stopServer);
+            }
+        },
+        KILL {
+            @Override
+            public void run(final IMobileAgent agent, final String placeName) {
+                LOG.error("Found unrecoverable agent, initiating forceful shutdown -- {} in place {}", agent.getName(), placeName);
+                var unused = CompletableFuture.runAsync(EmissaryServer::stopServerForce);
+            }
+        },
+        EXIT {
+            @Override
+            @SuppressWarnings("SystemExitOutsideMain")
+            public void run(final IMobileAgent agent, final String placeName) {
+                LOG.error("Found unrecoverable agent, exiting now -- {} in place {}", agent.getName(), placeName);
+                System.exit(1);
+            }
+        };
+
+        public abstract void run(IMobileAgent agent, String placeName);
+
+        public static Action from(final String value) {
+            try {
+                return valueOf(StringUtils.upperCase(value));
+            } catch (IllegalArgumentException e) {
+                LOG.warn("Unknown option [{}], falling back to {}", value, NOTIFY);
+                return NOTIFY;
+            }
         }
     }
 }

--- a/src/main/java/emissary/core/constants/Configurations.java
+++ b/src/main/java/emissary/core/constants/Configurations.java
@@ -12,6 +12,8 @@ public class Configurations {
     public static final String NEW_FORM = "NEW_FORM";
     public static final String OUTPUT_FORM = "OUTPUT_FORM";
     public static final String PLACE_RESOURCE_LIMIT_MILLIS = "PLACE_RESOURCE_LIMIT_MILLIS";
+    public static final String PLACE_RESOURCE_LIMIT_MILLIS_MAX = "PLACE_RESOURCE_LIMIT_MILLIS_MAX";
+    public static final String PLACE_MAX_TIMEOUT_ACTION = "PLACE_MAX_TIMEOUT_ACTION";
 
     // reserved config keys for service/place creation
     public static final String PLACE_NAME = "PLACE_NAME";

--- a/src/main/java/emissary/place/IServiceProviderPlace.java
+++ b/src/main/java/emissary/place/IServiceProviderPlace.java
@@ -149,6 +149,19 @@ public interface IServiceProviderPlace {
      */
     long getResourceLimitMillis();
 
+    /**
+     * Get max resource limit in millis if specified
+     *
+     * @return -2 if not specified, or long millis if specified
+     */
+    long getResourceLimitMillisMax();
+
+    /**
+     * Get the action to take if resource hits the max timeout
+     *
+     * @return "Notify" not specified, or the action if specified
+     */
+    String getMaxTimeoutAction();
 
     /**
      * Get the agent that is currently responsible for this thread

--- a/src/main/java/emissary/place/ServiceProviderPlace.java
+++ b/src/main/java/emissary/place/ServiceProviderPlace.java
@@ -44,8 +44,10 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
+import static emissary.core.constants.Configurations.PLACE_MAX_TIMEOUT_ACTION;
 import static emissary.core.constants.Configurations.PLACE_NAME;
 import static emissary.core.constants.Configurations.PLACE_RESOURCE_LIMIT_MILLIS;
+import static emissary.core.constants.Configurations.PLACE_RESOURCE_LIMIT_MILLIS_MAX;
 import static emissary.core.constants.Configurations.SERVICE_COST;
 import static emissary.core.constants.Configurations.SERVICE_DESCRIPTION;
 import static emissary.core.constants.Configurations.SERVICE_KEY;
@@ -1023,6 +1025,26 @@ public abstract class ServiceProviderPlace implements IServiceProviderPlace,
     @Override
     public long getResourceLimitMillis() {
         return configG.findLongEntry(PLACE_RESOURCE_LIMIT_MILLIS, -2L);
+    }
+
+    /**
+     * Get custom resource limitation in millis if specified
+     *
+     * @return -2 if not specified, or long millis if specified
+     */
+    @Override
+    public long getResourceLimitMillisMax() {
+        return configG.findLongEntry(PLACE_RESOURCE_LIMIT_MILLIS_MAX, -2L);
+    }
+
+    /**
+     * Get custom resource limitation in millis if specified
+     *
+     * @return -2 if not specified, or long millis if specified
+     */
+    @Override
+    public String getMaxTimeoutAction() {
+        return configG.findStringEntry(PLACE_MAX_TIMEOUT_ACTION, "NOTIFY");
     }
 
     /**

--- a/src/test/java/emissary/core/TimedResourceTest.java
+++ b/src/test/java/emissary/core/TimedResourceTest.java
@@ -64,7 +64,7 @@ class TimedResourceTest extends UnitTest {
         // should indicate complete
         assertTrue(first.checkState(System.currentTimeMillis()));
         // try to interrupt directly
-        first.interruptAgent();
+        first.interruptAgent(System.currentTimeMillis());
         // should not have been interrupted
         assertTrue(tma.latch.getCount() > 0L);
         tma.latch.countDown();


### PR DESCRIPTION
This pr allows you to add configurable actions to any place that hits a max timeout (after an interruption may fail). In a place config, you can add:
```
PLACE_RESOURCE_LIMIT_MILLIS = 60000
PLACE_RESOURCE_LIMIT_MILLIS_MAX = 70000
PLACE_MAX_TIMEOUT_ACTION = "KILL"
```