### PR TITLE
refresh :: add monitoring code to detect config changes

### DIFF
--- a/src/main/java/emissary/place/ServiceProviderRefreshablePlace.java
+++ b/src/main/java/emissary/place/ServiceProviderRefreshablePlace.java
@@ -220,8 +220,10 @@ public abstract class ServiceProviderRefreshablePlace extends ServiceProviderPla
             Preconditions.checkArgument(StringUtils.isNotBlank(path), "Path cannot be blank");
             Preconditions.checkArgument(intervalMinutes > 0, "Monitoring interval is not greater than 0");
 
-            final FileAlterationObserver observer;
             final Path file = Paths.get(path);
+            Preconditions.checkArgument(Files.exists(file), "Path does not exist");
+
+            final FileAlterationObserver observer;
             if (Files.isDirectory(file)) {
                 logger.debug("Monitoring directory {} for changes", file);
                 observer = new FileAlterationObserver(path);

--- a/src/main/java/emissary/place/ServiceProviderRefreshablePlace.java
+++ b/src/main/java/emissary/place/ServiceProviderRefreshablePlace.java
@@ -4,15 +4,25 @@ import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
 import emissary.core.Factory;
 
+import com.google.common.base.Preconditions;
 import jakarta.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.io.filefilter.NameFileFilter;
+import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
+import org.apache.commons.io.monitor.FileAlterationObserver;
+import org.apache.commons.lang3.StringUtils;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -20,13 +30,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public abstract class ServiceProviderRefreshablePlace extends ServiceProviderPlace {
 
-    private static final Logger logger = LoggerFactory.getLogger(ServiceProviderRefreshablePlace.class);
-
     private final Object allocatorLock = new Object();
     private final AtomicBoolean invalidated = new AtomicBoolean(false);
     private final AtomicBoolean defunct = new AtomicBoolean(false);
 
-    public ServiceProviderRefreshablePlace() throws IOException {}
+    private Monitor monitor;
+
+    public ServiceProviderRefreshablePlace() throws IOException {
+        super();
+    }
 
     public ServiceProviderRefreshablePlace(final String thePlaceLocation) throws IOException {
         super(thePlaceLocation);
@@ -78,6 +90,22 @@ public abstract class ServiceProviderRefreshablePlace extends ServiceProviderPla
         setupPlace(null, place.placeLocation, register);
     }
 
+    @Override
+    protected void setupPlace(@Nullable final String theDir, final String placeLocation, final boolean register) throws IOException {
+        super.setupPlace(theDir, placeLocation, register);
+
+        try {
+            Preconditions.checkNotNull(this.configG, "The configurator is null");
+            final var path = configG.findStringEntry("MONITORING_PATH");
+            if (StringUtils.isNotBlank(path)) {
+                final var intervalMinutes = configG.findLongEntry("MONITORING_INTERVAL_MINUTES", 15);
+                this.monitor = new Monitor(this, path, intervalMinutes);
+            }
+        } catch (RuntimeException e) {
+            logger.warn("Could not create file monitor, skipping!", e);
+        }
+    }
+
     /**
      * Get the invalid flag of the place. An invalidated place may indicate that the place has changes, such as new
      * configuration, and may trigger a follow-on process to reconfigure, reinitialize, or re-create the place.
@@ -85,6 +113,9 @@ public abstract class ServiceProviderRefreshablePlace extends ServiceProviderPla
      * @return true if the place has been invalidated, false otherwise
      */
     public final boolean isInvalidated() {
+        if (!this.invalidated.get() && this.monitor != null) {
+            this.monitor.run();
+        }
         return this.invalidated.get();
     }
 
@@ -92,7 +123,16 @@ public abstract class ServiceProviderRefreshablePlace extends ServiceProviderPla
      * Invalidate a place that need to be refreshed.
      */
     public final void invalidate() {
-        logger.info("Place[{}] being marked as invalidated", this.getPlaceName());
+        invalidate("");
+    }
+
+    /**
+     * Invalidate a place that need to be refreshed.
+     *
+     * @param reason an optional reason for place invalidation
+     */
+    public final void invalidate(final String reason) {
+        logger.info("Place marked as invalidated {}", reason);
         this.invalidated.set(true);
     }
 
@@ -126,8 +166,7 @@ public abstract class ServiceProviderRefreshablePlace extends ServiceProviderPla
     public final void refresh(final boolean full, final boolean silent) {
         logger.trace("Waiting for lock in refresh()");
         synchronized (this.allocatorLock) {
-            final String placeName = this.getPlaceName();
-            logger.debug("Attempting to refresh place[{}]...", placeName);
+            logger.debug("Attempting to refresh place...");
             if (!this.defunct.get()) {
                 if (isInvalidated()) {
                     if (full) {
@@ -136,19 +175,18 @@ public abstract class ServiceProviderRefreshablePlace extends ServiceProviderPla
                     }
                     Factory.create(this.getClass().getName(), this, full);
                     this.defunct.set(true);
-                    logger.info("Place[{}] refresh performed successfully", placeName);
+                    logger.info("Place refresh performed successfully");
                 } else {
                     if (!silent) {
-                        throw new IllegalStateException(
-                                "Cannot refresh place without first calling invalidate; no refresh performed for " + placeName);
+                        throw new IllegalStateException("Cannot refresh place without first calling invalidate; no refresh performed");
                     }
-                    logger.warn("Cannot refresh place without first calling invalidate; no refresh performed for {}", placeName);
+                    logger.warn("Cannot refresh place without first calling invalidate; no refresh performed");
                 }
             } else {
                 if (!silent) {
-                    throw new IllegalStateException("Error refreshing, DEFUNCT<" + placeName + ">");
+                    throw new IllegalStateException("Error refreshing defunct place");
                 }
-                logger.warn("DEFUNCT<{}>", placeName);
+                logger.warn("Error refreshing defunct place");
             }
         }
     }
@@ -160,10 +198,105 @@ public abstract class ServiceProviderRefreshablePlace extends ServiceProviderPla
      * @throws IOException if there is an issue loading the config
      */
     private Configurator loadConfigurator(@Nullable final List<String> configLocations, final String placeLocation) throws IOException {
-        logger.info("Reloading configurator using locations {}", configLocations);
+        slogger.info("Reloading configurator using locations {}", configLocations);
         if (CollectionUtils.isNotEmpty(configLocations)) {
             return ConfigUtil.getConfigInfo(configLocations);
         }
         return loadConfigurator(placeLocation);
+    }
+
+    /**
+     * Similar logic to a {@link org.apache.commons.io.monitor.FileAlterationMonitor} to trigger any registered
+     * {@link FileAlterationObserver} at a specified interval, except that this does not spawn a monitoring thread
+     */
+    class Monitor {
+
+        private final List<FileAlterationObserver> observers = new CopyOnWriteArrayList<>();
+        private final long intervalMinutes;
+        private Instant lastCheck;
+
+        protected Monitor(final ServiceProviderRefreshablePlace place, final String path, final long intervalMinutes) {
+            Preconditions.checkNotNull(place, "Refreshable place cannot be null");
+            Preconditions.checkArgument(StringUtils.isNotBlank(path), "Path cannot be blank");
+            Preconditions.checkArgument(intervalMinutes > 0, "Monitoring interval is not greater than 0");
+
+            final FileAlterationObserver observer;
+            final Path file = Paths.get(path);
+            if (Files.isDirectory(file)) {
+                logger.debug("Monitoring directory {} for changes", file);
+                observer = new FileAlterationObserver(path);
+            } else {
+                final Path parent = file.getParent();
+                final String fileName = file.getFileName().toString();
+                logger.debug("Monitoring file {} in directory {} for changes", fileName, parent);
+                observer = new FileAlterationObserver(parent.toFile(), new NameFileFilter(fileName));
+            }
+
+            final var listener = new RefreshListener(place);
+            observer.addListener(listener);
+            this.observers.add(observer);
+
+            this.intervalMinutes = intervalMinutes;
+            this.lastCheck = Instant.now();
+        }
+
+        synchronized void run() {
+            if (Duration.between(this.lastCheck, Instant.now()).toMinutes() >= this.intervalMinutes) {
+                logger.debug("Last file check was at {}, checking for changed files.", this.lastCheck);
+                this.observers.forEach(FileAlterationObserver::checkAndNotify);
+                this.lastCheck = Instant.now();
+            }
+        }
+
+        class RefreshListener extends FileAlterationListenerAdaptor {
+
+            private final ServiceProviderRefreshablePlace place;
+            private long lastModified = -1L;
+
+            RefreshListener(final ServiceProviderRefreshablePlace place) {
+                this.place = place;
+            }
+
+            @Override
+            public void onFileChange(final File file) {
+                handleChangeEvent(file);
+            }
+
+            @Override
+            public void onFileCreate(final File file) {
+                handleChangeEvent(file);
+            }
+
+            @Override
+            public void onFileDelete(final File file) {
+                handleChangeEvent(file);
+            }
+
+            @Override
+            public void onStop(final FileAlterationObserver observer) {
+                if (hasChanges()) {
+                    this.place.invalidate("due to a config change");
+                }
+            }
+
+            private void handleChangeEvent(final File file) {
+                logger.debug("Change event observed for {}", file);
+                this.lastModified = Long.max(this.lastModified, file.lastModified());
+            }
+
+            private boolean hasChanges() {
+                if (this.lastModified > 0L) {
+                    final var lastMod = Instant.ofEpochMilli(this.lastModified);
+
+                    // make sure no edits have occurred recently
+                    final boolean aboveThreshold = Duration.between(lastMod, Instant.now()).toMinutes() > 2;
+                    if (!aboveThreshold) {
+                        logger.debug("Files have been recently modified, waiting till next cycle.");
+                    }
+                    return aboveThreshold;
+                }
+                return false;
+            }
+        }
     }
 }

--- a/src/main/java/emissary/server/EmissaryServer.java
+++ b/src/main/java/emissary/server/EmissaryServer.java
@@ -288,7 +288,8 @@ public class EmissaryServer {
      */
     public static void invalidate() throws NamespaceException {
         LOG.info("Invalidating places that need to be reconfigured");
-        Namespace.lookup(ServiceProviderRefreshablePlace.class, true).forEach(ServiceProviderRefreshablePlace::invalidate);
+        Namespace.lookup(ServiceProviderRefreshablePlace.class, true)
+                .forEach(p -> p.invalidate("due to server invalidate"));
     }
 
     /**
@@ -300,7 +301,7 @@ public class EmissaryServer {
             waitForAgentsToDrain();
             Namespace.lookup(ServiceProviderRefreshablePlace.class)
                     .forEach(p -> {
-                        p.invalidate();
+                        p.invalidate("due to server refresh");
                         p.refresh(true);
                     });
             unpause();


### PR DESCRIPTION
This mechanism, similar to the Apache Commons FileAlterationMonitor, triggers registered FileAlterationObservers when files are changed. However, it operates on-demand, only checking for alterations when explicitly invoked at specified intervals and when the place is invoked, as opposed to the continuous monitoring employed by the FileAlterationMonitor.

Polling the file system for changes at predetermined intervals, this mechanism does not depend on the operating system's native file change notification events. This on-demand approach can be more resource-efficient, especially when file changes are infrequent, and can lead to reduced overhead and potentially better performance due to the absence of continuous monitoring and event handling.

Important Note: This on-demand mechanism may introduce a slight delay in detecting file changes, dependent on the chosen polling interval and when the place is invoked, compared to continuous monitoring solutions.