### PR TITLE
configs :: updates to support a config server

### DIFF
--- a/src/main/java/emissary/command/BaseCommand.java
+++ b/src/main/java/emissary/command/BaseCommand.java
@@ -11,6 +11,7 @@ import ch.qos.logback.classic.util.ContextInitializer;
 import ch.qos.logback.core.joran.spi.JoranException;
 import ch.qos.logback.core.joran.util.ConfigurationWatchListUtil;
 import jakarta.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -31,6 +32,10 @@ public abstract class BaseCommand implements EmissaryCommand {
     static final Logger LOG = LoggerFactory.getLogger(BaseCommand.class);
 
     public static final String COMMAND_NAME = "BaseCommand";
+
+    @Option(names = {"--config.server"}, description = "config server, i.e. http://localhost:8888/{application}/{profile}/{label}/{file}")
+    @Nullable
+    private String configServer;
 
     @Option(names = {"-c", "--config"}, description = "config dir, comma separated if multiple, defaults to <projectBase>/config",
             converter = PathExistsConverter.class)
@@ -62,6 +67,11 @@ public abstract class BaseCommand implements EmissaryCommand {
 
     @Option(names = {"-q", "--quiet"}, description = "hide banner and non essential messages\nDefault: ${DEFAULT-VALUE}")
     private boolean quiet = false;
+
+    @Nullable
+    public String getConfigServer() {
+        return StringUtils.trimToEmpty(this.configServer);
+    }
 
     public Path getConfig() {
         if (config == null) {
@@ -131,6 +141,7 @@ public abstract class BaseCommand implements EmissaryCommand {
 
     public void setupConfig() {
         logInfo("{} is set to {} ", ConfigUtil.PROJECT_BASE_ENV, getProjectBase().toAbsolutePath().toString());
+        setSystemProperty(ConfigUtil.CONFIG_SERVER_PROPERTY, getConfigServer());
         setSystemProperty(ConfigUtil.CONFIG_DIR_PROPERTY, getConfig().toAbsolutePath().toString());
         setSystemProperty(ConfigUtil.CONFIG_BIN_PROPERTY, getBinDir().toAbsolutePath().toString());
         setSystemProperty(ConfigUtil.CONFIG_OUTPUT_ROOT_PROPERTY, getOutputDir().toAbsolutePath().toString());

--- a/src/main/java/emissary/server/api/Configs.java
+++ b/src/main/java/emissary/server/api/Configs.java
@@ -54,8 +54,9 @@ public class Configs {
      */
     public Response getConfigs(String name, boolean detailed) {
         try {
-            return Response.ok().entity(getConfigsResponse(name, detailed)).build();
-        } catch (IOException e) {
+            final var clazz = Class.forName(StringUtils.substringBefore(name, CONFIG_FILE_ENDING));
+            return Response.ok().entity(getConfigsResponse(clazz.getName(), detailed)).build();
+        } catch (ClassNotFoundException | IOException e) {
             ConfigsResponseEntity cre = new ConfigsResponseEntity();
             cre.addError(e.getMessage());
             return Response.serverError().entity(cre).build();


### PR DESCRIPTION
This process focuses on retrieving pre-existing Emissary configurations from a designated configuration server. This configuration server has been specifically tested and verified to function correctly with a standard Spring configuration server. However, it's important to note that this process does not leverage or utilize any of the Spring Framework's built-in capabilities for handling JSON, YAML, or properties files. 

To achieve this configuration retrieval, a Spring configuration server was first instantiated and set up. Subsequently, the necessary Emissary configuration files were copied and placed into this Spring configuration server. Finally, Emissary itself was directed to retrieve its configurations from this newly populated server.

Important: This feature is disabled by default. To enable it, specify a configuration server parameter in the startup command.

`--config.server http://localhost:8888/config/dev/emissary/`

The sample output below shows the configuration server accurately resolves the file `emissary.spi.ClassLocationVerificationProvider.cfg` and appropriately returns a 404 status code for `emissary.spi.ClassLocationVerificationProvider-STANDALONE.cfg`.
```
emissary % ./emissary server -a 5 --config.server http://localhost:8888/config/dev/emissary/
 ________  ________ _____ _____  ___  ________   __
|  ___|  \/  |_   _/  ___/  ___|/ _ \ | ___ \ \ / /
| |__ | .  . | | | \ `--.\ `--./ /_\ \| |_/ /\ V / 
|  __|| |\/| | | |  `--. \`--. \  _  ||    /  \ /  
| |___| |  | |_| |_/\__/ /\__/ / | | || |\ \  | |  
\____/\_|  |_/\___/\____/\____/\_| |_/\_| \_| \_/  

Emissary Version: 8.25.0-SNAPSHOT - built on 2025-03-14T20:40:40Z - git hash: ca81d63
PROJECT_BASE is set to /emissary/target 
Setting emissary.config.server to http://localhost:8888/config/dev/emissary/ 
...
2025-03-14T20:43:16.377 [localhost-8001] DEBUG emissary.config.ConfigUtil -   - Loading config for (class) emissary.spi.ClassLocationVerificationProvider.cfg
2025-03-14T20:43:16.383 [localhost-8001] DEBUG emissary.config.ConfigUtil -   - Found config data from config server http://localhost:8888/config/dev/emissary/emissary.spi.ClassLocationVerificationProvider.cfg
2025-03-14T20:43:16.384 [localhost-8001] DEBUG emissary.config.ConfigUtil -   - Attempting flavor merge on emissary.spi.ClassLocationVerificationProvider-STANDALONE.cfg
2025-03-14T20:43:16.384 [localhost-8001] DEBUG emissary.config.ConfigUtil -   - Loading config for (string) emissary.spi.ClassLocationVerificationProvider-STANDALONE.cfg
2025-03-14T20:43:16.386 [localhost-8001] DEBUG emissary.config.ConfigUtil -   - Request failed to http://localhost:8888/config/dev/emissary/emissary.spi.ClassLocationVerificationProvider-STANDALONE.cfg with status code: 404
2025-03-14T20:43:16.386 [localhost-8001] DEBUG emissary.config.ConfigUtil -   - No file config found using config server emissary.spi.ClassLocationVerificationProvider-STANDALONE.cfg
2025-03-14T20:43:16.386 [localhost-8001] DEBUG emissary.config.ConfigUtil -   - No file config found using new style emissary.spi.ClassLocationVerificationProvider-STANDALONE.cfg
2025-03-14T20:43:16.386 [localhost-8001] DEBUG emissary.config.ConfigUtil -   - No config data as resource for emissary/spi/ClassLocationVerificationProvider-STANDALONE.cfg
2025-03-14T20:43:16.386 [localhost-8001] DEBUG emissary.config.ConfigUtil -   - No file config found using old style ClassLocationVerificationProvider-STANDALONE.cfg
2025-03-14T20:43:16.386 [localhost-8001] DEBUG emissary.config.ConfigUtil -   - Unable to opt import flavor config emissary.spi.ClassLocationVerificationProvider-STANDALONE.cfg
2025-03-14T20:43:16.389 [localhost-8001] INFO  emissary.spi.SPILoader -   - Initialized emissary.spi.ClassLocationVerificationProvider
```

