### PR TITLE
regression :: updated IbdoMethodNames to use BiConsumers

### DIFF
--- a/src/main/java/emissary/core/constants/IbdoMethodNames.java
+++ b/src/main/java/emissary/core/constants/IbdoMethodNames.java
@@ -1,86 +1,94 @@
 package emissary.core.constants;
 
+import emissary.core.IBaseDataObject;
+import emissary.core.channels.SeekableByteChannelFactory;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.function.BiConsumer;
+
 public final class IbdoMethodNames {
     /**
      * The IBaseDataObject set method name for Birth Order.
      */
-    public static final String SET_BIRTH_ORDER = "setBirthOrder";
+    public static final BiConsumer<IBaseDataObject, Integer> SET_BIRTH_ORDER = IBaseDataObject::setBirthOrder;
     /**
      * The IBaseDataObject set method name for Broken.
      */
-    public static final String SET_BROKEN = "setBroken";
+    public static final BiConsumer<IBaseDataObject, String> SET_BROKEN = IBaseDataObject::setBroken;
     /**
      * The IBaseDataObject set method name for Classification.
      */
-    public static final String SET_CLASSIFICATION = "setClassification";
+    public static final BiConsumer<IBaseDataObject, String> SET_CLASSIFICATION = IBaseDataObject::setClassification;
     /**
      * The IBaseDataObject set method name for Current Form.
      */
-    public static final String SET_CURRENT_FORM = "pushCurrentForm";
+    public static final BiConsumer<IBaseDataObject, String> SET_CURRENT_FORM = IBaseDataObject::pushCurrentForm;
     /**
      * The IBaseDataObject set method name for Data.
      */
-    public static final String SET_DATA = "setChannelFactory";
+    public static final BiConsumer<IBaseDataObject, SeekableByteChannelFactory> SET_DATA = IBaseDataObject::setChannelFactory;
     /**
      * The IBaseDataObject set method name for Filename.
      */
-    public static final String SET_FILENAME = "setFilename";
+    public static final BiConsumer<IBaseDataObject, String> SET_FILENAME = IBaseDataObject::setFilename;
     /**
      * The IBaseDataObject set method name for Font Encoding.
      */
-    public static final String SET_FONT_ENCODING = "setFontEncoding";
+    public static final BiConsumer<IBaseDataObject, String> SET_FONT_ENCODING = IBaseDataObject::setFontEncoding;
     /**
      * The IBaseDataObject set method name for Footer.
      */
-    public static final String SET_FOOTER = "setFooter";
+    public static final BiConsumer<IBaseDataObject, byte[]> SET_FOOTER = IBaseDataObject::setFooter;
     /**
      * The IBaseDataObject set method name for Header.
      */
-    public static final String SET_HEADER = "setHeader";
+    public static final BiConsumer<IBaseDataObject, byte[]> SET_HEADER = IBaseDataObject::setHeader;
     /**
      * The IBaseDataObject set method name for Header Encoding.
      */
-    public static final String SET_HEADER_ENCODING = "setHeaderEncoding";
+    public static final BiConsumer<IBaseDataObject, String> SET_HEADER_ENCODING = IBaseDataObject::setHeaderEncoding;
     /**
      * The IBaseDataObject set method name for Id.
      */
-    public static final String SET_ID = "setId";
+    public static final BiConsumer<IBaseDataObject, String> SET_ID = IBaseDataObject::setId;
     /**
      * The IBaseDataObject set method name for Num Children.
      */
-    public static final String SET_NUM_CHILDREN = "setNumChildren";
+    public static final BiConsumer<IBaseDataObject, Integer> SET_NUM_CHILDREN = IBaseDataObject::setNumChildren;
     /**
      * The IBaseDataObject set method name for Num Sibling.
      */
-    public static final String SET_NUM_SIBLINGS = "setNumSiblings";
+    public static final BiConsumer<IBaseDataObject, Integer> SET_NUM_SIBLINGS = IBaseDataObject::setNumSiblings;
     /**
      * The IBaseDataObject set method name for Outputable.
      */
-    public static final String SET_OUTPUTABLE = "setOutputable";
+    public static final BiConsumer<IBaseDataObject, Boolean> SET_OUTPUTABLE = IBaseDataObject::setOutputable;
     /**
      * The IBaseDataObject set method name for Parameter.
      */
-    public static final String SET_PARAMETER = "appendParameter";
+    public static final BiConsumer<IBaseDataObject, Pair<String, CharSequence>> SET_PARAMETER = (b, p) -> b.appendParameter(p.getKey(), p.getValue());
     /**
      * The IBaseDataObject set method name for Priority.
      */
-    public static final String SET_PRIORITY = "setPriority";
+    public static final BiConsumer<IBaseDataObject, Integer> SET_PRIORITY = IBaseDataObject::setPriority;
     /**
      * The IBaseDataObject method name to add Processing Error.
      */
-    public static final String ADD_PROCESSING_ERROR = "addProcessingError";
+    public static final BiConsumer<IBaseDataObject, String> ADD_PROCESSING_ERROR = IBaseDataObject::addProcessingError;
     /**
      * The IBaseDataObject set method name for Transaction Id.
      */
-    public static final String SET_TRANSACTION_ID = "setTransactionId";
+    public static final BiConsumer<IBaseDataObject, String> SET_TRANSACTION_ID = IBaseDataObject::setTransactionId;
     /**
      * The IBaseDataObject method name to add Alternate View.
      */
-    public static final String ADD_ALTERNATE_VIEW = "addAlternateView";
+    public static final BiConsumer<IBaseDataObject, Pair<String, byte[]>> ADD_ALTERNATE_VIEW =
+            (b, p) -> b.addAlternateView(p.getKey(), p.getValue());
     /**
      * The IBaseDataObject set method name for Work Bundle Id.
      */
-    public static final String SET_WORK_BUNDLE_ID = "setWorkBundleId";
+    public static final BiConsumer<IBaseDataObject, String> SET_WORK_BUNDLE_ID = IBaseDataObject::setWorkBundleId;
 
     private IbdoMethodNames() {}
 }

--- a/src/test/java/emissary/core/IBaseDataObjectDiffHelperTest.java
+++ b/src/test/java/emissary/core/IBaseDataObjectDiffHelperTest.java
@@ -387,16 +387,4 @@ class IBaseDataObjectDiffHelperTest extends UnitTest {
         TreeMap<String, Collection<Object>> sortedParams = new TreeMap<>(ibdo1.getParameters());
         assertEquals(expectedParams, sortedParams.keySet(), "parameters should be sorted in natural order of keys");
     }
-
-    @Test
-    void testDecoderIOExceptions() {
-        assertThrows(IOException.class, () -> IBaseDataObjectXmlCodecs.DEFAULT_BOOLEAN_DECODER.decode(null, null, "badMethodName"));
-        assertThrows(IOException.class,
-                () -> IBaseDataObjectXmlCodecs.DEFAULT_SEEKABLE_BYTE_CHANNEL_FACTORY_DECODER.decode(null, null, "badMethodName"));
-        assertThrows(IOException.class, () -> IBaseDataObjectXmlCodecs.DEFAULT_BYTE_ARRAY_DECODER.decode(null, null, "badMethodName"));
-        assertThrows(IOException.class, () -> IBaseDataObjectXmlCodecs.DEFAULT_INTEGER_DECODER.decode(null, null, "badMethodName"));
-        assertThrows(IOException.class, () -> IBaseDataObjectXmlCodecs.DEFAULT_STRING_DECODER.decode(null, null, "badMethodName"));
-        assertThrows(IOException.class, () -> IBaseDataObjectXmlCodecs.DEFAULT_STRING_BYTE_ARRAY_DECODER.decode(null, null, "badMethodName"));
-        assertThrows(IOException.class, () -> IBaseDataObjectXmlCodecs.DEFAULT_STRING_OBJECT_DECODER.decode(null, null, "badMethodName"));
-    }
 }


### PR DESCRIPTION
The current implementation relies on reflection to access IBDO methods. This approach, however, is being replaced with direct method calls to improve robustness and maintainability. Reflection, while flexible, introduces fragility due to its reliance on string-based method lookups. These string representations can easily break during refactoring, leading to unexpected errors and runtime failures. By shifting to direct method calls, we eliminate this risk and ensure that method invocations remain intact even as the codebase evolves. This transition not only enhances the reliability of the system but also improves its overall performance by bypassing the overhead associated with reflection.