### PR TITLE
enforce analyzed test scope dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,11 @@
         <version>${dep.jersey.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.glassfish.jersey.test-framework</groupId>
+        <artifactId>jersey-test-framework-provider-jetty</artifactId>
+        <version>${dep.jersey.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.jdom</groupId>
         <artifactId>jdom2</artifactId>
         <version>${dep.jdom.version}</version>
@@ -292,11 +297,6 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>${dep.mockito.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-junit-jupiter</artifactId>
         <version>${dep.mockito.version}</version>
       </dependency>
       <dependency>
@@ -613,10 +613,6 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
-          <groupId>jakarta.servlet</groupId>
-          <artifactId>jakarta.servlet-api</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.hamcrest</groupId>
           <artifactId>*</artifactId>
         </exclusion>
@@ -640,11 +636,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -1252,7 +1243,7 @@
             </goals>
             <configuration>
               <failOnWarning>true</failOnWarning>
-              <ignoreNonCompile>true</ignoreNonCompile>
+              <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
             </configuration>
           </execution>
           <execution>

--- a/src/test/java/emissary/server/mvc/EndpointTestBase.java
+++ b/src/test/java/emissary/server/mvc/EndpointTestBase.java
@@ -9,6 +9,7 @@ import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.mvc.mustache.MustacheMvcFeature;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
+import org.glassfish.jersey.test.jetty.JettyTestContainerFactory;
 import org.junit.jupiter.api.AfterAll;
 
 public abstract class EndpointTestBase extends JerseyTest {
@@ -25,6 +26,7 @@ public abstract class EndpointTestBase extends JerseyTest {
         // Tells Jersey to use first available port, fixes address already in use exception
         forceSet(TestProperties.CONTAINER_PORT, "0");
         final ResourceConfig application = new ResourceConfig();
+        application.register(JettyTestContainerFactory.class);
         application.register(MultiPartFeature.class);
         application.property(MustacheMvcFeature.TEMPLATE_BASE_PATH, "/templates");
         application.register(MustacheMvcFeature.class).packages("emissary.server.mvc");


### PR DESCRIPTION
- mockito-junit-jupiter isn't used
- jersey-test-framework-provider-jetty is required for mvc tests using EndpointTestBase/JerseyTest, but is discovered rather than imported. Registering the class that is ultimately being used gets around that
- the pom can now move from `ignoreNonCompile` to `ignoreUnusedRuntime` since that's the only remaining scenario