### PR TITLE
pmd :: UselessOverridingMethod

### DIFF
--- a/src/main/java/emissary/kff/SpamSumSignature.java
+++ b/src/main/java/emissary/kff/SpamSumSignature.java
@@ -94,6 +94,7 @@ public class SpamSumSignature {
     }
 
     @Override
+    @SuppressWarnings("UselessOverridingMethod")
     public int hashCode() {
         return super.hashCode();
     }


### PR DESCRIPTION
Removing this method causes compilation errors, so suppressing the warning.
This is the only remaining instance of the pmd UselessOverridingMethod warning.