### PR TITLE
pmd :: UselessParentheses

### DIFF
--- a/src/main/java/emissary/kff/Ssdeep.java
+++ b/src/main/java/emissary/kff/Ssdeep.java
@@ -31,6 +31,7 @@ public final class Ssdeep {
     private static final int SPAMSUM_LENGTH = 64;
     private static final int MIN_BLOCKSIZE = 3;
 
+    @SuppressWarnings("PMD.UselessParentheses")
     public static final int FUZZY_MAX_RESULT = SPAMSUM_LENGTH + (SPAMSUM_LENGTH / 2 + 20);
 
     /** The window size for the rolling hash. */

--- a/src/main/java/emissary/transform/decode/JsonEscape.java
+++ b/src/main/java/emissary/transform/decode/JsonEscape.java
@@ -41,7 +41,7 @@ public class JsonEscape {
                 if ((i + 3) < data.length && isOctalDigit(data[i + 3])) {
                     end++;
                 }
-                String s = new String(data, i + 1, (end - i));
+                String s = new String(data, i + 1, end - i);
                 try {
                     int num = Integer.parseInt(s, 8);
                     char[] ch = Character.toChars(num);
@@ -71,7 +71,7 @@ public class JsonEscape {
     }
 
     protected static boolean isOctalDigit(byte b) {
-        return (b >= '0' && b <= '7');
+        return b >= '0' && b <= '7';
     }
 
     /** This class is not meant to be instantiated. */

--- a/src/main/java/emissary/util/Hexl.java
+++ b/src/main/java/emissary/util/Hexl.java
@@ -38,6 +38,7 @@ public class Hexl {
      * 
      * @param limit how many bytes of data to print starting from 0
      */
+    @SuppressWarnings("PMD.UselessParentheses")
     public static String toHexString(byte[] data, int limit) {
 
         StringBuilder output = new StringBuilder(2048);

--- a/src/main/java/emissary/util/xml/AbstractJDOMUtil.java
+++ b/src/main/java/emissary/util/xml/AbstractJDOMUtil.java
@@ -185,6 +185,7 @@ public abstract class AbstractJDOMUtil {
     /**
      * Create a JDOM element, protecting the data with encoding if needed
      */
+    @SuppressWarnings("PMD.UselessParentheses")
     public static Element protectedElement(final String name, final String s) {
         final Element e = new Element(name);
         int badCount = 0;


### PR DESCRIPTION
Suppressed the warnings in places where the parentheses seemed useful/needed.
Removed parentheses from JsonEscape as they were not necessary.
This resolves all remaining pmd UselessParentheses warnings.