### PR TITLE
removing obsolete myKey value from SessionProducer constructor

### DIFF
--- a/src/main/java/emissary/parser/SessionProducer.java
+++ b/src/main/java/emissary/parser/SessionProducer.java
@@ -19,7 +19,6 @@ public class SessionProducer {
     public static final String PARSER_ERROR = "This session could not be completely parsed. The format was bad.";
 
     protected SessionParser sp;
-    // protected String myKey;
     protected int numSessions = 0;
     protected List<String> initialForms;
 
@@ -29,12 +28,10 @@ public class SessionProducer {
      * Creates a SessionProducer
      *
      * @param sp The SessionParser, which has parsed theContent.
-     * @param myKey Value to stick into the transform history, obsolete
      * @param initialForms Forms to be preloaded onto the form stack.
      */
-    public SessionProducer(SessionParser sp, String myKey, List<String> initialForms) {
+    public SessionProducer(SessionParser sp, List<String> initialForms) {
         this.sp = sp;
-        // this.myKey = myKey;
         this.initialForms = initialForms;
     }
 

--- a/src/main/java/emissary/parser/SessionProducer.java
+++ b/src/main/java/emissary/parser/SessionProducer.java
@@ -28,6 +28,20 @@ public class SessionProducer {
      * Creates a SessionProducer
      *
      * @param sp The SessionParser, which has parsed theContent.
+     * @param myKey Value to stick into the transform history, obsolete
+     * @param initialForms Forms to be preloaded onto the form stack.
+     * @deprecated use {@link #SessionProducer(SessionParser, List)}
+     */
+    @Deprecated
+    public SessionProducer(SessionParser sp, String myKey, List<String> initialForms) {
+        this.sp = sp;
+        this.initialForms = initialForms;
+    }
+
+    /**
+     * Creates a SessionProducer
+     *
+     * @param sp The SessionParser, which has parsed theContent.
      * @param initialForms Forms to be preloaded onto the form stack.
      */
     public SessionProducer(SessionParser sp, List<String> initialForms) {

--- a/src/main/java/emissary/pickup/PickUpPlace.java
+++ b/src/main/java/emissary/pickup/PickUpPlace.java
@@ -585,7 +585,7 @@ public abstract class PickUpPlace extends ServiceProviderPlace implements IPickU
             logger.debug("Using session parser from raf ident {}", sp.getClass().getName());
 
             // ... and a session producer to crank out the data objects...
-            SessionProducer dof = new SessionProducer(sp, myKey, null);
+            SessionProducer dof = new SessionProducer(sp, (List<String>) null);
 
             long fileStart = System.currentTimeMillis();
             long totalSize = 0;
@@ -640,7 +640,7 @@ public abstract class PickUpPlace extends ServiceProviderPlace implements IPickU
         SessionParser sp = parserFactory.makeSessionParser(InMemoryChannelFactory.create(data).create());
 
         // .. and a session producer to crank out the data objects...
-        SessionProducer dof = new SessionProducer(sp, myKey, null);
+        SessionProducer dof = new SessionProducer(sp, (List<String>) null);
 
         // For each session get a data object from the producer
         boolean isParserComplete = false;


### PR DESCRIPTION
this was noticed through the pmd UnusedFormalParameter warnings, as `myKey` was not was not used from the method signature with all uses in the class being commented out.