### PR TITLE
pmd :: EmptyControlStatement

### DIFF
--- a/contrib/pmd/maven-pmd-plugin-default.xml
+++ b/contrib/pmd/maven-pmd-plugin-default.xml
@@ -43,7 +43,11 @@ under the License.
     <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />
     <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" />
 
-    <rule ref="category/java/codestyle.xml/EmptyControlStatement" />
+    <rule ref="category/java/codestyle.xml/EmptyControlStatement">
+        <properties>
+            <property name="allowCommentedBlocks" value="true" />
+        </properties>
+    </rule>
     <rule ref="category/java/codestyle.xml/ExtendsObject" />
     <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop" />
     <!--rule ref="category/java/codestyle.xml/TooManyStaticImports" /-->

--- a/src/main/java/emissary/util/LineTokenizer.java
+++ b/src/main/java/emissary/util/LineTokenizer.java
@@ -183,6 +183,7 @@ public class LineTokenizer {
         int end = index;
 
         for (; end < data.length && data[end] != delim; end++) {
+            // Do nothing.
         }
 
         byte[] tok = new byte[end - index];


### PR DESCRIPTION
Instead of suppressing each of these, I added the property to the pmd xml file to allow empty control statements if there is a comment included inside.