### PR TITLE
pmd :: AvoidBranchingStatementAsLastInLoop

### DIFF
--- a/src/main/java/emissary/directory/DirectoryPlace.java
+++ b/src/main/java/emissary/directory/DirectoryPlace.java
@@ -966,6 +966,7 @@ public class DirectoryPlace extends ServiceProviderPlace implements IRemoteDirec
      * @param entries map of DirectoryEntry stored in this directory
      * @return List of DirectoryEntry with next place to go or empty list if none
      */
+    @SuppressWarnings("PMD.AvoidBranchingStatementAsLastInLoop")
     protected List<DirectoryEntry> nextKeys(final String dataId, final IBaseDataObject payload, @Nullable final DirectoryEntry lastPlace,
             final DirectoryEntryMap entries) {
         // Find the entry list for the type being requested

--- a/src/main/java/emissary/jni/JniRepositoryPlace.java
+++ b/src/main/java/emissary/jni/JniRepositoryPlace.java
@@ -123,6 +123,7 @@ public class JniRepositoryPlace extends ServiceProviderPlace {
      * Lookup the requested file in the repository either for delivery or timestamp checking
      */
     @Nullable
+    @SuppressWarnings("PMD.AvoidBranchingStatementAsLastInLoop")
     private File nativeLibraryLookup(final String query) {
 
         String[] fileList = null;

--- a/src/main/java/emissary/util/ConstructorLookupCache.java
+++ b/src/main/java/emissary/util/ConstructorLookupCache.java
@@ -135,6 +135,7 @@ public final class ConstructorLookupCache {
      *         matching constructor; otherwise {@code null}.
      */
     @Nullable
+    @SuppressWarnings("PMD.AvoidBranchingStatementAsLastInLoop")
     private static Constructor<?> directConstructorLookup(final Class<?> clazz, final Class<?>[] argTypes) {
         // Look for an exact match.
         try {


### PR DESCRIPTION
this pr suppresses these pmd warnings.
https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_errorprone.html#avoidbranchingstatementaslastinloop
this is one warning where I could see adding in the properties to the pmd xml file could be helpful in the future, but for now since there are only three instances, I figured I'd go with suppression. If we'd prefer the properties, I can add them in.