### PR TITLE
enforce use of static imports for Assertions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -909,6 +909,10 @@
                     <reason>Use jakarta.annotation instead</reason>
                     <bannedImport>javax.annotation.**</bannedImport>
                   </RestrictImports>
+                  <RestrictImports>
+                    <reason>Use static imports for assertions</reason>
+                    <bannedImport>org.junit.jupiter.api.Assertions</bannedImport>
+                  </RestrictImports>
                 </rules>
               </configuration>
             </execution>

--- a/src/test/java/emissary/roll/RollManagerTest.java
+++ b/src/test/java/emissary/roll/RollManagerTest.java
@@ -5,7 +5,6 @@ import emissary.core.EmissaryRuntimeException;
 import emissary.test.core.junit5.UnitTest;
 import emissary.test.core.junit5.extensions.EmissaryIsolatedClassLoaderExtension;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -17,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RollManagerTest extends UnitTest {
@@ -38,7 +38,7 @@ class RollManagerTest extends UnitTest {
         r.addPropertyChangeListener(o);
         rm.addRoller(r);
         r.incrementProgress();
-        Assertions.assertNotNull(o.o, "Roller notified");
+        assertNotNull(o.o, "Roller notified");
         rm.exec.shutdown();
     }
 

--- a/src/test/java/emissary/spi/ClassLocationVerificationProviderTest.java
+++ b/src/test/java/emissary/spi/ClassLocationVerificationProviderTest.java
@@ -4,27 +4,29 @@ import emissary.Emissary;
 import emissary.test.core.junit5.UnitTest;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ClassLocationVerificationProviderTest extends UnitTest {
     @Test
     void testVerifyClassInWorkingDirectory() {
         String emissaryClassName = Emissary.class.getName();
         boolean status = ClassLocationVerificationProvider.verify(emissaryClassName, "/classes/");
-        Assertions.assertTrue(status);
+        assertTrue(status);
 
         status = ClassLocationVerificationProvider.verify(emissaryClassName, "doesnotexist");
-        Assertions.assertFalse(status);
+        assertFalse(status);
     }
 
     @Test
     void testVerifyClassInJar() {
         String javaClassName = StringUtils.class.getName();
         boolean status = ClassLocationVerificationProvider.verify(javaClassName, "commons-lang");
-        Assertions.assertTrue(status);
+        assertTrue(status);
 
         status = ClassLocationVerificationProvider.verify(javaClassName, "doesnotexist");
-        Assertions.assertFalse(status);
+        assertFalse(status);
     }
 }

--- a/src/test/java/emissary/util/PkiUtilTest.java
+++ b/src/test/java/emissary/util/PkiUtilTest.java
@@ -3,7 +3,6 @@ package emissary.util;
 import emissary.test.core.junit5.UnitTest;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -17,6 +16,12 @@ import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 class PkiUtilTest extends UnitTest {
     private static final String projectBase = System.getenv("PROJECT_BASE"); // set in surefire config
 
@@ -24,11 +29,11 @@ class PkiUtilTest extends UnitTest {
     void testIsPemCertificate() throws IOException {
         String data = getAsciiString("/certs/testcertwithcomments.pem");
         boolean isPem = PkiUtil.isPemCertificate(data);
-        Assertions.assertTrue(isPem, "Expected a PEM file");
+        assertTrue(isPem, "Expected a PEM file");
 
         data = getAsciiString("/certs/testkeystore.jks");
         isPem = PkiUtil.isPemCertificate(data);
-        Assertions.assertFalse(isPem, "Expected a JKS file");
+        assertFalse(isPem, "Expected a JKS file");
     }
 
     private static String getAsciiString(String resourceName) throws IOException {
@@ -42,16 +47,16 @@ class PkiUtilTest extends UnitTest {
         KeyStore keyStore = PkiUtil.buildStore(path, null, "JKS");
 
         Certificate keyStoreCertificate = keyStore.getCertificate("cert_0");
-        Assertions.assertInstanceOf(X509Certificate.class, keyStoreCertificate);
-        Assertions.assertEquals("CN=Apache Tika,OU=Apache Tika,O=Tika,L=Apache,ST=Apache Tika,C=ZZ",
+        assertInstanceOf(X509Certificate.class, keyStoreCertificate);
+        assertEquals("CN=Apache Tika,OU=Apache Tika,O=Tika,L=Apache,ST=Apache Tika,C=ZZ",
                 ((X509Certificate) keyStoreCertificate).getIssuerX500Principal().getName());
-        Assertions.assertEquals("28e5ff97573af326ba8e77de449f2e3fd92f571f", ((X509Certificate) keyStoreCertificate).getSerialNumber().toString(16));
+        assertEquals("28e5ff97573af326ba8e77de449f2e3fd92f571f", ((X509Certificate) keyStoreCertificate).getSerialNumber().toString(16));
 
         keyStoreCertificate = keyStore.getCertificate("cert_1");
-        Assertions.assertInstanceOf(X509Certificate.class, keyStoreCertificate);
-        Assertions.assertEquals("CN=testca,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU",
+        assertInstanceOf(X509Certificate.class, keyStoreCertificate);
+        assertEquals("CN=testca,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU",
                 ((X509Certificate) keyStoreCertificate).getIssuerX500Principal().getName());
-        Assertions.assertEquals("3ad73a827ac85d83b0595e773b5c4728d8fb705c", ((X509Certificate) keyStoreCertificate).getSerialNumber().toString(16));
+        assertEquals("3ad73a827ac85d83b0595e773b5c4728d8fb705c", ((X509Certificate) keyStoreCertificate).getSerialNumber().toString(16));
     }
 
     @Test
@@ -63,24 +68,24 @@ class PkiUtilTest extends UnitTest {
         String path = getAbsoluteFilePath("/certs/testkeystore.jks");
         KeyStore keyStore = PkiUtil.buildStore(path, pazz, "JKS");
         Key key = keyStore.getKey(alias, pazz);
-        Assertions.assertInstanceOf(PrivateKey.class, key);
-        Assertions.assertEquals("PKCS#8", key.getFormat());
+        assertInstanceOf(PrivateKey.class, key);
+        assertEquals("PKCS#8", key.getFormat());
 
         // Test loading a JKS with X509 certificate to Keystore
         path = getAbsoluteFilePath("/certs/testtruststore.jks");
         keyStore = PkiUtil.buildStore(path, pazz, "JKS");
         Certificate keyStoreCertificate = keyStore.getCertificate(alias);
-        Assertions.assertInstanceOf(X509Certificate.class, keyStoreCertificate);
-        Assertions.assertEquals("CN=emissary,OU=emissary,O=emissary,L=emissary,ST=Unknown,C=Unknown",
+        assertInstanceOf(X509Certificate.class, keyStoreCertificate);
+        assertEquals("CN=emissary,OU=emissary,O=emissary,L=emissary,ST=Unknown,C=Unknown",
                 ((X509Certificate) keyStoreCertificate).getIssuerX500Principal().getName());
-        Assertions.assertEquals("3e2adf6", ((X509Certificate) keyStoreCertificate).getSerialNumber().toString(16));
+        assertEquals("3e2adf6", ((X509Certificate) keyStoreCertificate).getSerialNumber().toString(16));
     }
 
     @Test
     void testLoadPWFromFile() throws Exception {
         char[] password = PkiUtil.loadPassword("file:///" + getAbsoluteFilePath("/emissary/util/web/password.file"));
-        Assertions.assertNotNull(password, "Failed to read password from file");
-        Assertions.assertEquals("password", String.valueOf(password));
+        assertNotNull(password, "Failed to read password from file");
+        assertEquals("password", String.valueOf(password));
     }
 
     /**
@@ -92,13 +97,13 @@ class PkiUtilTest extends UnitTest {
     @Test
     void testLoadPWFromEnv() throws Exception {
         char[] password = PkiUtil.loadPassword("${PROJECT_BASE}");
-        Assertions.assertNotNull(password, "Failed to read environment variable");
-        Assertions.assertEquals(projectBase, String.valueOf(password));
+        assertNotNull(password, "Failed to read environment variable");
+        assertEquals(projectBase, String.valueOf(password));
     }
 
     private static String getAbsoluteFilePath(String name) {
         URL resource = PkiUtilTest.class.getResource(name);
-        Assertions.assertNotNull(resource);
+        assertNotNull(resource);
         return resource.getFile();
     }
 }


### PR DESCRIPTION
follow-on to #1095 to enforce the main use case where this violation shows up