### PR TITLE
dependencies: bump commons-pool2 from 2.11.1 to 2.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <dep.commons-exec.version>1.3</dep.commons-exec.version>
     <dep.commons-io.version>2.17.0</dep.commons-io.version>
     <dep.commons-lang.version>3.17.0</dep.commons-lang.version>
-    <dep.commons-pool.version>2.11.1</dep.commons-pool.version>
+    <dep.commons-pool.version>2.12.1</dep.commons-pool.version>
     <dep.dropwizard.metrics.version>4.2.25</dep.dropwizard.metrics.version>
     <dep.errorprone.version>2.23.0</dep.errorprone.version>
     <dep.gson.version>2.10.1</dep.gson.version>


### PR DESCRIPTION
https://commons.apache.org/proper/commons-pool/changes.html#a2.12.1

"Make BaseGenericObjectPool implement AutoCloseable." is what stood out to me for future code updates

This might want to wait for 2.12.2 to be released for the extra bug-fix.