### PR TITLE
update to jaxb runtime 4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
     <dep.jackson.version>2.15.2</dep.jackson.version>
     <dep.jakarta.annotation-api.version>2.1.1</dep.jakarta.annotation-api.version>
     <dep.jakarta.ws.rs-api.version>3.1.0</dep.jakarta.ws.rs-api.version>
-    <dep.jakarta.xml.bind-api.version>3.0.1</dep.jakarta.xml.bind-api.version>
+    <dep.jakarta.xml.bind-api.version>4.0.2</dep.jakarta.xml.bind-api.version>
     <dep.janino.version>3.1.12</dep.janino.version>
-    <dep.jaxb.runtime.version>3.0.1</dep.jaxb.runtime.version>
+    <dep.jaxb.runtime.version>4.0.5</dep.jaxb.runtime.version>
     <dep.jdom.version>2.0.6.1</dep.jdom.version>
     <dep.jersey.version>3.1.3</dep.jersey.version>
     <dep.jetty-jakarta-servlet-api.version>5.0.2</dep.jetty-jakarta-servlet-api.version>


### PR DESCRIPTION
This was previously not possible as 4.x required jdk 11. Then I believe we had some artifacts that needed upgrading first to get out of the older sun activation libraries. I believe we have moved past all that and now this is possible. 

```
							      >	angus-activation-2.0.2.jar
istack-commons-runtime-4.0.1.jar			      |	istack-commons-runtime-4.1.2.jar
jakarta.activation-2.0.1.jar				      |	jakarta.activation-api-2.1.3.jar
jakarta.xml.bind-api-3.0.1.jar				      |	jakarta.xml.bind-api-4.0.2.jar
jaxb-core-3.0.1.jar					      |	jaxb-core-4.0.5.jar
jaxb-runtime-3.0.1.jar					      |	jaxb-runtime-4.0.5.jar
txw2-3.0.1.jar						      |	txw2-4.0.5.jar
```

- [x] check availability