### PR TITLE
dependencies: bump commons-io from 2.17.0 to 2.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dep.commons-collections.version>4.4</dep.commons-collections.version>
     <dep.commons-compress.version>1.27.1</dep.commons-compress.version>
     <dep.commons-exec.version>1.3</dep.commons-exec.version>
-    <dep.commons-io.version>2.17.0</dep.commons-io.version>
+    <dep.commons-io.version>2.19.0</dep.commons-io.version>
     <dep.commons-lang.version>3.17.0</dep.commons-lang.version>
     <dep.commons-pool.version>2.11.1</dep.commons-pool.version>
     <dep.dropwizard.metrics.version>4.2.30</dep.dropwizard.metrics.version>


### PR DESCRIPTION
- [x] check for availability