### PR TITLE
Update io.grpc:grpc-bom to 1.65.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <dep.commons-pool.version>2.11.1</dep.commons-pool.version>
     <dep.dropwizard.metrics.version>4.2.30</dep.dropwizard.metrics.version>
     <dep.errorprone.version>2.23.0</dep.errorprone.version>
-    <dep.grpc.version>1.45.1</dep.grpc.version>
+    <dep.grpc.version>1.65.0</dep.grpc.version>
     <dep.gson.version>2.10.1</dep.gson.version>
     <dep.guava.version>32.1.2-jre</dep.guava.version>
     <dep.httpclient.version>5.2.1</dep.httpclient.version>


### PR DESCRIPTION
`1.65.0` is the newest gRPC version that works out-of-the-box on CentOS7.