### PR TITLE
regression-test :: move encoders/decoders to ExtractionTest and update to use IBaseDataObjectXmlHelper

### DIFF
--- a/src/test/java/emissary/core/IBaseDataObjectXmlCodecs.java
+++ b/src/test/java/emissary/core/IBaseDataObjectXmlCodecs.java
@@ -127,6 +127,11 @@ public final class IBaseDataObjectXmlCodecs {
         METHOD_MAP.put(IbdoXmlElementNames.TRANSACTION_ID, IbdoMethodNames.SET_TRANSACTION_ID);
         METHOD_MAP.put(IbdoXmlElementNames.VIEW, IbdoMethodNames.ADD_ALTERNATE_VIEW);
         METHOD_MAP.put(IbdoXmlElementNames.WORK_BUNDLE_ID, IbdoMethodNames.SET_WORK_BUNDLE_ID);
+
+        // legacy fields
+
+        METHOD_MAP.put(IbdoXmlElementNames.INITIAL_FORM, IbdoMethodNames.ENQUEUE_CURRENT_FORM);
+        METHOD_MAP.put(IbdoXmlElementNames.ALT_VIEW, IbdoMethodNames.ADD_ALTERNATE_VIEW);
     }
     private static final String NO_IBDO_METHOD_MATCH_ELEMENT_NAME = "Could not find the IBDO method for element name ";
 

--- a/src/test/java/emissary/core/IBaseDataObjectXmlHelper.java
+++ b/src/test/java/emissary/core/IBaseDataObjectXmlHelper.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
+import static emissary.core.constants.IbdoXmlElementNames.ALT_VIEW;
 import static emissary.core.constants.IbdoXmlElementNames.ANSWERS;
 import static emissary.core.constants.IbdoXmlElementNames.ATTACHMENT_ELEMENT_PREFIX;
 import static emissary.core.constants.IbdoXmlElementNames.BIRTH_ORDER;
@@ -31,6 +32,7 @@ import static emissary.core.constants.IbdoXmlElementNames.HEADER;
 import static emissary.core.constants.IbdoXmlElementNames.HEADER_ENCODING;
 import static emissary.core.constants.IbdoXmlElementNames.ID;
 import static emissary.core.constants.IbdoXmlElementNames.INDEX;
+import static emissary.core.constants.IbdoXmlElementNames.INITIAL_FORM;
 import static emissary.core.constants.IbdoXmlElementNames.NUM_CHILDREN;
 import static emissary.core.constants.IbdoXmlElementNames.NUM_SIBLINGS;
 import static emissary.core.constants.IbdoXmlElementNames.OUTPUTABLE;
@@ -151,6 +153,10 @@ public final class IBaseDataObjectXmlHelper {
             decoders.decodeString(element, ibdo, TRANSACTION_ID);
             decoders.decodeStringByteArray(element, ibdo, VIEW);
             decoders.decodeString(element, ibdo, WORK_BUNDLE_ID);
+
+            // legacy fields
+            decoders.decodeString(element, ibdo, INITIAL_FORM);
+            decoders.decodeStringByteArray(element, ibdo, ALT_VIEW);
         } catch (IOException e) {
             LOGGER.error("Failed to parse XML!", e);
         }

--- a/src/test/java/emissary/core/constants/IbdoMethodNames.java
+++ b/src/test/java/emissary/core/constants/IbdoMethodNames.java
@@ -89,6 +89,10 @@ public final class IbdoMethodNames {
      * The IBaseDataObject set method name for Work Bundle Id.
      */
     public static final BiConsumer<IBaseDataObject, String> SET_WORK_BUNDLE_ID = IBaseDataObject::setWorkBundleId;
+    /**
+     * The IBaseDataObject method name to enqueue current form.
+     */
+    public static final BiConsumer<IBaseDataObject, String> ENQUEUE_CURRENT_FORM = IBaseDataObject::enqueueCurrentForm;
 
     private IbdoMethodNames() {}
 }

--- a/src/test/java/emissary/core/constants/IbdoXmlElementNames.java
+++ b/src/test/java/emissary/core/constants/IbdoXmlElementNames.java
@@ -115,5 +115,29 @@ public final class IbdoXmlElementNames {
      */
     public static final String INDEX = "index";
 
+    // legacy fields
+
+    /**
+     * The XML attribute for initial form
+     */
+    public static final String INITIAL_FORM = "initialForm";
+    /**
+     * The XML attribute index for file type
+     */
+    public static final String FILE_TYPE = "fileType";
+    /**
+     * The XML attribute index for alternate view
+     */
+    public static final String ALT_VIEW = "altView";
+    /**
+     * The XML attribute index for input alternate view
+     */
+    public static final String INPUT_ALT_VIEW = "inputAlternateView";
+    /**
+     * The XML attribute index for bad alternate view
+     */
+    public static final String BAD_ALT_VIEW = "badAlternateView";
+
+
     private IbdoXmlElementNames() {}
 }

--- a/src/test/java/emissary/test/core/junit5/RegressionTest.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTest.java
@@ -2,12 +2,9 @@ package emissary.test.core.junit5;
 
 import emissary.core.DiffCheckConfiguration;
 import emissary.core.IBaseDataObject;
-import emissary.core.IBaseDataObjectXmlCodecs.ElementDecoders;
-import emissary.core.IBaseDataObjectXmlCodecs.ElementEncoders;
 import emissary.core.IBaseDataObjectXmlHelper;
 import emissary.core.channels.FileChannelFactory;
 import emissary.core.channels.SeekableByteChannelFactory;
-import emissary.place.IServiceProviderPlace;
 import emissary.test.core.junit5.LogbackTester.SimplifiedLogEvent;
 import emissary.util.ByteUtil;
 import emissary.util.PlaceComparisonHelper;
@@ -32,7 +29,6 @@ import java.util.Optional;
 import java.util.TreeMap;
 
 import static emissary.core.IBaseDataObjectXmlCodecs.ALWAYS_SHA256_ELEMENT_ENCODERS;
-import static emissary.core.IBaseDataObjectXmlCodecs.DEFAULT_ELEMENT_DECODERS;
 import static emissary.core.IBaseDataObjectXmlCodecs.SHA256_ELEMENT_ENCODERS;
 import static emissary.core.constants.IbdoXmlElementNames.ANSWERS;
 import static emissary.core.constants.IbdoXmlElementNames.SETUP;
@@ -143,46 +139,6 @@ public abstract class RegressionTest extends ExtractionTest {
     }
 
     /**
-     * This method returns the XML element decoders.
-     * 
-     * @return the XML element decoders.
-     */
-    @Deprecated
-    protected ElementDecoders getDecoders() {
-        return DEFAULT_ELEMENT_DECODERS;
-    }
-
-    /**
-     * This method returns the XML element decoders.
-     * 
-     * @param resource the "resource" currently be tested.
-     * @return the XML element decoders.
-     */
-    protected ElementDecoders getDecoders(final String resource) {
-        return getDecoders();
-    }
-
-    /**
-     * This method returns the XML element encoders.
-     * 
-     * @return the XML element encoders.
-     */
-    @Deprecated
-    protected ElementEncoders getEncoders() {
-        return SHA256_ELEMENT_ENCODERS;
-    }
-
-    /**
-     * This method returns the XML element encoders.
-     * 
-     * @param resource the "resource" currently be tested.
-     * @return the XML element encoders.
-     */
-    protected ElementEncoders getEncoders(final String resource) {
-        return getEncoders();
-    }
-
-    /**
      * When the data is able to be retrieved from the XML (e.g. when getEncoders() returns the default encoders), then this
      * method should be empty. However, in this case getEncoders() is returning the sha256 encoders which means the original
      * data cannot be retrieved from the XML. Therefore, in order to test equivalence, all of the non-printable data in the
@@ -266,23 +222,6 @@ public abstract class RegressionTest extends ExtractionTest {
 
         // Run the normal extraction/regression tests
         super.testExtractionPlace(resource);
-    }
-
-    @Override
-    protected List<IBaseDataObject> processHeavyDutyHook(IServiceProviderPlace place, IBaseDataObject payload)
-            throws Exception {
-        if (getLogbackLoggerName() == null) {
-            actualSimplifiedLogEvents = new ArrayList<>();
-            return super.processHeavyDutyHook(place, payload);
-        } else {
-            try (LogbackTester logbackTester = new LogbackTester(getLogbackLoggerName())) {
-                final List<IBaseDataObject> attachments = super.processHeavyDutyHook(place, payload);
-
-                actualSimplifiedLogEvents = logbackTester.getSimplifiedLogEvents();
-
-                return attachments;
-            }
-        }
     }
 
     @Override


### PR DESCRIPTION
Builds on #1153 -- updating setupPayload to use the IBaseDataObjectXmlHelper class to parse the answer file. Had to move the encoder/decoder methods up to ExtractionTest. Also, removed `processHeavyDutyHook` in RegressionTest as it was almost identical to the overridden method. 