### PR TITLE
add murmur hash 'HASH_ID' to KffDataObjectHandler

### DIFF
--- a/src/main/java/emissary/place/KffHashPlace.java
+++ b/src/main/java/emissary/place/KffHashPlace.java
@@ -23,35 +23,49 @@ public class KffHashPlace extends ServiceProviderPlace {
 
     private boolean useSbc = false;
 
+    private boolean createMurmurHash = false;
+    private String murmurHashParamName = "HASH_ID";
+
     public KffHashPlace(String thePlaceLocation) throws IOException {
         super(thePlaceLocation);
+        configurePlace();
     }
 
     public KffHashPlace(String configFile, String theDir, String thePlaceLocation) throws IOException {
         super(configFile, theDir, thePlaceLocation);
+        configurePlace();
     }
 
     public KffHashPlace(InputStream configStream, String theDir, String thePlaceLocation) throws IOException {
         super(configStream, theDir, thePlaceLocation);
+        configurePlace();
     }
 
     public KffHashPlace(InputStream configStream) throws IOException {
         super(configStream);
+        configurePlace();
     }
 
     public KffHashPlace(String configFile, String placeLocation) throws IOException {
         super(configFile, placeLocation);
+        configurePlace();
     }
 
     public KffHashPlace(InputStream configStream, String placeLocation) throws IOException {
         super(configStream, placeLocation);
+        configurePlace();
     }
 
     @Override
     protected void setupPlace(String theDir, String placeLocation) throws IOException {
         super.setupPlace(theDir, placeLocation);
-        useSbc = configG.findBooleanEntry("USE_SBC", useSbc);
         initKff();
+    }
+
+    protected void configurePlace() {
+        useSbc = configG.findBooleanEntry("USE_SBC", useSbc);
+        createMurmurHash = configG.findBooleanEntry("CREATE_MURMUR_HASH", createMurmurHash);
+        murmurHashParamName = configG.findStringEntry("MURMUR_HASH_PARAM_NAME", murmurHashParamName);
     }
 
     @Override
@@ -61,7 +75,7 @@ public class KffHashPlace extends ServiceProviderPlace {
             return;
         }
 
-        kff.hash(payload, useSbc);
+        kff.hash(payload, useSbc, createMurmurHash, murmurHashParamName);
     }
 
 }

--- a/src/main/resources/emissary/place/KffHashPlace.cfg
+++ b/src/main/resources/emissary/place/KffHashPlace.cfg
@@ -9,3 +9,6 @@ SERVICE_PROXY = "UNKNOWN"
 
 # Use SeekableByteChannel-related methods (true) vs byte array based (false)
 USE_SBC = false
+
+CREATE_MURMUR_HASH = true
+MURMUR_HASH_PARAM_NAME = "HASH_ID"

--- a/src/test/java/emissary/kff/KffDataObjectHandlerTest.java
+++ b/src/test/java/emissary/kff/KffDataObjectHandlerTest.java
@@ -55,6 +55,15 @@ class KffDataObjectHandlerTest extends UnitTest {
 
     static final String DATA_CRC32 = "33323239323631363138";
 
+    /**
+     * HashCode hashCode = Hashing.murmur3_128().newHasher() .putString(DATA_MD5, StandardCharsets.UTF_8)
+     * .putString(DATA_SHA1, StandardCharsets.UTF_8) .putString(DATA_SHA256, StandardCharsets.UTF_8) .hash();
+     *
+     * return new StringBuilder(hashCode.toString()) .insert(20, "-") .insert(16, "-") .insert(12, "-") .insert(8, "-")
+     * .toString();
+     */
+    static final String DATA_HASH_ID = "b0cf6000-dbd3-3df6-eead-e7b144bdcc48";
+
     @Nullable
     protected KffDataObjectHandler kff;
     @Nullable
@@ -444,6 +453,41 @@ class KffDataObjectHandlerTest extends UnitTest {
     @Test
     void testEmptySbcf() {
         assertEquals(new HashMap<>(), kff.hashData(SeekableByteChannelHelper.EMPTY_CHANNEL_FACTORY, null));
+    }
+
+    @Test
+    void testMurmurHashCreation() {
+        payload.setParameter(KffDataObjectHandler.KFF_PARAM_MD5, DATA_MD5);
+        payload.setParameter(KffDataObjectHandler.KFF_PARAM_SHA1, DATA_SHA1);
+        payload.setParameter(KffDataObjectHandler.KFF_PARAM_SHA256, DATA_SHA256);
+
+        String murmurHash = KffDataObjectHandler.createMurmurHash(payload);
+
+        assertNotNull(murmurHash, "murmur hash should not be null when all hashes are set");
+        assertFalse(murmurHash.isEmpty(), "murmur hash should not be empty");
+        assertEquals(DATA_HASH_ID, murmurHash);
+    }
+
+    @Test
+    void testMurmurHashWithoutInputHashes() {
+        payload.deleteParameter(KffDataObjectHandler.KFF_PARAM_MD5);
+        payload.deleteParameter(KffDataObjectHandler.KFF_PARAM_SHA1);
+        payload.deleteParameter(KffDataObjectHandler.KFF_PARAM_SHA256);
+
+        String murmurHash = KffDataObjectHandler.createMurmurHash(payload);
+
+        assertNull(murmurHash, "murmur hash should be null when no hashes are set");
+    }
+
+    @Test
+    void testMurmurHashNotCreatedWhenMissingAnInputHash() {
+        payload.setParameter(KffDataObjectHandler.KFF_PARAM_MD5, DATA_MD5);
+        payload.deleteParameter(KffDataObjectHandler.KFF_PARAM_SHA1);
+        payload.setParameter(KffDataObjectHandler.KFF_PARAM_SHA256, DATA_SHA256);
+
+        String murmurHash = KffDataObjectHandler.createMurmurHash(payload);
+
+        assertNull(murmurHash, "murmur hash should be null when when one of the input hashes is missing");
     }
 
 }


### PR DESCRIPTION
Leveraging KffDataObjectHandler, create a new hash metadata field with the name HASH_ID. The field name should be configurable as well as the option to enable or disable the creation.

Create a murmur3 128 bit hash off the input of md5sum()-sha1sum()-sha256sum()

Original request code snippet so we can ensure the output matches the requested formatting:
```java
public static String getFileUUIDFromHashes(String md5, String sha1, String  sha256) {

  HashFunction hashFunction = Hashing.murmur3_128();
  HashCode hashCode = hashFunction.newHasher()
        .putString(md5, UTF_8)
        .putString(sha1, UTF_8)
        .putString(sha256, UTF_8)
        .hash();
  return new StringBuilder(hashCode.toString())
        .insert(20, "-")
        .insert(16, "-")
        .insert(12, "-")
        .insert(8, "-")
        .toString();
}
```