### PR TITLE
use 'java.io.tmpdir' location for unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
          when using the CLDR locale provider, which is the default in JDK11.
          https://www.oracle.com/technetwork/java/javase/documentation/java11locales-5069639.html
       -->
-    <surefire.argline>@{argLine} -Xmx1024m -Xms256m -Djava.locale.providers=COMPAT -Djava.net.preferIPv4Stack=true -Duser.timezone=GMT -Djava.awt.headless=true</surefire.argline>
+    <surefire.argline>@{argLine} -Xmx1024m -Xms256m -Djava.io.tmpdir=${java.io.tmpdir} -Djava.locale.providers=COMPAT -Djava.net.preferIPv4Stack=true -Duser.timezone=GMT -Djava.awt.headless=true</surefire.argline>
     <surefire.forkCount>.5C</surefire.forkCount>
   </properties>
   <dependencyManagement>

--- a/src/test/java/emissary/config/ServiceConfigGuideTest.java
+++ b/src/test/java/emissary/config/ServiceConfigGuideTest.java
@@ -400,7 +400,7 @@ class ServiceConfigGuideTest extends UnitTest {
 
         assertEquals(-1, sc.findStringEntry("MYPROJ").indexOf("PRJ_BASE"), "Replacement of  PRJ_BASE with value failed");
 
-        assertEquals(System.getProperty("java.io.tmpdir"), sc.findStringEntry("MYTMP"), "TMP_DIR magic replacement failed");
+        assertEquals(System.getProperty("java.io.tmpdir"), sc.findStringEntry("MYTMP"), "TMPDIR magic replacement failed");
 
         assertFalse(sc.findStringEntry("MYHOST").contains("@"), "Replacement of magic HOST failed");
 

--- a/src/test/java/emissary/test/core/junit5/UnitTest.java
+++ b/src/test/java/emissary/test/core/junit5/UnitTest.java
@@ -61,7 +61,7 @@ public abstract class UnitTest {
     @SuppressWarnings("NonFinalStaticField")
     public static File temporaryDirectory;
     @SuppressWarnings({"ConstantField", "NonFinalStaticField"})
-    protected static String TMPDIR = "/tmp";
+    protected static String TMPDIR = System.getProperty("java.io.tmpdir", "/tmp");
     @Nullable
     protected Package thisPackage = null;
     @Nullable


### PR DESCRIPTION
We can't assume '/tmp' works for unit testing everywhere due to possible security restrictions executing from '/tmp'. This should be configurable for those who require it. 

Adding this to the argline for surefire allows for proper promotion to the forked processes.

This also cleans up some variables:
 - TEMP_DIR (how we reference in cfg files)
 - TMPDIR (how we reference via env)
 - TMP_DIR (is confusing and should be removed)