### PR TITLE
New CoordinationPlace configs to deny places or put them at end of ref list

### DIFF
--- a/src/main/java/emissary/place/CoordinationPlace.java
+++ b/src/main/java/emissary/place/CoordinationPlace.java
@@ -108,6 +108,8 @@ public class CoordinationPlace extends ServiceProviderPlace {
         updateTransformHistory = configG.findBooleanEntry("UPDATE_TRANSFORM_HISTORY", false);
 
         placeKeys = configG.findEntries("SERVICE_COORDINATION");
+        placeKeys.addAll(configG.findEntries("APPEND_SERVICE_COORDINATION"));
+        placeKeys.removeAll(configG.findEntries("DENY_SERVICE_COORDINATION"));
         logger.debug("We got {} entries to coordinate", placeKeys.size());
 
         placeRefs = new ArrayList<>();

--- a/src/test/java/emissary/place/CoordinationPlaceTest.java
+++ b/src/test/java/emissary/place/CoordinationPlaceTest.java
@@ -1,16 +1,13 @@
 package emissary.place;
 
+import emissary.config.ConfigUtil;
 import emissary.core.DataObjectFactory;
+import emissary.core.EmissaryException;
 import emissary.core.IBaseDataObject;
 import emissary.core.MobileAgent;
 import emissary.core.Namespace;
 import emissary.core.ResourceWatcher;
-import emissary.place.sample.CachePlace;
-import emissary.place.sample.RefreshablePlace;
-import emissary.place.sample.ToLowerPlace;
-import emissary.place.sample.ToUpperPlace;
 import emissary.test.core.junit5.UnitTest;
-import emissary.util.io.ResourceReader;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -18,7 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.io.InputStream;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -38,8 +35,7 @@ class CoordinationPlaceTest extends UnitTest {
     public void setUp() throws Exception {
         super.setUp();
 
-        InputStream configStream = new ResourceReader().getConfigDataAsStream(this);
-        place = new CoordinationPlace(configStream);
+        place = new CoordinationPlace("emissary.place.CoordinationPlace.cfg");
 
         mockCoordPlace = mock(IServiceProviderPlace.class);
         place.placeRefs = Collections.singletonList(mockCoordPlace);
@@ -87,13 +83,23 @@ class CoordinationPlaceTest extends UnitTest {
     }
 
     @Test
-    void testPlaceReferenceOrder() {
-        place.configG.addEntry("APPEND_SERVICE_COORDINATION", RefreshablePlace.class.getName());
-        place.configG.addEntry("DENY_SERVICE_COORDINATION", CachePlace.class.getName());
+    void testPlaceReferenceOrder() throws IOException {
+        place.configG = ConfigUtil.getConfigInfo(CoordinationPlaceTest.class);
+        place.configurePlace();
 
-        place.configG.addEntry("SERVICE_COORDINATION", CachePlace.class.getName());
-        place.configG.addEntry("SERVICE_COORDINATION", ToLowerPlace.class.getName());
-        place.configG.addEntry("SERVICE_COORDINATION", ToUpperPlace.class.getName());
+        assertEquals(3, place.placeRefs.size());
+        assertEquals("emissary.place.sample.CachePlace", place.placeRefs.get(0).getPlaceName());
+        assertEquals("emissary.place.sample.ToLowerPlace", place.placeRefs.get(1).getPlaceName());
+        assertEquals("emissary.place.sample.ToUpperPlace", place.placeRefs.get(2).getPlaceName());
+    }
+
+    @Test
+    void testPlaceReferenceOrderWithFlavor() throws EmissaryException, IOException {
+        String originalFlavor = System.getProperty(ConfigUtil.CONFIG_FLAVOR_PROPERTY);
+        System.setProperty(ConfigUtil.CONFIG_FLAVOR_PROPERTY, String.join(",", originalFlavor, "FLAVORTEST"));
+        ConfigUtil.initialize();
+
+        place.configG = ConfigUtil.getConfigInfo(CoordinationPlaceTest.class);
         place.configurePlace();
 
         assertEquals(3, place.placeRefs.size());
@@ -101,9 +107,8 @@ class CoordinationPlaceTest extends UnitTest {
         assertEquals("emissary.place.sample.ToUpperPlace", place.placeRefs.get(1).getPlaceName());
         assertEquals("emissary.place.sample.RefreshablePlace", place.placeRefs.get(2).getPlaceName());
 
-        place.configG.removeEntry("APPEND_SERVICE_COORDINATION", RefreshablePlace.class.getName());
-        place.configG.removeEntry("SERVICE_COORDINATION", ToUpperPlace.class.getName());
-        place.configG.removeEntry("SERVICE_COORDINATION", ToLowerPlace.class.getName());
+        System.setProperty(ConfigUtil.CONFIG_FLAVOR_PROPERTY, originalFlavor);
+        ConfigUtil.initialize();
     }
 
     @Test

--- a/src/test/java/emissary/place/CoordinationPlaceTest.java
+++ b/src/test/java/emissary/place/CoordinationPlaceTest.java
@@ -103,25 +103,29 @@ class CoordinationPlaceTest extends UnitTest {
     @Test
     void testPlaceReferenceOrderWithFlavor() throws EmissaryException, IOException {
         String originalFlavor = System.getProperty(ConfigUtil.CONFIG_FLAVOR_PROPERTY);
-        System.setProperty(ConfigUtil.CONFIG_FLAVOR_PROPERTY, String.join(",", originalFlavor, "FLAVORTEST"));
-        ConfigUtil.initialize();
 
-        place.configG = ConfigUtil.getConfigInfo(CoordinationPlaceTest.class);
-        place.configurePlace();
+        try {
+            System.setProperty(ConfigUtil.CONFIG_FLAVOR_PROPERTY, String.join(",", originalFlavor, "FLAVORTEST"));
+            ConfigUtil.initialize();
 
-        List<String> expectedRefs = List.of(
-                "emissary.place.sample.ToLowerPlace",
-                "emissary.place.sample.ToUpperPlace",
-                "emissary.place.sample.RefreshablePlace");
+            place.configG = ConfigUtil.getConfigInfo(CoordinationPlaceTest.class);
+            place.configurePlace();
 
-        List<String> actualRefs = place.placeRefs.stream()
-                .map(IServiceProviderPlace::getPlaceName)
-                .collect(Collectors.toList());
+            List<String> expectedRefs = List.of(
+                    "emissary.place.sample.ToLowerPlace",
+                    "emissary.place.sample.ToUpperPlace",
+                    "emissary.place.sample.RefreshablePlace");
 
-        assertEquals(expectedRefs, actualRefs);
+            List<String> actualRefs = place.placeRefs.stream()
+                    .map(IServiceProviderPlace::getPlaceName)
+                    .collect(Collectors.toList());
 
-        System.setProperty(ConfigUtil.CONFIG_FLAVOR_PROPERTY, originalFlavor);
-        ConfigUtil.initialize();
+            assertEquals(expectedRefs, actualRefs);
+
+        } finally {
+            System.setProperty(ConfigUtil.CONFIG_FLAVOR_PROPERTY, originalFlavor);
+            ConfigUtil.initialize();
+        }
     }
 
     @Test

--- a/src/test/java/emissary/place/CoordinationPlaceTest.java
+++ b/src/test/java/emissary/place/CoordinationPlaceTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -87,10 +88,16 @@ class CoordinationPlaceTest extends UnitTest {
         place.configG = ConfigUtil.getConfigInfo(CoordinationPlaceTest.class);
         place.configurePlace();
 
-        assertEquals(3, place.placeRefs.size());
-        assertEquals("emissary.place.sample.CachePlace", place.placeRefs.get(0).getPlaceName());
-        assertEquals("emissary.place.sample.ToLowerPlace", place.placeRefs.get(1).getPlaceName());
-        assertEquals("emissary.place.sample.ToUpperPlace", place.placeRefs.get(2).getPlaceName());
+        List<String> expectedRefs = List.of(
+                "emissary.place.sample.CachePlace",
+                "emissary.place.sample.ToLowerPlace",
+                "emissary.place.sample.ToUpperPlace");
+
+        List<String> actualRefs = place.placeRefs.stream()
+                .map(IServiceProviderPlace::getPlaceName)
+                .collect(Collectors.toList());
+
+        assertEquals(expectedRefs, actualRefs);
     }
 
     @Test
@@ -102,10 +109,16 @@ class CoordinationPlaceTest extends UnitTest {
         place.configG = ConfigUtil.getConfigInfo(CoordinationPlaceTest.class);
         place.configurePlace();
 
-        assertEquals(3, place.placeRefs.size());
-        assertEquals("emissary.place.sample.ToLowerPlace", place.placeRefs.get(0).getPlaceName());
-        assertEquals("emissary.place.sample.ToUpperPlace", place.placeRefs.get(1).getPlaceName());
-        assertEquals("emissary.place.sample.RefreshablePlace", place.placeRefs.get(2).getPlaceName());
+        List<String> expectedRefs = List.of(
+                "emissary.place.sample.ToLowerPlace",
+                "emissary.place.sample.ToUpperPlace",
+                "emissary.place.sample.RefreshablePlace");
+
+        List<String> actualRefs = place.placeRefs.stream()
+                .map(IServiceProviderPlace::getPlaceName)
+                .collect(Collectors.toList());
+
+        assertEquals(expectedRefs, actualRefs);
 
         System.setProperty(ConfigUtil.CONFIG_FLAVOR_PROPERTY, originalFlavor);
         ConfigUtil.initialize();

--- a/src/test/java/emissary/place/CoordinationPlaceTest.java
+++ b/src/test/java/emissary/place/CoordinationPlaceTest.java
@@ -5,6 +5,10 @@ import emissary.core.IBaseDataObject;
 import emissary.core.MobileAgent;
 import emissary.core.Namespace;
 import emissary.core.ResourceWatcher;
+import emissary.place.sample.CachePlace;
+import emissary.place.sample.RefreshablePlace;
+import emissary.place.sample.ToLowerPlace;
+import emissary.place.sample.ToUpperPlace;
 import emissary.test.core.junit5.UnitTest;
 import emissary.util.io.ResourceReader;
 
@@ -80,6 +84,26 @@ class CoordinationPlaceTest extends UnitTest {
         List<IBaseDataObject> sprouts = place.processHeavyDuty(ibdo);
         assertTrue(CollectionUtils.isNotEmpty(sprouts) && sprouts.size() == 1);
         assertTrue(ibdo.getAllCurrentForms().contains("TESTCOORDINATE"));
+    }
+
+    @Test
+    void testPlaceReferenceOrder() {
+        place.configG.addEntry("APPEND_SERVICE_COORDINATION", RefreshablePlace.class.getName());
+        place.configG.addEntry("DENY_SERVICE_COORDINATION", CachePlace.class.getName());
+
+        place.configG.addEntry("SERVICE_COORDINATION", CachePlace.class.getName());
+        place.configG.addEntry("SERVICE_COORDINATION", ToLowerPlace.class.getName());
+        place.configG.addEntry("SERVICE_COORDINATION", ToUpperPlace.class.getName());
+        place.configurePlace();
+
+        assertEquals(3, place.placeRefs.size());
+        assertEquals("emissary.place.sample.ToLowerPlace", place.placeRefs.get(0).getPlaceName());
+        assertEquals("emissary.place.sample.ToUpperPlace", place.placeRefs.get(1).getPlaceName());
+        assertEquals("emissary.place.sample.RefreshablePlace", place.placeRefs.get(2).getPlaceName());
+
+        place.configG.removeEntry("APPEND_SERVICE_COORDINATION", RefreshablePlace.class.getName());
+        place.configG.removeEntry("SERVICE_COORDINATION", ToUpperPlace.class.getName());
+        place.configG.removeEntry("SERVICE_COORDINATION", ToLowerPlace.class.getName());
     }
 
     @Test

--- a/src/test/resources/emissary/place/CoordinationPlaceTest-FLAVORTEST.cfg
+++ b/src/test/resources/emissary/place/CoordinationPlaceTest-FLAVORTEST.cfg
@@ -1,0 +1,2 @@
+DENY_SERVICE_COORDINATION = "emissary.place.sample.CachePlace"
+APPEND_SERVICE_COORDINATION = "emissary.place.sample.RefreshablePlace"

--- a/src/test/resources/emissary/place/CoordinationPlaceTest.cfg
+++ b/src/test/resources/emissary/place/CoordinationPlaceTest.cfg
@@ -1,0 +1,9 @@
+# Test to set up a coordinate place that needs an upper and a lower
+URL = "@{emissary.node.scheme}://@{emissary.node.name}:@{emissary.node.port}"
+SERVICE_KEY = "TEST.TESTCOORDINATE.COORDINATE.@{URL}/CoordinationPlaceTest$3050"
+
+SERVICE_COORDINATION = "emissary.place.sample.CachePlace"
+SERVICE_COORDINATION = "emissary.place.sample.ToLowerPlace"
+SERVICE_COORDINATION = "emissary.place.sample.ToUpperPlace"
+
+OUTPUT_FORM = "TESTCOORDINATE"


### PR DESCRIPTION
All `SERVICE_COORDINATION` parameters defined in a coordination place's flavored config file will end up at the beginning of the reference list. Added two new parameters for when this behavior isn't wanted:
1. `APPEND_SERVICE_COORDINATION`: Appends a place to the *end* of the reference list
2. `DENY_SERVICE_COORDINATION`: Remove a place from the reference list (e.g. it was defined in the base config file but you don't want it in a given flavor)

These changes haven't been discussed anywhere prior to this PR as far as I'm aware. It just seemed like it would be useful. These code changes only took a few minutes so if we decide we don't wanna move forward with this it's not a big deal. 

