### PR TITLE
adding OS specific checks to attachment elements in ExtractionTest

### DIFF
--- a/src/test/java/emissary/test/core/junit5/ExtractionTest.java
+++ b/src/test/java/emissary/test/core/junit5/ExtractionTest.java
@@ -382,28 +382,40 @@ public abstract class ExtractionTest extends UnitTest {
                 osSpecificNumAtt = true;
             }
         }
+
+        // check attachments answer file count against payload count
         if (!osSpecificNumAtt) {
             numAtt = JDOMUtil.getChildIntValue(el, "numAttachments");
             numAttElements = el.getChildren().stream().filter(c -> c.getName().startsWith(ATTACHMENT_ELEMENT_PREFIX)).count();
-        }
 
-        // check attachments answer file count against payload count
-        if (numAtt > -1) {
-            if (osSpecificNumAtt && attachments != null && !attachments.isEmpty()) {
-                assertTrue(numAtt <= attachments.size(), String.format(
-                        "Expected <numAttachments> in %s for specific OS not less than or equal to number of att in payload. ==> expected: <%d> but was: <%d>",
-                        tname, numAtt, attachments.size()));
-            } else {
+            if (numAtt > -1) {
                 assertEquals(numAtt, attachments != null ? attachments.size() : 0,
                         String.format("Expected <numAttachments> in %s not equal to number of att in payload.", tname));
+            } else if (numAtt == -1 && numAttElements > 0) {
+                assertEquals(numAttElements, attachments != null ? attachments.size() : 0,
+                        String.format("Expected <att#> in %s not equal to number of att in payload.", tname));
+            } else {
+                if (attachments != null && !attachments.isEmpty()) {
+                    fail(String.format("%d attachments in payload with no count in answer xml, add matching <numAttachments> count for %s",
+                            attachments.size(), tname));
+                }
             }
-        } else if (numAtt == -1 && numAttElements > 0) {
-            assertEquals(numAttElements, attachments != null ? attachments.size() : 0,
-                    String.format("Expected <att#> in %s not equal to number of att in payload.", tname));
         } else {
-            if (attachments != null && !attachments.isEmpty()) {
-                fail(String.format("%d attachments in payload with no count in answer xml, add matching <numAttachments> count for %s",
-                        attachments.size(), tname));
+            int attInPayload = attachments != null ? attachments.size() : 0;
+            assertTrue(numAtt <= attInPayload, String.format(
+                    "Expected <numAttachments> in %s for specific OS not less than or equal to number of att in payload. ==> expected: <%d> but was: <%d>",
+                    tname, numAtt, attInPayload));
+            assertTrue(numAttElements <= attInPayload, String.format(
+                    "Expected <att#> in %s for specific OS not less than or equal to number of att in payload. ==> expected: <%d> but was: <%d>",
+                    tname, numAttElements, attInPayload));
+            if (numAtt == -1) {
+                assertEquals(0, numAttElements,
+                        String.format("OS Specific <numAttachments> & <att#> in %s are not equal. ==> <numAttachments>:<%d> <att#>:<%d>", tname,
+                                0, numAttElements));
+            } else {
+                assertEquals(numAtt, numAttElements,
+                        String.format("OS Specific <numAttachments> & <att#> in %s are not equal. ==> <numAttachments>:<%d> <att#>:<%d>", tname,
+                                numAtt, numAttElements));
             }
         }
 

--- a/src/test/java/emissary/test/core/junit5/ExtractionTest.java
+++ b/src/test/java/emissary/test/core/junit5/ExtractionTest.java
@@ -373,21 +373,20 @@ public abstract class ExtractionTest extends UnitTest {
         boolean osSpecificNumAtt = false;
         List<Element> numAttachments = el.getChildren("numAttachments");
         for (Element numAttEl : numAttachments) {
-            if (verifyOs(numAttEl) && numAttEl.getAttribute("os-release") != null) {
-                String osRelease = numAttEl.getAttribute("os-release").getValue();
+            if (verifyOs(numAttEl)) {
                 numAtt = Integer.parseInt(numAttEl.getValue());
                 numAttElements = el.getChildren().stream().filter(
-                        c -> c.getName().startsWith(ATTACHMENT_ELEMENT_PREFIX) && c.getAttribute("os-release").getValue().equals(osRelease))
-                        .count();
-                osSpecificNumAtt = true;
+                        c -> c.getName().startsWith(ATTACHMENT_ELEMENT_PREFIX) && verifyOs(c)).count();
+                // see if os specific numAttachments for check against payload
+                if (numAttEl.getAttribute("os-release") != null) {
+                    osSpecificNumAtt = true;
+                }
+                break;
             }
         }
 
         // check attachments answer file count against payload count
         if (!osSpecificNumAtt) {
-            numAtt = JDOMUtil.getChildIntValue(el, "numAttachments");
-            numAttElements = el.getChildren().stream().filter(c -> c.getName().startsWith(ATTACHMENT_ELEMENT_PREFIX)).count();
-
             if (numAtt > -1) {
                 assertEquals(numAtt, attachments != null ? attachments.size() : 0,
                         String.format("Expected <numAttachments> in %s not equal to number of att in payload.", tname));
@@ -410,8 +409,8 @@ public abstract class ExtractionTest extends UnitTest {
                     tname, numAttElements, attInPayload));
             if (numAtt == -1) {
                 assertEquals(0, numAttElements,
-                        String.format("OS Specific <numAttachments> & <att#> in %s are not equal. ==> <numAttachments>:<%d> <att#>:<%d>", tname,
-                                0, numAttElements));
+                        String.format("OS Specific <numAttachments> & <att#> in %s are not equal. ==> <numAttachments>:<%d> <att#>:<%d>", tname, 0,
+                                numAttElements));
             } else {
                 assertEquals(numAtt, numAttElements,
                         String.format("OS Specific <numAttachments> & <att#> in %s are not equal. ==> <numAttachments>:<%d> <att#>:<%d>", tname,

--- a/src/test/java/emissary/test/core/junit5/ExtractionTest.java
+++ b/src/test/java/emissary/test/core/junit5/ExtractionTest.java
@@ -371,32 +371,39 @@ public abstract class ExtractionTest extends UnitTest {
         int numAtt = -1;
         long numAttElements = 0;
         boolean osSpecificNumAtt = false;
-        for (Element numAttEl : el.getChildren("numAttachments")) {
+        List<Element> numAttachments = el.getChildren("numAttachments");
+        for (Element numAttEl : numAttachments) {
             if (verifyOs(numAttEl) && numAttEl.getAttribute("os-release") != null) {
                 String osRelease = numAttEl.getAttribute("os-release").getValue();
-                numAtt = JDOMUtil.getChildIntValue(numAttEl, "numAttachments");
+                numAtt = Integer.parseInt(numAttEl.getValue());
                 numAttElements = el.getChildren().stream().filter(
-                        c -> c.getName().startsWith(ATTACHMENT_ELEMENT_PREFIX) && numAttEl.getAttribute("os-release").getValue().equals(osRelease))
+                        c -> c.getName().startsWith(ATTACHMENT_ELEMENT_PREFIX) && c.getAttribute("os-release").getValue().equals(osRelease))
                         .count();
                 osSpecificNumAtt = true;
-            } else {
-                numAtt = JDOMUtil.getChildIntValue(el, "numAttachments");
-                numAttElements = el.getChildren().stream().filter(c -> c.getName().startsWith(ATTACHMENT_ELEMENT_PREFIX)).count();
             }
         }
-        // check attachments answer file count against payload count
         if (!osSpecificNumAtt) {
-            if (numAtt > -1) {
+            numAtt = JDOMUtil.getChildIntValue(el, "numAttachments");
+            numAttElements = el.getChildren().stream().filter(c -> c.getName().startsWith(ATTACHMENT_ELEMENT_PREFIX)).count();
+        }
+
+        // check attachments answer file count against payload count
+        if (numAtt > -1) {
+            if (osSpecificNumAtt && attachments != null && !attachments.isEmpty()) {
+                assertTrue(numAtt <= attachments.size(), String.format(
+                        "Expected <numAttachments> in %s for specific OS not less than or equal to number of att in payload. ==> expected: <%d> but was: <%d>",
+                        tname, numAtt, attachments.size()));
+            } else {
                 assertEquals(numAtt, attachments != null ? attachments.size() : 0,
                         String.format("Expected <numAttachments> in %s not equal to number of att in payload.", tname));
-            } else if (numAtt == -1 && numAttElements > 0) {
-                assertEquals(numAttElements, attachments != null ? attachments.size() : 0,
-                        String.format("Expected <att#> in %s not equal to number of att in payload.", tname));
-            } else {
-                if (attachments != null && !attachments.isEmpty()) {
-                    fail(String.format("%d attachments in payload with no count in answer xml, add matching <numAttachments> count for %s",
-                            attachments.size(), tname));
-                }
+            }
+        } else if (numAtt == -1 && numAttElements > 0) {
+            assertEquals(numAttElements, attachments != null ? attachments.size() : 0,
+                    String.format("Expected <att#> in %s not equal to number of att in payload.", tname));
+        } else {
+            if (attachments != null && !attachments.isEmpty()) {
+                fail(String.format("%d attachments in payload with no count in answer xml, add matching <numAttachments> count for %s",
+                        attachments.size(), tname));
             }
         }
 

--- a/src/test/resources/emissary/test/core/junit5/OsSpecificTest.xml
+++ b/src/test/resources/emissary/test/core/junit5/OsSpecificTest.xml
@@ -1,5 +1,10 @@
 <result>
     <answers>
+    	<numAttachments os-release="mac">0</numAttachments>
+        <numAttachments os-release="rhel">0</numAttachments>
+        <numAttachments os-release="centos">0</numAttachments>
+        <numAttachments os-release="ubuntu">0</numAttachments>
+    
         <dataLength os-release="ubuntu">22</dataLength>
         <dataLength os-release="centos">51</dataLength>
         <dataLength os-release="rhel">20</dataLength>

--- a/src/test/resources/emissary/test/core/schemas/answers.xsd
+++ b/src/test/resources/emissary/test/core/schemas/answers.xsd
@@ -178,6 +178,8 @@
             <xs:group ref="children"/>
         </xs:choice>
         <xs:attribute name="index" type="xs:int" />
+        <xs:attribute ref="os-release"/>
+        <xs:attribute ref="os-version"/>
     </xs:complexType>
     <xs:group name="children">
         <xs:sequence>


### PR DESCRIPTION
adding ability to have OS specific `<numAttachments>` & `<att#>` in test answer files.