### PR TITLE
Add unlimited retry support for gRPC calls

### DIFF
--- a/src/main/java/emissary/grpc/retry/RetryHandler.java
+++ b/src/main/java/emissary/grpc/retry/RetryHandler.java
@@ -13,6 +13,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -34,6 +36,9 @@ import java.util.function.Supplier;
  * default={@code 2.0}</li>
  * <li>{@code GRPC_RETRY_NUM_FAILS_BEFORE_WARN} - Determines the number of execution failures before logger should start
  * sending warnings, default={@code 3}</li>
+ * <li>{@code GRPC_RETRY_UNLIMITED} - When {@code true}, the retry cycle restarts indefinitely after exhausting
+ * {@code GRPC_RETRY_MAX_ATTEMPTS} until the call succeeds. Use this when downstream systems must block until the gRPC
+ * request completes and a permanent failure is not acceptable, default={@code false}</li>
  * </ul>
  * To calculate exponential backoff wait time, let:
  * <ul>
@@ -60,6 +65,7 @@ public final class RetryHandler {
     public static final String GRPC_RETRY_MAX_WAIT_MILLIS = "GRPC_RETRY_MAX_WAIT_MILLIS";
     public static final String GRPC_RETRY_MULTIPLIER = "GRPC_RETRY_MULTIPLIER";
     public static final String GRPC_RETRY_NUM_FAILS_BEFORE_WARN = "GRPC_RETRY_NUM_FAILS_BEFORE_WARN";
+    public static final String GRPC_RETRY_UNLIMITED = "GRPC_RETRY_UNLIMITED";
 
     private static final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
     private static final Logger logger = LoggerFactory.getLogger(RetryHandler.class);
@@ -67,6 +73,7 @@ public final class RetryHandler {
     private final String internalName;
     private final int maxAttempts;
     private final int numFailsBeforeWarn;
+    private final boolean retryUnlimited;
     private final Retry retry;
 
     /**
@@ -81,6 +88,7 @@ public final class RetryHandler {
         internalName = retryName;
         maxAttempts = configG.findIntEntry(GRPC_RETRY_MAX_ATTEMPTS, 4);
         numFailsBeforeWarn = configG.findIntEntry(GRPC_RETRY_NUM_FAILS_BEFORE_WARN, 3);
+        retryUnlimited = configG.findBooleanEntry(GRPC_RETRY_UNLIMITED, false);
 
         retry = Retry.of(internalName, RetryConfig.custom()
                 .maxAttempts(maxAttempts)
@@ -107,10 +115,52 @@ public final class RetryHandler {
     }
 
     public <T> T execute(Supplier<T> supplier) {
-        return Retry.decorateSupplier(retry, supplier).get();
+        if (!retryUnlimited) {
+            return Retry.decorateSupplier(retry, supplier).get();
+        }
+        int cycleCount = 0;
+        while (true) {
+            try {
+                return Retry.decorateSupplier(retry, supplier).get();
+            } catch (ServiceNotAvailableException | PoolException e) {
+                logger.warn("{} exhausted {} max retry attempts (cycle #{}), restarting due to unlimited retry mode",
+                        internalName, maxAttempts, ++cycleCount);
+            }
+        }
     }
 
     public <T> CompletionStage<T> executeAsync(Supplier<CompletionStage<T>> supplier) {
-        return Retry.decorateCompletionStage(retry, scheduler, supplier).get();
+        if (!retryUnlimited) {
+            return Retry.decorateCompletionStage(retry, scheduler, supplier).get();
+        }
+        CompletableFuture<T> result = new CompletableFuture<>();
+        attemptAsyncUnlimited(supplier, result, 0);
+        return result;
+    }
+
+    private <T> void attemptAsyncUnlimited(Supplier<CompletionStage<T>> supplier, CompletableFuture<T> result, int cycleCount) {
+        Retry.decorateCompletionStage(retry, scheduler, supplier).get()
+                .whenComplete((value, throwable) -> {
+                    if (throwable == null) {
+                        result.complete(value);
+                    } else {
+                        Throwable cause = unwrapCompletionCause(throwable);
+                        if (cause instanceof ServiceNotAvailableException || cause instanceof PoolException) {
+                            logger.warn("{} exhausted {} max retry attempts (cycle #{}), restarting due to unlimited retry mode",
+                                    internalName, maxAttempts, cycleCount + 1);
+                            scheduler.execute(() -> attemptAsyncUnlimited(supplier, result, cycleCount + 1));
+                        } else {
+                            result.completeExceptionally(throwable);
+                        }
+                    }
+                });
+    }
+
+    private static Throwable unwrapCompletionCause(Throwable throwable) {
+        Throwable current = throwable;
+        while (current instanceof CompletionException && current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
     }
 }

--- a/src/test/java/emissary/grpc/sample/GrpcSampleServicePlaceTest.java
+++ b/src/test/java/emissary/grpc/sample/GrpcSampleServicePlaceTest.java
@@ -296,6 +296,54 @@ class GrpcSampleServicePlaceTest extends UnitTest {
     }
 
     @Nested
+    class UnlimitedRetryTests extends UnitTest {
+        private static final String TARGET_ID = ENDPOINT_1_ID;
+        // Small max attempts per cycle so tests cross cycle boundaries quickly
+        private static final int RETRY_ATTEMPTS = 2;
+
+        @BeforeEach
+        void initialize() {
+            samplePlace = placeFactory.buildPlace(
+                    new ConfigEntry(RetryHandler.GRPC_RETRY_MAX_ATTEMPTS, Integer.toString(RETRY_ATTEMPTS)),
+                    new ConfigEntry(RetryHandler.GRPC_RETRY_UNLIMITED, Boolean.TRUE.toString()),
+                    new ConfigEntry(RetryHandler.GRPC_RETRY_INITIAL_WAIT_MILLIS, "1"),
+                    new ConfigEntry(RetryHandler.GRPC_RETRY_MAX_WAIT_MILLIS, "1"),
+                    new ConfigEntry(GrpcSampleServicePlace.GRPC_PORT + ENDPOINT_1_ID, getPort(endpointOneServer)),
+                    new ConfigEntry(GrpcSampleServicePlace.GRPC_PORT + ENDPOINT_2_ID, getPort(endpointTwoServer)));
+            dataObject = new BaseDataObject(INPUT_DATA, FILENAME, createSampleForm(TARGET_ID));
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Status.Code.class, names = {"RESOURCE_EXHAUSTED", "UNAVAILABLE"}, mode = EnumSource.Mode.INCLUDE)
+        void testGrpcSucceedsAfterMultipleRetryCycles(Status.Code code) {
+            Status status = Status.fromCode(code);
+            AtomicInteger attemptNumber = new AtomicInteger(0);
+            // Require more failures than a single retry cycle allows, forcing at least one cycle restart
+            int totalFailuresBeforeSuccess = RETRY_ATTEMPTS * 3;
+
+            samplePlace.throwExceptionsDuringProcessWithSuccessfulRetry(dataObject, new StatusRuntimeException(status),
+                    totalFailuresBeforeSuccess, attemptNumber);
+
+            assertArrayEquals(ENDPOINT_1_PROCESSED_DATA, getSampleAltView(dataObject));
+            assertEquals(totalFailuresBeforeSuccess, attemptNumber.get());
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Status.Code.class, names = {"RESOURCE_EXHAUSTED", "UNAVAILABLE"}, mode = EnumSource.Mode.EXCLUDE)
+        void testNonRecoverableCodesStillFail(Status.Code code) {
+            Status status = Status.fromCode(code);
+            AtomicInteger attemptNumber = new AtomicInteger(0);
+
+            Runnable invocation = () -> samplePlace.throwExceptionsDuringProcessWithSuccessfulRetry(
+                    dataObject, new StatusRuntimeException(status), RETRY_ATTEMPTS * 3, attemptNumber);
+            assertThrows(ServiceException.class, invocation::run);
+
+            // Non-recoverable errors are not retried regardless of unlimited mode
+            assertEquals(1, attemptNumber.get());
+        }
+    }
+
+    @Nested
     class ProcessRoutingTests extends UnitTest {
         private static final String ENDPOINT_3_ID = "EXAMPLE_ENDPOINT_3";
 


### PR DESCRIPTION
Downstream had this feature to block processing gRPC is not responsive. Match the same capability here. 



This pull request adds support for an "unlimited retry" mode to the `RetryHandler`, allowing gRPC calls to be retried indefinitely until they succeed, rather than failing after a maximum number of attempts. It introduces a new configuration option, updates the retry logic for both synchronous and asynchronous calls, and adds comprehensive tests for the new behavior.

**Unlimited Retry Feature:**

* Added a new configuration property `GRPC_RETRY_UNLIMITED` to enable unlimited retry cycles after exhausting the configured maximum attempts. When enabled, the retry cycle restarts indefinitely until the call succeeds. [[1]](diffhunk://#diff-6793610d295357d2736a5a4b64c64a48f66a95801cfae07880ccae2a98e11eedR39-R41) [[2]](diffhunk://#diff-6793610d295357d2736a5a4b64c64a48f66a95801cfae07880ccae2a98e11eedR68-R76) [[3]](diffhunk://#diff-6793610d295357d2736a5a4b64c64a48f66a95801cfae07880ccae2a98e11eedR91)
* Updated the `execute` and `executeAsync` methods in `RetryHandler` to support unlimited retry cycles, including custom logic for both synchronous and asynchronous retries.
* Added helper methods for unwrapping exceptions and handling retry cycles in asynchronous execution.

**Testing:**

* Added a new nested test class `UnlimitedRetryTests` in `GrpcSampleServicePlaceTest.java` to verify the unlimited retry behavior, including tests for both recoverable and non-recoverable gRPC error codes.

**Dependency and Import Updates:**

* Added imports for `CompletableFuture` and `CompletionException` to support the new async retry logic.