### PR TITLE
exclude github-actions[bot] from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,6 +3,7 @@ changelog:
   exclude:
     authors:
       - github-actions
+      - github-actions[bot]
   categories:
     - title: Breaking Changes 🚨
       labels:


### PR DESCRIPTION
this is to avoid adding the "set next dev snapshot prs"