### PR TITLE
tech-debt :: updated code to use path.of

### DIFF
--- a/src/main/java/emissary/command/BaseCommand.java
+++ b/src/main/java/emissary/command/BaseCommand.java
@@ -23,7 +23,6 @@ import java.io.PrintStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 @Command(description = "Base Command")
@@ -39,7 +38,7 @@ public abstract class BaseCommand implements EmissaryCommand {
 
     @Option(names = {"-b", "--projectBase"}, description = "defaults to PROJECT_BASE, errors if different\nDefault: ${DEFAULT-VALUE}",
             converter = ProjectBaseConverter.class)
-    private Path projectBase = Paths.get(System.getenv("PROJECT_BASE"));
+    private Path projectBase = Path.of(System.getenv("PROJECT_BASE"));
 
     @Option(names = "--logbackConfig", description = "logback configuration file, defaults to <configDir>/logback.xml")
     @Nullable
@@ -210,7 +209,7 @@ public abstract class BaseCommand implements EmissaryCommand {
             // logCfg can be null if Emissary.setupLogbackForConsole is called
             LOG.warn("Not using {}, staying with test config {}", getLogbackConfig(), logCfg);
             doLogbackReinit(loggerContext, logCfg.getPath());
-        } else if (Files.exists(Paths.get(getLogbackConfig()))) {
+        } else if (Files.exists(Path.of(getLogbackConfig()))) {
             doLogbackReinit(loggerContext, getLogbackConfig());
         } else {
             LOG.warn("logback configuration not found {}, not reconfiguring logging", getLogbackConfig());

--- a/src/main/java/emissary/command/converter/FileExistsConverter.java
+++ b/src/main/java/emissary/command/converter/FileExistsConverter.java
@@ -8,7 +8,6 @@ import picocli.CommandLine.ITypeConverter;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class FileExistsConverter implements ITypeConverter<File> {
     private final String optionName;
@@ -24,7 +23,7 @@ public class FileExistsConverter implements ITypeConverter<File> {
 
     @Override
     public File convert(String value) {
-        Path p = Paths.get(value);
+        Path p = Path.of(value);
         if (!Files.exists(p)) {
             String msg = String.format("The option '%s' was configured with path '%s' which does not exist", optionName, p);
             LOG.error(msg);

--- a/src/main/java/emissary/command/converter/PathExistsConverter.java
+++ b/src/main/java/emissary/command/converter/PathExistsConverter.java
@@ -8,7 +8,6 @@ import picocli.CommandLine.ITypeConverter;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class PathExistsConverter implements ITypeConverter<Path> {
     private final String optionName;
@@ -29,7 +28,7 @@ public class PathExistsConverter implements ITypeConverter<Path> {
     }
 
     public Path convert(String option, String value) {
-        Path p = Paths.get(Strings.CS.removeEnd(value, "/"));
+        Path p = Path.of(Strings.CS.removeEnd(value, "/"));
         // ensure the value exists
         if (!Files.exists(p)) {
             String msg = String.format("The option '%s' was configured with path '%s' which does not exist", option, p);

--- a/src/main/java/emissary/command/converter/ProjectBaseConverter.java
+++ b/src/main/java/emissary/command/converter/ProjectBaseConverter.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine.ITypeConverter;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class ProjectBaseConverter extends PathExistsConverter implements ITypeConverter<Path> {
     public ProjectBaseConverter() {
@@ -28,7 +27,7 @@ public class ProjectBaseConverter extends PathExistsConverter implements ITypeCo
 
         // if PROJECT_BASE not null, set some variables
         if (projectBaseEnv != null) {
-            projectBaseEnvPath = Paths.get(projectBaseEnv);
+            projectBaseEnvPath = Path.of(projectBaseEnv);
             projectBaseEnvString = projectBaseEnvPath.toAbsolutePath().toString();
         }
 

--- a/src/main/java/emissary/config/ConfigUtil.java
+++ b/src/main/java/emissary/config/ConfigUtil.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -164,7 +164,7 @@ public class ConfigUtil {
         for (final String dir : dirs) {
             final String dirNoTrailingSlash = removeTrailingSlash(dir);
             // only add directories that exist
-            if (Files.exists(Paths.get(dirNoTrailingSlash))) {
+            if (Files.exists(Path.of(dirNoTrailingSlash))) {
                 configDirs.add(dirNoTrailingSlash);
             } else {
                 logger.warn("Directory configured but didn't exist: {}", dirNoTrailingSlash);
@@ -234,7 +234,7 @@ public class ConfigUtil {
             final List<String> candidates = new ArrayList<>();
             for (final String dir : getConfigDirs()) {
                 final String fname = dir + "/" + file;
-                if (Files.exists(Paths.get(fname))) {
+                if (Files.exists(Path.of(fname))) {
                     candidates.add(fname);
                 }
             }
@@ -545,7 +545,7 @@ public class ConfigUtil {
         // Add config.dir part if not already absolute
         final String filename = f.startsWith("/") ? f : getConfigFile(f);
 
-        return Files.newInputStream(Paths.get(filename));
+        return Files.newInputStream(Path.of(filename));
     }
 
     /**

--- a/src/main/java/emissary/config/ExtractResource.java
+++ b/src/main/java/emissary/config/ExtractResource.java
@@ -10,7 +10,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 /**
  * This class assists users and integrators by extracting the named resource and putting it into the config directory
@@ -63,7 +63,7 @@ public class ExtractResource {
         final String rezdata = getResource(resource);
         final String outputPath = this.outputDirectory + "/" + resource.replaceAll("/", ".");
         logger.debug("Writing " + outputPath);
-        try (BufferedOutputStream os = new BufferedOutputStream(Files.newOutputStream(Paths.get(outputPath)))) {
+        try (BufferedOutputStream os = new BufferedOutputStream(Files.newOutputStream(Path.of(outputPath)))) {
             os.write(rezdata.getBytes());
         }
     }

--- a/src/main/java/emissary/config/ServiceConfigGuide.java
+++ b/src/main/java/emissary/config/ServiceConfigGuide.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 import java.io.StreamTokenizer;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -323,7 +323,7 @@ public class ServiceConfigGuide implements Configurator, Serializable {
                 } catch (IOException e) {
                     // Throw exception if it is an IMPORT_FILE and the base file is not found
                     if ("IMPORT_FILE".equals(parmName) && i == 0) {
-                        String importFileName = Paths.get(svalArg).getFileName().toString();
+                        String importFileName = Path.of(svalArg).getFileName().toString();
                         throw new IOException("In " + filename + ", cannot find IMPORT_FILE: " + sval
                                 + " on the specified path. Make sure IMPORT_FILE (" + importFileName + ") exists, and the file path is correct.",
                                 e);

--- a/src/main/java/emissary/kff/KffChainLoader.java
+++ b/src/main/java/emissary/kff/KffChainLoader.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 
@@ -113,7 +113,7 @@ public class KffChainLoader {
         KffChain kff = getChainInstance();
 
         for (int i = 0; i < args.length; i++) {
-            try (InputStream is = Files.newInputStream(Paths.get(args[i]))) {
+            try (InputStream is = Files.newInputStream(Path.of(args[i]))) {
                 byte[] buffer = IOUtils.toByteArray(is);
 
                 KffResult r = kff.check(args[i], buffer);

--- a/src/main/java/emissary/kff/KffQuincyFile.java
+++ b/src/main/java/emissary/kff/KffQuincyFile.java
@@ -5,7 +5,7 @@ import org.apache.commons.io.IOUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 /**
  * KffQuincyFile compares files against the Quincy KFF dataset. The dataset only contains MD5 sums to that's our
@@ -35,7 +35,7 @@ public class KffQuincyFile extends KffFile {
         kff.addAlgorithm("SHA-256");
 
         for (int i = 1; i < args.length; i++) {
-            try (InputStream is = Files.newInputStream(Paths.get(args[i]))) {
+            try (InputStream is = Files.newInputStream(Path.of(args[i]))) {
                 byte[] buffer = IOUtils.toByteArray(is);
 
                 KffResult r = kff.check(args[i], buffer);

--- a/src/main/java/emissary/kff/Ssdeep.java
+++ b/src/main/java/emissary/kff/Ssdeep.java
@@ -14,7 +14,7 @@ import java.io.RandomAccessFile;
 import java.nio.channels.Channels;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 /**
@@ -708,7 +708,7 @@ public final class Ssdeep {
     public static void main(final String[] args) throws Exception {
         final Ssdeep ss = new Ssdeep();
         for (final String f : args) {
-            try (InputStream is = Files.newInputStream(Paths.get(f))) {
+            try (InputStream is = Files.newInputStream(Path.of(f))) {
                 final byte[] buffer = IOUtils.toByteArray(is);
                 // output format matches the original ssdeep program
                 System.out.println(ss.fuzzyHash(buffer) + ",\"" + f + "\"");

--- a/src/main/java/emissary/output/DropOffUtil.java
+++ b/src/main/java/emissary/output/DropOffUtil.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -207,7 +206,7 @@ public class DropOffUtil {
         // If a file already exists under this name, we're going
         // to have to move it aside. This is going to break the link
         // if it is an attachment to another parent document.
-        final Path theFile = Paths.get(fileName);
+        final Path theFile = Path.of(fileName);
         try {
             Files.deleteIfExists(theFile);
         } catch (IOException e) {
@@ -224,7 +223,7 @@ public class DropOffUtil {
      */
     public boolean setupPath(final String fileName) {
         final String pathName = fileName.substring(0, fileName.lastIndexOf(SEPARATOR));
-        final Path thePath = Paths.get(pathName);
+        final Path thePath = Path.of(pathName);
 
         // If the specified output directory doesn't exist try creating it
         if (!Files.exists(thePath)) {

--- a/src/main/java/emissary/output/filter/AbstractRollableFilter.java
+++ b/src/main/java/emissary/output/filter/AbstractRollableFilter.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -83,7 +82,7 @@ public abstract class AbstractRollableFilter extends AbstractFilter {
      */
     protected void initOutputConfig() {
         this.defaultOutputPath = this.filterConfig.findStringEntry(OUTPUT_PATH, defaultOutputPath);
-        this.outputPath = Paths.get(this.defaultOutputPath);
+        this.outputPath = Path.of(this.defaultOutputPath);
     }
 
     /**

--- a/src/main/java/emissary/output/roller/JournaledCoalescer.java
+++ b/src/main/java/emissary/output/roller/JournaledCoalescer.java
@@ -18,7 +18,6 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -285,7 +284,7 @@ public class JournaledCoalescer implements IJournaler, ICoalescer {
             return;
         }
         long offset = last.getOffset();
-        Path p = Paths.get(last.getVal());
+        Path p = Path.of(last.getVal());
         LOG.debug("Reading from path {}", p);
         try (FileChannel part = FileChannel.open(p, READ)) {
             long partSize = Files.size(p);
@@ -360,7 +359,7 @@ public class JournaledCoalescer implements IJournaler, ICoalescer {
 
     protected void renameToError(Path path) {
         try {
-            Path errorPath = Paths.get(path.toString() + ERROR_EXT);
+            Path errorPath = Path.of(path.toString() + ERROR_EXT);
             Files.move(path, errorPath);
         } catch (IOException ex) {
             LOG.warn("Unable to rename file {}.", path.toString(), ex);
@@ -390,7 +389,7 @@ public class JournaledCoalescer implements IJournaler, ICoalescer {
 
     private static void deleteParts(Collection<JournalEntry> entries) throws IOException {
         for (JournalEntry entry : entries) {
-            Path p = Paths.get(entry.getVal());
+            Path p = Path.of(entry.getVal());
             Files.deleteIfExists(p);
         }
     }

--- a/src/main/java/emissary/output/roller/journal/JournalReader.java
+++ b/src/main/java/emissary/output/roller/journal/JournalReader.java
@@ -12,7 +12,6 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -201,7 +200,7 @@ public class JournalReader implements Closeable {
     @SuppressWarnings("SystemOut")
     public static void main(String[] args) throws Exception {
         String path = args[0];
-        try (JournalReader jr = new JournalReader(Paths.get(path))) {
+        try (JournalReader jr = new JournalReader(Path.of(path))) {
             Journal j = jr.getJournal();
             System.out.println("Journal File: " + path);
             System.out.println("Journal Version: " + j.getKey());

--- a/src/main/java/emissary/output/roller/journal/JournaledChannelPool.java
+++ b/src/main/java/emissary/output/roller/journal/JournaledChannelPool.java
@@ -7,7 +7,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.UUID;
@@ -158,7 +157,7 @@ public class JournaledChannelPool implements AutoCloseable {
     }
 
     private void createChannel() throws IOException {
-        final Path p = Paths.get(this.directory.toString(), this.key + "_" + UUID.randomUUID().toString() + EXTENSION);
+        final Path p = Path.of(this.directory.toString(), this.key + "_" + UUID.randomUUID().toString() + EXTENSION);
         final JournaledChannel ko = new JournaledChannel(p, this.key, this.created);
         this.allchannels[this.created++] = ko;
         this.free.add(ko);

--- a/src/main/java/emissary/pickup/PickUpPlace.java
+++ b/src/main/java/emissary/pickup/PickUpPlace.java
@@ -35,7 +35,6 @@ import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -252,7 +251,7 @@ public abstract class PickUpPlace extends ServiceProviderPlace implements IPickU
             return;
         }
 
-        Path monitoredPath = Paths.get(monitoredPathStr);
+        Path monitoredPath = Path.of(monitoredPathStr);
         if (!Files.exists(monitoredPath)) {
             logger.warn("Monitored path {} does not exist, disk space monitoring disabled", monitoredPath);
             return;

--- a/src/main/java/emissary/pickup/WorkSpace.java
+++ b/src/main/java/emissary/pickup/WorkSpace.java
@@ -30,7 +30,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryUsage;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1243,7 +1243,7 @@ public class WorkSpace implements Runnable {
 
                     // Skip dot files possibly
                     // TODO Maybe we want to change this to explicitly look for "." instead of isHidden
-                    if (skipDotFilesArg && Files.isHidden(Paths.get(fileName))) {
+                    if (skipDotFilesArg && Files.isHidden(Path.of(fileName))) {
                         logger.debug("Skipping dot file {}", fileName);
                         continue;
                     }

--- a/src/main/java/emissary/place/ServiceProviderRefreshablePlace.java
+++ b/src/main/java/emissary/place/ServiceProviderRefreshablePlace.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -204,7 +203,7 @@ public abstract class ServiceProviderRefreshablePlace extends ServiceProviderPla
             Preconditions.checkArgument(StringUtils.isNotBlank(path), "Path cannot be blank");
             Preconditions.checkArgument(intervalMinutes > 0, "Monitoring interval is not greater than 0");
 
-            final Path file = Paths.get(path);
+            final Path file = Path.of(path);
             Preconditions.checkArgument(Files.exists(file), "Path does not exist");
 
             final FileAlterationObserver observer;

--- a/src/main/java/emissary/server/EmissaryServer.java
+++ b/src/main/java/emissary/server/EmissaryServer.java
@@ -66,7 +66,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -197,7 +196,7 @@ public class EmissaryServer {
             String serverLocation = cmd.getScheme() + "://" + cmd.getHost() + ":" + cmd.getPort();
 
             // write out env.sh file here
-            Path envsh = Paths.get(ConfigUtil.getProjectBase() + File.separator + "env.sh");
+            Path envsh = Path.of(ConfigUtil.getProjectBase() + File.separator + "env.sh");
             if (Files.exists(envsh)) {
                 LOG.debug("Removing old {}", envsh.toAbsolutePath());
                 Files.delete(envsh);
@@ -718,7 +717,7 @@ public class EmissaryServer {
     private ContextHandler buildEmissaryHandler() throws EmissaryException {
         // must set these set or you are not an EmissaryNode
         String configDir = System.getProperty(ConfigUtil.CONFIG_DIR_PROPERTY, null);
-        if (configDir == null || !Files.exists(Paths.get(configDir))) {
+        if (configDir == null || !Files.exists(Path.of(configDir))) {
             throw new EmissaryException("Config dir error. " + ConfigUtil.CONFIG_DIR_PROPERTY + " is " + configDir);
         }
         // set number of agents if it has been set
@@ -844,7 +843,7 @@ public class EmissaryServer {
         sslContextFactory.setKeyStorePassword(keystorePass);
 
         KeyStore trustStoreInstance;
-        try (InputStream is = Files.newInputStream(Paths.get(trustStore))) {
+        try (InputStream is = Files.newInputStream(Path.of(trustStore))) {
             trustStoreInstance = KeyStore.getInstance("JKS");
             trustStoreInstance.load(is, trustStorePass.toCharArray());
         } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException e) {

--- a/src/main/java/emissary/util/Hexl.java
+++ b/src/main/java/emissary/util/Hexl.java
@@ -7,7 +7,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 /**
  * Pretend to be Emacs hexl mode
@@ -124,7 +124,7 @@ public class Hexl {
 
         for (int i = 0; i < argv.length; i++) {
 
-            try (InputStream theFile = Files.newInputStream(Paths.get(argv[i]));
+            try (InputStream theFile = Files.newInputStream(Path.of(argv[i]));
                     DataInputStream theStream = new DataInputStream(theFile)) {
                 theContent = IOUtils.toByteArray(theStream);
             } catch (IOException e) {

--- a/src/main/java/emissary/util/PkiUtil.java
+++ b/src/main/java/emissary/util/PkiUtil.java
@@ -13,7 +13,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -52,7 +52,7 @@ public class PkiUtil {
         if (isPemCertificate(pemData)) {
             loadKeyStore(keyStore, pemData);
         } else {
-            try (InputStream is = Files.newInputStream(Paths.get(path))) {
+            try (InputStream is = Files.newInputStream(Path.of(path))) {
                 keyStore.load(is, pazz);
             }
         }

--- a/src/main/java/emissary/util/io/ListOpenFiles.java
+++ b/src/main/java/emissary/util/io/ListOpenFiles.java
@@ -4,14 +4,13 @@ import emissary.util.shell.Executrix;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class ListOpenFiles {
 
     Executrix exec = new Executrix();
 
     public boolean isOpen(String path) {
-        return isOpen(Paths.get(path));
+        return isOpen(Path.of(path));
     }
 
     public boolean isOpen(Path path) {

--- a/src/test/java/emissary/client/EmissaryClientTest.java
+++ b/src/test/java/emissary/client/EmissaryClientTest.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.TimeUnit;
@@ -28,8 +27,8 @@ class EmissaryClientTest extends UnitTest {
     @Test
     void testDefaultRequestConfig() {
         logger.debug("Starting testDefaultRequestConfig");
-        Path origCfg = Paths.get(ConfigUtil.getProjectBase() + "/classes/emissary/client/EmissaryClient.cfg");
-        Path hiddenCfg = Paths.get(ConfigUtil.getProjectBase() + "/classes/emissary/client/EmissaryClient.cfg.hideme");
+        Path origCfg = Path.of(ConfigUtil.getProjectBase() + "/classes/emissary/client/EmissaryClient.cfg");
+        Path hiddenCfg = Path.of(ConfigUtil.getProjectBase() + "/classes/emissary/client/EmissaryClient.cfg.hideme");
         try {
             // remove EmissaryClient.cfg from classpath
             Files.move(origCfg, hiddenCfg, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
@@ -72,7 +71,7 @@ class EmissaryClientTest extends UnitTest {
     @Test
     void testRequestConfigFromConfigDir() throws IOException {
         logger.debug("Starting testRequestConfigFromConfigDir");
-        Path cfgFile = Paths.get(ConfigUtil.getConfigDirs().get(0) + "/emissary.client.EmissaryClient.cfg");
+        Path cfgFile = Path.of(ConfigUtil.getConfigDirs().get(0) + "/emissary.client.EmissaryClient.cfg");
         try (OutputStream out = Files.newOutputStream(cfgFile, StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
             int newConnectionTimeout = 5000;
             int newConnectionManagerTimeout = 4000;

--- a/src/test/java/emissary/command/FeedCommandIT.java
+++ b/src/test/java/emissary/command/FeedCommandIT.java
@@ -20,7 +20,6 @@ import picocli.CommandLine.ParameterException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -56,7 +55,7 @@ class FeedCommandIT extends UnitTest {
     @BeforeEach
     public void setup() throws Exception {
         command = null;
-        baseDir = Paths.get(System.getenv(ConfigUtil.PROJECT_BASE_ENV));
+        baseDir = Path.of(System.getenv(ConfigUtil.PROJECT_BASE_ENV));
         inputDir = Files.createTempDirectory(tmpDir, "input");
         arguments.clear();
     }

--- a/src/test/java/emissary/command/ServerCommandIT.java
+++ b/src/test/java/emissary/command/ServerCommandIT.java
@@ -5,7 +5,7 @@ import emissary.test.core.junit5.UnitTest;
 
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -17,13 +17,13 @@ class ServerCommandIT extends UnitTest {
     @Test
     void testGetConfig() throws Exception {
         ServerCommand cmd = ServerCommand.parse(ServerCommand.class, "-b", PROJECT_BASE, "-m", "standalone");
-        assertEquals(Paths.get(PROJECT_BASE + "/config"), cmd.getConfig());
+        assertEquals(Path.of(PROJECT_BASE + "/config"), cmd.getConfig());
     }
 
     @Test
     void testGetConfigWithTrailingSlash() throws Exception {
         ServerCommand cmd = ServerCommand.parse(ServerCommand.class, "-b ", PROJECT_BASE_SLASH + "/", "-m", "standalone");
-        assertEquals(Paths.get(PROJECT_BASE_SLASH + "/config"), cmd.getConfig());
+        assertEquals(Path.of(PROJECT_BASE_SLASH + "/config"), cmd.getConfig());
     }
 
     @Test

--- a/src/test/java/emissary/config/ConfigUtilTest.java
+++ b/src/test/java/emissary/config/ConfigUtilTest.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -55,7 +54,7 @@ class ConfigUtilTest extends UnitTest {
     public void setUp() throws Exception {
         configDir = System.getProperty(ConfigUtil.CONFIG_DIR_PROPERTY, ".");
         testFilesAndDirectories = new ArrayList<>();
-        configPath = Paths.get(configDir);
+        configPath = Path.of(configDir);
 
         appender = new ListAppender<>();
         appender.start();
@@ -163,12 +162,12 @@ class ConfigUtilTest extends UnitTest {
         System.setProperty(ConfigUtil.CONFIG_FLAVOR_PROPERTY, "TESTFLAVOR");
         ConfigUtil.initialize();
 
-        final Path baseFile = Paths.get(configDir, "emissary.blubber.Whale.cfg");
+        final Path baseFile = Path.of(configDir, "emissary.blubber.Whale.cfg");
         try (OutputStream ros = Files.newOutputStream(baseFile)) {
             ros.write("FOO = \"BAR\"\n".getBytes());
         }
 
-        final Path flavFile = Paths.get(configDir, "emissary.blubber.Whale-TESTFLAVOR.cfg");
+        final Path flavFile = Path.of(configDir, "emissary.blubber.Whale-TESTFLAVOR.cfg");
         try (OutputStream ros = Files.newOutputStream(flavFile)) {
             ros.write("FOO = \"BAR2\"\n".getBytes());
         }
@@ -194,12 +193,12 @@ class ConfigUtilTest extends UnitTest {
         System.setProperty(ConfigUtil.CONFIG_FLAVOR_PROPERTY, "TESTFLAVOR");
         ConfigUtil.initialize();
 
-        final Path baseFile = Paths.get(configDir, "emissary.blubber.Shark.cfg");
+        final Path baseFile = Path.of(configDir, "emissary.blubber.Shark.cfg");
         try (OutputStream ros = Files.newOutputStream(baseFile)) {
             ros.write("FOO = \"BAR\"\n".getBytes());
         }
 
-        final Path flavFile = Paths.get(configDir, "emissary.blubber.Shark-TESTFLAVOR.cfg");
+        final Path flavFile = Path.of(configDir, "emissary.blubber.Shark-TESTFLAVOR.cfg");
         try (OutputStream ros = Files.newOutputStream(flavFile)) {
             ros.write("QUUZ = \"@{FOO}\"\n".getBytes());
         }
@@ -276,7 +275,7 @@ class ConfigUtilTest extends UnitTest {
         final Path configDir1 = createTmpSubDir("config1A");
         final String cfgName1 = "emissary.grapes.Monkey.cfg";
         createFileAndPopulate(configDir1, cfgName1, "BOO = \"HOO\"\n");
-        final Path cfgName2 = Paths.get(configPath.toString(), "configgone", "emissary.grapes.Panda.cfg");
+        final Path cfgName2 = Path.of(configPath.toString(), "configgone", "emissary.grapes.Panda.cfg");
         final String origConfigDirProp = System.getProperty(CONFIG_DIR_PROPERTY);
         System.setProperty(CONFIG_DIR_PROPERTY, configDir1 + "," + cfgName2.getParent());
 
@@ -561,32 +560,32 @@ class ConfigUtilTest extends UnitTest {
     @Test
     void testGetFlavorFromFile() {
         final String flavor =
-                ConfigUtil.getFlavorsFromCfgFile(Paths.get(configPath.toString() + "emissary.admin.ClassNameInventory-flavor1.cfg").toFile());
+                ConfigUtil.getFlavorsFromCfgFile(Path.of(configPath.toString() + "emissary.admin.ClassNameInventory-flavor1.cfg").toFile());
         assertEquals("flavor1", flavor, "Flavors didn't match");
     }
 
     @Test
     void testGetMultipleFlavorFromFile() {
-        final String flavor = ConfigUtil.getFlavorsFromCfgFile(Paths.get(configPath.toString(), "emissary.junk.TrunkPlace-f1,f2,f3.cfg").toFile());
+        final String flavor = ConfigUtil.getFlavorsFromCfgFile(Path.of(configPath.toString(), "emissary.junk.TrunkPlace-f1,f2,f3.cfg").toFile());
         assertEquals("f1,f2,f3", flavor, "Flavors didn't match");
     }
 
     @Test
     void testGetFlavorsNotACfgFile() {
-        final String flavor = ConfigUtil.getFlavorsFromCfgFile(Paths.get(configPath.toString(), "emissary.util.JunkPlace-f1.config").toFile());
+        final String flavor = ConfigUtil.getFlavorsFromCfgFile(Path.of(configPath.toString(), "emissary.util.JunkPlace-f1.config").toFile());
         assertEquals("", flavor, "Should have been empty, not a cfg file");
     }
 
     @Test
     void testGetNoFlavor() {
-        final String flavor = ConfigUtil.getFlavorsFromCfgFile(Paths.get(configPath.toString(), "emissary.util.PepperPlace.config").toFile());
+        final String flavor = ConfigUtil.getFlavorsFromCfgFile(Path.of(configPath.toString(), "emissary.util.PepperPlace.config").toFile());
         assertEquals("", flavor, "Should have been empty, no flavor");
     }
 
     @Test
     void testGetFlavorMultipleHyphens() {
         final String flavor =
-                ConfigUtil.getFlavorsFromCfgFile(Paths.get(configPath.toString(), "emissary.util.DrPibbPlace-flavor1-flavor2-flavor3.cfg").toFile());
+                ConfigUtil.getFlavorsFromCfgFile(Path.of(configPath.toString(), "emissary.util.DrPibbPlace-flavor1-flavor2-flavor3.cfg").toFile());
         assertEquals("flavor3", flavor, "Should have been the last flavor");
 
     }
@@ -630,7 +629,7 @@ class ConfigUtilTest extends UnitTest {
         final String[] files = new String[] {priname};
 
         String result = "";
-        String importFileName = Paths.get(impname).getFileName().toString();
+        String importFileName = Path.of(impname).getFileName().toString();
 
         try {
             Executrix.writeDataToFile(primary, priname);
@@ -649,14 +648,14 @@ class ConfigUtilTest extends UnitTest {
     }
 
     private Path createTmpSubDir(final String name) throws IOException {
-        final Path dir = Paths.get(configPath.toString(), name);
+        final Path dir = Path.of(configPath.toString(), name);
         Files.createDirectory(dir);
         testFilesAndDirectories.add(dir);
         return dir;
     }
 
     private Path createFileAndPopulate(final Path dir, final String name, final String contents) {
-        final Path file = Paths.get(dir.toString(), name);
+        final Path file = Path.of(dir.toString(), name);
         testFilesAndDirectories.add(file);
         try (OutputStream ros = Files.newOutputStream(file)) {
             ros.write(contents.getBytes());

--- a/src/test/java/emissary/config/FTestServiceConfigGuide.java
+++ b/src/test/java/emissary/config/FTestServiceConfigGuide.java
@@ -11,7 +11,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -30,12 +29,12 @@ public class FTestServiceConfigGuide extends FunctionalTest {
         List<Path> configFiles = new ArrayList<>();
 
         for (String dir : ConfigUtil.getConfigDirs()) {
-            configFiles.addAll(findFilesByExtension(Paths.get(dir), ".cfg"));
+            configFiles.addAll(findFilesByExtension(Path.of(dir), ".cfg"));
         }
 
         // look for cfg files under src
-        Path root = Paths.get(ConfigUtil.projectRootDirectory()).getParent();
-        configFiles.addAll(findFilesByExtension(Paths.get(root.toString(), "src"), ".cfg"));
+        Path root = Path.of(ConfigUtil.projectRootDirectory()).getParent();
+        configFiles.addAll(findFilesByExtension(Path.of(root.toString(), "src"), ".cfg"));
 
         return configFiles.stream().map(p -> Arguments.of(p.toString()));
     }
@@ -46,7 +45,7 @@ public class FTestServiceConfigGuide extends FunctionalTest {
     @ParameterizedTest
     @MethodSource("data")
     void testAllConfFiles(String resource) {
-        Path underTest = Paths.get(resource).toAbsolutePath().normalize();
+        Path underTest = Path.of(resource).toAbsolutePath().normalize();
         logger.debug("Parsing config file:" + underTest);
         assertDoesNotThrow(() -> ConfigUtil.getConfigInfo(underTest.toString()));
     }

--- a/src/test/java/emissary/config/ServiceConfigGuideTest.java
+++ b/src/test/java/emissary/config/ServiceConfigGuideTest.java
@@ -18,7 +18,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -377,8 +376,8 @@ class ServiceConfigGuideTest extends UnitTest {
 
     @Test
     void testCreateDirAndFile(@TempDir final Path tdir) throws IOException {
-        final Path tfile = Paths.get(tdir.toString(), "foo-file.txt");
-        final Path t2file = Paths.get(tdir.toString(), "subdir", "blubdir", "bar-file.txt");
+        final Path tfile = Path.of(tdir.toString(), "foo-file.txt");
+        final Path t2file = Path.of(tdir.toString(), "subdir", "blubdir", "bar-file.txt");
         String s =
                 "CREATE_DIRECTORY = \"" + tdir + "\"\n" + "CREATE_FILE = \"" + tfile + "\"\n" + "CREATE_FILE = \""
                         + tfile + "\"\n" + "CREATE_FILE = \"" + t2file + "\"\n";
@@ -511,7 +510,7 @@ class ServiceConfigGuideTest extends UnitTest {
         final byte[] primary = ("IMPORT_FILE = \"" + impname + "\"\n").getBytes();
 
         String result = "";
-        String importFileName = Paths.get(impname).getFileName().toString();
+        String importFileName = Path.of(impname).getFileName().toString();
 
         try {
             assertTrue(Executrix.writeDataToFile(primary, priname));

--- a/src/test/java/emissary/output/roller/JournaledCoalescerTest.java
+++ b/src/test/java/emissary/output/roller/JournaledCoalescerTest.java
@@ -23,7 +23,6 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
@@ -79,7 +78,7 @@ class JournaledCoalescerTest extends UnitTest {
     @Test
     void testNonExistentDirectory() {
         // test
-        assertThrows(FileNotFoundException.class, () -> new JournaledCoalescer(Paths.get("/asdasd/asdasd/asdasd"), fileNameGenerator));
+        assertThrows(FileNotFoundException.class, () -> new JournaledCoalescer(Path.of("/asdasd/asdasd/asdasd"), fileNameGenerator));
     }
 
     @SuppressWarnings("resource")
@@ -214,7 +213,7 @@ class JournaledCoalescerTest extends UnitTest {
             one.commit();
         }
 
-        Path oldRolling = Paths.get(targetBudPath.toString(), finalBudOutput.getFileName().toString() + ROLLING_EXT);
+        Path oldRolling = Path.of(targetBudPath.toString(), finalBudOutput.getFileName().toString() + ROLLING_EXT);
         Files.createFile(oldRolling);
 
         // test
@@ -342,7 +341,7 @@ class JournaledCoalescerTest extends UnitTest {
         long partSize = Files.size(target);
         // open journal
         Journal j;
-        try (JournalReader jr = new JournalReader(Paths.get(key + Journal.EXT))) {
+        try (JournalReader jr = new JournalReader(Path.of(key + Journal.EXT))) {
             j = jr.getJournal();
         }
         Path rolled = Files.createTempFile(targetBudPath, "rolled_badfile", "");

--- a/src/test/java/emissary/place/ServiceProviderPlaceTest.java
+++ b/src/test/java/emissary/place/ServiceProviderPlaceTest.java
@@ -22,7 +22,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 
@@ -230,9 +229,9 @@ class ServiceProviderPlaceTest extends UnitTest {
         Path cfg;
         // Write out the config data to the temp config dir
         if (usePackage) {
-            cfg = Paths.get(configDir, thisPackage.getName() + ".MyFileConfigedTestPlace" + ConfigUtil.CONFIG_FILE_ENDING);
+            cfg = Path.of(configDir, thisPackage.getName() + ".MyFileConfigedTestPlace" + ConfigUtil.CONFIG_FILE_ENDING);
         } else {
-            cfg = Paths.get(configDir, "MyFileConfigedTestPlace" + ConfigUtil.CONFIG_FILE_ENDING);
+            cfg = Path.of(configDir, "MyFileConfigedTestPlace" + ConfigUtil.CONFIG_FILE_ENDING);
         }
 
         try (OutputStream fos = Files.newOutputStream(cfg)) {

--- a/src/test/java/emissary/place/UnixCommandPlaceTest.java
+++ b/src/test/java/emissary/place/UnixCommandPlaceTest.java
@@ -20,7 +20,6 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -48,7 +47,7 @@ class UnixCommandPlaceTest extends UnitTest {
     @Override
     @BeforeEach
     public void setUp() throws Exception {
-        scriptFile = Paths.get(TMPDIR, "testUnixCommand.sh");
+        scriptFile = Path.of(TMPDIR, "testUnixCommand.sh");
         // read our default config for this place, not something else that got configured in
         try (InputStream is = new ResourceReader().getConfigDataAsStream(this.getClass())) {
             place = new UnixCommandPlace(is);
@@ -120,7 +119,7 @@ class UnixCommandPlaceTest extends UnitTest {
 
         // fake an output file and load it with some data
         String DATA = "test-test";
-        Path outputFile = Paths.get(TMPDIR, "output.out");
+        Path outputFile = Path.of(TMPDIR, "output.out");
 
         try {
             IOUtils.write(DATA, Files.newOutputStream(outputFile), StandardCharsets.UTF_8);

--- a/src/test/java/emissary/place/VersionPlaceTest.java
+++ b/src/test/java/emissary/place/VersionPlaceTest.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -33,7 +32,7 @@ class VersionPlaceTest extends UnitTest {
     @BeforeEach
     public void setUp() throws Exception {
         payload = DataObjectFactory.getInstance();
-        gitRepositoryFile = Paths.get(new ResourceReader().getResource("emissary/util/test.git.properties").toURI());
+        gitRepositoryFile = Path.of(new ResourceReader().getResource("emissary/util/test.git.properties").toURI());
         testGitRepoState = GitRepositoryState.getRepositoryState(gitRepositoryFile);
     }
 
@@ -81,7 +80,7 @@ class VersionPlaceTest extends UnitTest {
     void testVersionRegex() throws IOException, URISyntaxException {
         // uses different test gitRepoState properties file with version number that matches default regex
         // passes this file to getVersion() to verify version returned has no date
-        Path regexTestFile = Paths.get(new ResourceReader().getResource("emissary/util/test.version.regex.git.properties").toURI());
+        Path regexTestFile = Path.of(new ResourceReader().getResource("emissary/util/test.version.regex.git.properties").toURI());
         GitRepositoryState regexRepoState = GitRepositoryState.getRepositoryState(regexTestFile);
 
         // create the place, using the normal class cfg

--- a/src/test/java/emissary/server/api/EmissaryApiTest.java
+++ b/src/test/java/emissary/server/api/EmissaryApiTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -62,10 +62,10 @@ class EmissaryApiTest extends EndpointTestBase {
         doReturn(8001).when(node).getNodePort();
         when(mockServer.getNode()).thenReturn(node);
         when(mockServer.getServerCommand()).thenReturn(srvCmd);
-        when(srvCmd.getConfig()).thenReturn(Paths.get("/path/to/project/config"));
-        when(srvCmd.getProjectBase()).thenReturn(Paths.get("/path/to/project"));
-        when(srvCmd.getOutputDir()).thenReturn(Paths.get("/path/to/project/output"));
-        when(srvCmd.getBinDir()).thenReturn(Paths.get("/path/to/project/bin"));
+        when(srvCmd.getConfig()).thenReturn(Path.of("/path/to/project/config"));
+        when(srvCmd.getProjectBase()).thenReturn(Path.of("/path/to/project"));
+        when(srvCmd.getOutputDir()).thenReturn(Path.of("/path/to/project/output"));
+        when(srvCmd.getBinDir()).thenReturn(Path.of("/path/to/project/bin"));
         when(srvCmd.getHost()).thenReturn("localhost");
         when(srvCmd.getPort()).thenReturn(8001);
         when(srvCmd.getScheme()).thenReturn("https");

--- a/src/test/java/emissary/test/core/junit5/AnswerGenerator.java
+++ b/src/test/java/emissary/test/core/junit5/AnswerGenerator.java
@@ -21,7 +21,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -120,7 +119,7 @@ public abstract class AnswerGenerator {
      */
     public static Path getTestResx() {
         // Gets us the parent folder to PROJECT_BASE
-        Path pathBuilder = Paths.get(System.getenv("PROJECT_BASE"));
+        Path pathBuilder = Path.of(System.getenv("PROJECT_BASE"));
         // If in Docker, we need to go into src - we're probably already in it otherwise
         if (pathBuilder.endsWith("main")) { // Docker
             pathBuilder = pathBuilder.getParent();

--- a/src/test/java/emissary/test/core/junit5/ExtractionTest.java
+++ b/src/test/java/emissary/test/core/junit5/ExtractionTest.java
@@ -38,7 +38,6 @@ import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -228,7 +227,7 @@ public abstract class ExtractionTest extends UnitTest {
     @Nullable
     protected IBaseDataObject getInitialIbdo(final String resource) {
         try {
-            final Path datFileUrl = Paths.get(new ResourceReader().getResource(resource).toURI());
+            final Path datFileUrl = Path.of(new ResourceReader().getResource(resource).toURI());
             final InitialFinalFormFormat datFile = new InitialFinalFormFormat(datFileUrl);
             final SeekableByteChannelFactory sbcf = FileChannelFactory.create(datFile.getPath());
             // Create a BDO for the data, and set the filename correctly

--- a/src/test/java/emissary/test/core/junit5/RegressionTest.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTest.java
@@ -14,7 +14,6 @@ import org.jdom2.Element;
 
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -77,7 +76,7 @@ public abstract class RegressionTest extends ExtractionTest {
     @Nullable
     protected String getInitialForm(final String resource) {
         try {
-            final Path datFileUrl = Paths.get(new ResourceReader().getResource(resource).toURI());
+            final Path datFileUrl = Path.of(new ResourceReader().getResource(resource).toURI());
             final InitialFinalFormFormat datFile = new InitialFinalFormFormat(datFileUrl);
             return datFile.getInitialForm();
         } catch (final URISyntaxException e) {

--- a/src/test/java/emissary/test/core/junit5/RegressionTestAnswerGenerator.java
+++ b/src/test/java/emissary/test/core/junit5/RegressionTestAnswerGenerator.java
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -86,7 +85,7 @@ public class RegressionTestAnswerGenerator extends AnswerGenerator {
     @Override
     protected void tweakFinalIbdoBeforeSerialization(final String resource, final IBaseDataObject finalIbdo) {
         try {
-            final Path datFileUrl = Paths.get(new ResourceReader().getResource(resource).toURI());
+            final Path datFileUrl = Path.of(new ResourceReader().getResource(resource).toURI());
             final InitialFinalFormFormat datFile = new InitialFinalFormFormat(datFileUrl);
             if (!finalIbdo.currentForm().equals(datFile.getFinalForm())) {
                 final String format = "Final form from place [%s] didn't match final form in filename [%s]";

--- a/src/test/java/emissary/test/core/junit5/extensions/EmissaryIsolatedClassLoaderExtension.java
+++ b/src/test/java/emissary/test/core/junit5/extensions/EmissaryIsolatedClassLoaderExtension.java
@@ -10,7 +10,7 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 public class EmissaryIsolatedClassLoaderExtension implements InvocationInterceptor {
@@ -66,7 +66,7 @@ public class EmissaryIsolatedClassLoaderExtension implements InvocationIntercept
             String[] paths = System.getProperty("java.class.path").split("[" + File.pathSeparator + "]");
             return Arrays.stream(paths).map(path -> {
                 try {
-                    return Paths.get(path).toUri().toURL();
+                    return Path.of(path).toUri().toURL();
                 } catch (MalformedURLException e) {
                     throw new IllegalArgumentException("Invalid class path item: " + path, e);
                 }

--- a/src/test/java/emissary/util/io/ListOpenFilesTest.java
+++ b/src/test/java/emissary/util/io/ListOpenFilesTest.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -31,7 +30,7 @@ class ListOpenFilesTest extends UnitTest {
         super.setUp();
         this.instance = new ListOpenFiles();
         this.tmpDir = tmpDir;
-        this.file = Paths.get(tmpDir.toString(), "open");
+        this.file = Path.of(tmpDir.toString(), "open");
         Files.write(file, "test".getBytes(UTF_8));
     }
 
@@ -54,6 +53,6 @@ class ListOpenFilesTest extends UnitTest {
         assertFalse(instance.isOpen(file));
 
         // test for a file that does not exist
-        assertFalse(instance.isOpen(Paths.get(tmpDir.toString(), "dne")));
+        assertFalse(instance.isOpen(Path.of(tmpDir.toString(), "dne")));
     }
 }

--- a/src/test/java/emissary/util/roll/RollableFileOutputStreamTest.java
+++ b/src/test/java/emissary/util/roll/RollableFileOutputStreamTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,10 +41,10 @@ class RollableFileOutputStreamTest extends UnitTest implements FileNameGenerator
         // setup
         String file1name = this.nextFileName();
         String file2name = this.nextFileName();
-        Path file1 = Paths.get(tmpDir.toString(), "." + file1name);
+        Path file1 = Path.of(tmpDir.toString(), "." + file1name);
         Files.createFile(file1);
         Files.write(file1, "Foo".getBytes());
-        Path file2 = Paths.get(tmpDir.toString(), "." + file2name);
+        Path file2 = Path.of(tmpDir.toString(), "." + file2name);
         Files.createFile(file2);
         // test
         try (RollableFileOutputStream instance = new RollableFileOutputStream(this, tmpDir.toFile())) {
@@ -54,10 +53,10 @@ class RollableFileOutputStreamTest extends UnitTest implements FileNameGenerator
 
         // verify
         assertFalse(Files.exists(file1));
-        assertTrue(Files.exists(Paths.get(tmpDir.toString(), file1name)));
+        assertTrue(Files.exists(Path.of(tmpDir.toString(), file1name)));
         // make sure 0 byte file was deleted
         assertFalse(Files.exists(file2));
-        assertFalse(Files.exists(Paths.get(tmpDir.toString(), file2name)));
+        assertFalse(Files.exists(Path.of(tmpDir.toString(), file2name)));
     }
 
     /**
@@ -70,8 +69,8 @@ class RollableFileOutputStreamTest extends UnitTest implements FileNameGenerator
             instance.write(data.getBytes());
             assertEquals(data.length(), instance.bytesWritten);
             instance.roll();
-            assertTrue(Files.exists(Paths.get(tmpDir.toString(), lastFile)));
-            assertTrue(Files.exists(Paths.get(tmpDir.toString(), "." + currentFile)));
+            assertTrue(Files.exists(Path.of(tmpDir.toString(), lastFile)));
+            assertTrue(Files.exists(Path.of(tmpDir.toString(), "." + currentFile)));
             assertEquals(0L, instance.bytesWritten);
         }
     }
@@ -94,7 +93,7 @@ class RollableFileOutputStreamTest extends UnitTest implements FileNameGenerator
         try (RollableFileOutputStream instance = new RollableFileOutputStream(this, tmpDir.toFile())) {
             instance.write(INT);
         }
-        Path f = Paths.get(tmpDir.toString(), currentFile);
+        Path f = Path.of(tmpDir.toString(), currentFile);
         try (InputStream is = Files.newInputStream(f)) {
             assertEquals(INT, is.read());
             assertEquals(-1, is.read());
@@ -109,7 +108,7 @@ class RollableFileOutputStreamTest extends UnitTest implements FileNameGenerator
         try (RollableFileOutputStream instance = new RollableFileOutputStream(this, tmpDir.toFile())) {
             instance.write(data.getBytes(), 0, data.length());
         }
-        Path f = Paths.get(tmpDir.toString(), currentFile);
+        Path f = Path.of(tmpDir.toString(), currentFile);
         try (InputStream is = Files.newInputStream(f)) {
             int i = 0;
             for (; i < data.length(); i++) {
@@ -129,7 +128,7 @@ class RollableFileOutputStreamTest extends UnitTest implements FileNameGenerator
             instance.setDeleteZeroByteFiles(true);
             instance.roll();
         }
-        Path f = Paths.get(tmpDir.toString(), currentFile);
+        Path f = Path.of(tmpDir.toString(), currentFile);
         assertFalse(Files.exists(f));
     }
 

--- a/src/test/java/emissary/util/shell/ExecutrixTest.java
+++ b/src/test/java/emissary/util/shell/ExecutrixTest.java
@@ -18,7 +18,6 @@ import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -258,8 +257,8 @@ class ExecutrixTest extends UnitTest {
             assertNotNull(data, "Data read from copy");
             assertEquals(3, data.length, "All data read from copy");
         } finally {
-            Files.deleteIfExists(Paths.get(TMPDIR, "foo.dat"));
-            Files.deleteIfExists(Paths.get(TMPDIR, "bar.dat"));
+            Files.deleteIfExists(Path.of(TMPDIR, "foo.dat"));
+            Files.deleteIfExists(Path.of(TMPDIR, "bar.dat"));
         }
     }
 


### PR DESCRIPTION
In Java's NIO.2 file API, Paths.get() and Path.of() are functionally identical methods used to create a [Path](https://docs.oracle.com/en/java/javase/24/docs/api/java.base/java/nio/file/Paths.html) object from a string or URI. 

The key differences between them are:
- **Introduction Version**: Paths.get() was introduced in Java 7. Path.of() was introduced later in Java 11.
- **Implementation**: In modern Java versions (Java 11+), Paths.get() simply delegates its call directly to Path.of().
- **Recommendation**: Oracle now recommends using Path.of() over Paths.get(). The Paths class is largely considered a legacy utility class that may be deprecated in future releases.
- **Consistency**: Path.of() follows the modern Java naming convention (like List.of(), Set.of()) where static factory methods are placed directly on the interface they return, reducing the need for separate utility classes like Paths.