### PR TITLE
upgrade deprecated provideArguments() method

### DIFF
--- a/src/test/java/emissary/command/FeedCommandIT.java
+++ b/src/test/java/emissary/command/FeedCommandIT.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import picocli.CommandLine.ParameterException;
 
 import java.io.IOException;
@@ -117,7 +118,7 @@ class FeedCommandIT extends UnitTest {
                 INT_ARGS);
 
         @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
             return cartesian.stream().map(list -> Arguments.of((Object[]) list.toArray(new String[0])));
         }
     }


### PR DESCRIPTION
```
provideArguments(org.junit.jupiter.api.extension.ExtensionContext) in org.junit.jupiter.params.provider.ArgumentsProvider has been deprecated
```

we were overriding a deprecated method here, so updating to the new implementation of the method we should be overriding.

https://docs.junit.org/6.0.1/api/org.junit.jupiter.params/org/junit/jupiter/params/provider/ArgumentsProvider.html#provideArguments(org.junit.jupiter.params.support.ParameterDeclarations,org.junit.jupiter.api.extension.ExtensionContext)