### PR TITLE
Make gRPC futures thread interruptible

### DIFF
--- a/src/main/java/emissary/grpc/future/CompletableFutureAdaptors.java
+++ b/src/main/java/emissary/grpc/future/CompletableFutureAdaptors.java
@@ -15,23 +15,31 @@ public class CompletableFutureAdaptors {
     /**
      * Converts a Guava {@link ListenableFuture} future to a Java {@link CompletableFuture}.
      *
-     * @param future Guava future
+     * @param listenable Guava future
      * @return completable future
      * @param <R> result type
      */
-    public static <R extends GeneratedMessageV3> CompletableFuture<R> fromListenableFuture(ListenableFuture<R> future) {
-        CompletableFuture<R> completableFuture = new CompletableFuture<>();
-        Futures.addCallback(future, new FutureCallback<>() {
+    public static <R extends GeneratedMessageV3> CompletableFuture<R> fromListenableFuture(ListenableFuture<R> listenable) {
+        CompletableFuture<R> completable = new CompletableFuture<>();
+
+        FutureCallback<R> callback = new FutureCallback<>() {
             @Override
             public void onSuccess(R result) {
-                completableFuture.complete(result);
+                completable.complete(result);
             }
 
             @Override
             public void onFailure(@Nonnull Throwable t) {
-                completableFuture.completeExceptionally(t);
+                if (listenable.isCancelled()) {
+                    completable.cancel(false);
+                } else {
+                    completable.completeExceptionally(t);
+                }
             }
-        }, MoreExecutors.directExecutor()); // Direct executor runs callback immediately on thread completing Guava future
-        return completableFuture;
+        };
+
+        // Direct executor runs callback immediately on thread completing Guava future
+        Futures.addCallback(listenable, callback, MoreExecutors.directExecutor());
+        return completable;
     }
 }

--- a/src/main/java/emissary/grpc/future/CompletableFutureFinalizers.java
+++ b/src/main/java/emissary/grpc/future/CompletableFutureFinalizers.java
@@ -2,11 +2,13 @@ package emissary.grpc.future;
 
 import emissary.grpc.exceptions.GrpcExceptionUtils;
 
+import io.grpc.Status;
 import jakarta.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -17,8 +19,9 @@ public class CompletableFutureFinalizers {
     /**
      * Waits for a provided asynchronous computation to complete and then return its result. This method blocks the calling
      * thread until the {@link CompletableFuture} input has completed. If the future completes exceptionally, the
-     * corresponding {@link CompletableFuture#join()} call will throw a {@link RuntimeException}, unless the future has been
-     * preconfigured with explicit exception handling behavior.
+     * corresponding {@link CompletableFuture#get()} call will throw a {@link RuntimeException}, unless the future has been
+     * preconfigured with explicit exception handling behavior. If the thread is interrupted while the future is still
+     * completing, the call will be canceled and a {@link io.grpc.StatusRuntimeException} will be thrown.
      *
      * @param future future representing an asynchronous computation
      * @return the result returned by an asynchronous computation
@@ -26,8 +29,13 @@ public class CompletableFutureFinalizers {
      */
     public static <R> R awaitAndGet(CompletableFuture<R> future) {
         try {
-            return future.join();
-        } catch (RuntimeException e) {
+            return future.get();
+        } catch (InterruptedException e) {
+            future.cancel(true);
+            Thread.currentThread().interrupt();
+            throw GrpcExceptionUtils.toContextualRuntimeException(
+                    Status.CANCELLED.asRuntimeException());
+        } catch (ExecutionException | RuntimeException e) {
             throw GrpcExceptionUtils.toContextualRuntimeException(
                     GrpcExceptionUtils.unwrapAsyncThrowable(e));
         }

--- a/src/main/java/emissary/grpc/future/CompletableFutureFinalizers.java
+++ b/src/main/java/emissary/grpc/future/CompletableFutureFinalizers.java
@@ -31,10 +31,9 @@ public class CompletableFutureFinalizers {
         try {
             return future.get();
         } catch (InterruptedException e) {
-            future.cancel(true);
+            future.cancel(false);
             Thread.currentThread().interrupt();
-            throw GrpcExceptionUtils.toContextualRuntimeException(
-                    Status.CANCELLED.asRuntimeException());
+            throw GrpcExceptionUtils.toContextualRuntimeException(Status.CANCELLED.asRuntimeException());
         } catch (ExecutionException | RuntimeException e) {
             throw GrpcExceptionUtils.toContextualRuntimeException(
                     GrpcExceptionUtils.unwrapAsyncThrowable(e));

--- a/src/main/java/emissary/grpc/future/CompletableFutureFinalizers.java
+++ b/src/main/java/emissary/grpc/future/CompletableFutureFinalizers.java
@@ -20,8 +20,11 @@ public class CompletableFutureFinalizers {
      * Waits for a provided asynchronous computation to complete and then return its result. This method blocks the calling
      * thread until the {@link CompletableFuture} input has completed. If the future completes exceptionally, the
      * corresponding {@link CompletableFuture#get()} call will throw a {@link RuntimeException}, unless the future has been
-     * preconfigured with explicit exception handling behavior. If the thread is interrupted while the future is still
-     * completing, the call will be canceled and a {@link io.grpc.StatusRuntimeException} will be thrown.
+     * preconfigured with explicit exception handling behavior.
+     * <p>
+     * If the thread is interrupted while the future is still completing, the client-side future will be canceled and a
+     * {@link io.grpc.StatusRuntimeException} will be thrown. Note that while the client will send a cancellation message,
+     * the in-flight RPC may still complete on the server, depending on how it was built.
      *
      * @param future future representing an asynchronous computation
      * @return the result returned by an asynchronous computation
@@ -46,6 +49,10 @@ public class CompletableFutureFinalizers {
      * corresponding {@link CompletableFuture#join()} call will throw a {@link RuntimeException}, unless explicit behavior
      * has been passed through the {@code exceptionally} argument. Note that the {@code exceptionally} argument will not run
      * if the future has already been preconfigured with exception handling behavior.
+     * <p>
+     * If the thread is interrupted while the future is still completing, the client-side future will be canceled and a
+     * {@link io.grpc.StatusRuntimeException} will be thrown. Note that while the client will send a cancellation message,
+     * the in-flight RPC may still complete on the server, depending on how it was built.
      *
      * @param future future representing an asynchronous computation
      * @param exceptionally function for handling exceptions thrown by the future, throws normally if {@code null}
@@ -64,6 +71,10 @@ public class CompletableFutureFinalizers {
      * calling thread until each {@link CompletableFuture} in the input is complete. If any future completes exceptionally,
      * the corresponding {@link CompletableFuture#join()} call will throw a {@link RuntimeException}, and iteration will
      * stop at that point, unless the future has been preconfigured with explicit exception handling behavior.
+     * <p>
+     * If the thread is interrupted while the futures are still completing, the client-side futures will be canceled and a
+     * {@link io.grpc.StatusRuntimeException} will be thrown. Note that while the client will send a cancellation message,
+     * the in-flight RPCs may still complete on the server, depending on how it was built.
      *
      * @param futures collection of futures representing asynchronous computations
      * @param factory creates the output collection instance
@@ -83,6 +94,10 @@ public class CompletableFutureFinalizers {
      * stop at that point, unless explicit behavior has been passed through the {@code exceptionally} argument. Note that
      * the {@code exceptionally} argument will not run if the future has already been preconfigured with exception handling
      * behavior.
+     * <p>
+     * If the thread is interrupted while the futures are still completing, the client-side futures will be canceled and a
+     * {@link io.grpc.StatusRuntimeException} will be thrown. Note that while the client will send a cancellation message,
+     * the in-flight RPCs may still complete on the server, depending on how it was built.
      *
      * @param futures collection of futures representing asynchronous computations
      * @param factory creates the output collection instance
@@ -103,6 +118,10 @@ public class CompletableFutureFinalizers {
      * calling thread until each {@link CompletableFuture} in the input is complete. If any future completes exceptionally,
      * the corresponding {@link CompletableFuture#join()} call will throw a {@link RuntimeException}, and iteration will
      * stop at that point, unless the future has been preconfigured with explicit exception handling behavior.
+     * <p>
+     * If the thread is interrupted while the futures are still completing, the client-side futures will be canceled and a
+     * {@link io.grpc.StatusRuntimeException} will be thrown. Note that while the client will send a cancellation message,
+     * the in-flight RPCs may still complete on the server, depending on how it was built.
      *
      * @param futures map of keys to futures representing asynchronous computations
      * @param factory creates the output map instance
@@ -123,6 +142,10 @@ public class CompletableFutureFinalizers {
      * stop at that point, unless explicit behavior has been passed through the {@code exceptionally} argument. Note that
      * the {@code exceptionally} argument will not run if the future has already been preconfigured with exception handling
      * behavior.
+     * <p>
+     * If the thread is interrupted while the futures are still completing, the client-side futures will be canceled and a
+     * {@link io.grpc.StatusRuntimeException} will be thrown. Note that while the client will send a cancellation message,
+     * the in-flight RPCs may still complete on the server, depending on how it was built.
      *
      * @param futures map of keys to futures representing asynchronous computations
      * @param factory creates the output map instance

--- a/src/main/java/emissary/grpc/invoker/GrpcInvoker.java
+++ b/src/main/java/emissary/grpc/invoker/GrpcInvoker.java
@@ -13,6 +13,9 @@ import io.grpc.stub.AbstractFutureStub;
 import org.apache.commons.pool2.ObjectPool;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -71,32 +74,36 @@ public class GrpcInvoker {
     public <Q extends GeneratedMessageV3, R extends GeneratedMessageV3, S extends AbstractFutureStub<S>> CompletableFuture<R> invokeAsync(
             ObjectPool<ManagedChannel> channelPool, Function<ManagedChannel, S> stubFactory,
             BiFunction<S, Q, ListenableFuture<R>> callLogic, Q request) {
-        return retryHandler.executeAsync(() -> {
+        AtomicReference<ListenableFuture<R>> listenableRef = new AtomicReference<>();
+        CompletionStage<R> stage = retryHandler.executeAsync(() -> {
             ManagedChannel channel = ConnectionFactory.acquireChannel(channelPool);
             try {
                 S stub = stubFactory.apply(channel);
-                ListenableFuture<R> listenable = callLogic.apply(stub, request);
-                CompletableFuture<R> completable = CompletableFutureAdaptors.fromListenableFuture(listenable);
-                return completable.handle(handleFuture(channel, channelPool));
+                listenableRef.set(callLogic.apply(stub, request));
+                CompletableFuture<R> completable = CompletableFutureAdaptors.fromListenableFuture(listenableRef.get());
+                return attachHandlingHook(completable, channel, channelPool);
             } catch (RuntimeException e) {
                 ConnectionFactory.invalidateChannel(channel, channelPool);
                 throw GrpcExceptionUtils.toContextualRuntimeException(e);
             }
-        }).toCompletableFuture();
+        });
+        return attachCancellationHook(stage.toCompletableFuture(), listenableRef);
     }
 
     /**
-     * Creates a handler for gRPC future completion that manages channel lifecycle and exception mapping. Runs when the
-     * future completes regardless of success or failure.
+     * Attaches a completion hook to the provided {@link CompletableFuture} using
+     * {@link CompletableFuture#handle(BiFunction)}. This hook manages channel lifecycle and exception mapping, and runs
+     * when the future completes regardless of its success or failure.
      *
+     * @param future the future to attach the hook to
      * @param channel the borrowed channel
      * @param channelPool the pool the channel came from
      * @param <R> response type
-     * @return handler function suitable for {@link CompletableFuture#handle}
+     * @return a future with explicit handling logic
      */
-    private static <R extends GeneratedMessageV3> BiFunction<R, Throwable, R> handleFuture(
-            ManagedChannel channel, ObjectPool<ManagedChannel> channelPool) {
-        return (response, throwable) -> {
+    private static <R extends GeneratedMessageV3> CompletableFuture<R> attachHandlingHook(
+            CompletableFuture<R> future, ManagedChannel channel, ObjectPool<ManagedChannel> channelPool) {
+        return future.handle((response, throwable) -> {
             if (throwable == null) {
                 ConnectionFactory.returnChannel(channel, channelPool);
                 return response;
@@ -104,6 +111,40 @@ public class GrpcInvoker {
             ConnectionFactory.invalidateChannel(channel, channelPool);
             throw GrpcExceptionUtils.toContextualRuntimeException(
                     GrpcExceptionUtils.unwrapAsyncThrowable(throwable));
-        };
+        });
+    }
+
+    /**
+     * Attaches a completion hook to the provided {@link CompletableFuture} using
+     * {@link CompletableFuture#whenComplete(BiConsumer)}, while explicitly ignoring the returned dependent future. This
+     * helper exists to preserve cancellation semantics when working with chained {@code CompletableFuture} operations.
+     * <p>
+     * {@code CompletableFuture} propagation is directional:
+     * <ul>
+     * <li>Normal completion (success or failure) flows downstream from a source future to its dependent futures.</li>
+     * <li>Cancellation of a dependent future doesn't propagate upstream to the source future.</li>
+     * </ul>
+     * <p>
+     * Hooks added to futures (e.g. {@link CompletableFuture#whenComplete(BiConsumer)}) create new dependent futures. If
+     * those returned futures are used directly, cancellation applied to them will not automatically cancel the original
+     * future.
+     *
+     * @param future the future to attach the hook to
+     * @param currentRpc reference to the currently active RPC future
+     * @param <R> the result type
+     * @return the root future
+     */
+    @SuppressWarnings({"FutureReturnValueIgnored", "Interruption"})
+    private static <R extends GeneratedMessageV3> CompletableFuture<R> attachCancellationHook(
+            CompletableFuture<R> future, AtomicReference<ListenableFuture<R>> currentRpc) {
+        future.whenComplete((response, throwable) -> {
+            if (future.isCancelled()) {
+                ListenableFuture<R> rpc = currentRpc.get();
+                if (rpc != null) {
+                    rpc.cancel(true);
+                }
+            }
+        });
+        return future;
     }
 }

--- a/src/test/java/emissary/grpc/sample/GrpcSampleServiceImpl.java
+++ b/src/test/java/emissary/grpc/sample/GrpcSampleServiceImpl.java
@@ -5,8 +5,10 @@ import emissary.grpc.sample.v1.SampleRequest;
 import emissary.grpc.sample.v1.SampleResponse;
 import emissary.grpc.sample.v1.SampleServiceGrpc;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
+import io.grpc.Context;
 import io.grpc.stub.StreamObserver;
 
 import java.io.ByteArrayOutputStream;
@@ -87,9 +89,14 @@ public abstract class GrpcSampleServiceImpl extends SampleServiceGrpc.SampleServ
 
         @Override
         public byte[] process(byte[] query) {
+            Context context = Context.current();
+            context.addListener(ignored -> releaseLatch.countDown(), MoreExecutors.directExecutor());
             startedLatch.countDown();
             try {
                 releaseLatch.await();
+                if (context.isCancelled()) {
+                    return new byte[0];
+                }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new IllegalStateException(e);

--- a/src/test/java/emissary/grpc/sample/GrpcSampleServicePlaceTest.java
+++ b/src/test/java/emissary/grpc/sample/GrpcSampleServicePlaceTest.java
@@ -393,7 +393,7 @@ class GrpcSampleServicePlaceTest extends UnitTest {
                 assertNull(errorRef.get());
 
                 clientThread.interrupt();
-                clientThread.join(1000);
+                clientThread.join(500);
                 assertFalse(clientThread.isAlive(), "Client thread should exit after interruption");
 
                 Throwable error = errorRef.get();
@@ -459,7 +459,7 @@ class GrpcSampleServicePlaceTest extends UnitTest {
                 assertTrue(clientThread.isAlive());
                 releaseLatchTwo.countDown();
 
-                clientThread.join(1000); // Wait for thread to die
+                clientThread.join(500); // Wait for thread to die
                 assertFalse(clientThread.isAlive());
 
                 assertEquals(2, o.getAlternateViews().size());
@@ -514,7 +514,7 @@ class GrpcSampleServicePlaceTest extends UnitTest {
                 assertNull(errorRef.get());
 
                 clientThread.interrupt();
-                clientThread.join(2000);
+                clientThread.join(500);
                 assertFalse(clientThread.isAlive(), "Client thread should exit after interruption");
 
                 Throwable error = errorRef.get();
@@ -573,7 +573,7 @@ class GrpcSampleServicePlaceTest extends UnitTest {
                 assertTrue(clientThread.isAlive());
                 releaseLatch.countDown();
 
-                clientThread.join(1000); // Wait for thread to die
+                clientThread.join(500); // Wait for thread to die
                 assertFalse(clientThread.isAlive());
 
                 assertEquals(2, o.getAlternateViews().size());

--- a/src/test/java/emissary/grpc/sample/GrpcSampleServicePlaceTest.java
+++ b/src/test/java/emissary/grpc/sample/GrpcSampleServicePlaceTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -357,6 +358,56 @@ class GrpcSampleServicePlaceTest extends UnitTest {
         }
 
         @Test
+        void testThreadInterruptCancelsSequentialGrpc() throws IOException, InterruptedException {
+            CountDownLatch startedLatch = new CountDownLatch(1);
+            CountDownLatch releaseLatch = new CountDownLatch(1);
+            Server synchronicityServer = null;
+
+            try {
+                synchronicityServer = startSynchronicityServer(startedLatch, releaseLatch);
+
+                samplePlace = placeFactory.buildPlace(
+                        new ConfigEntry(GrpcSampleServicePlace.GRPC_HOST + ENDPOINT_1_ID, null),
+                        new ConfigEntry(GrpcSampleServicePlace.GRPC_HOST + ENDPOINT_2_ID, null),
+                        new ConfigEntry(GrpcSampleServicePlace.GRPC_HOST + SYNCHRONICITY_1_ID, ENDPOINT_HOST),
+                        new ConfigEntry(GrpcSampleServicePlace.GRPC_HOST + SYNCHRONICITY_2_ID, ENDPOINT_HOST),
+                        new ConfigEntry(GrpcSampleServicePlace.GRPC_PORT + SYNCHRONICITY_1_ID, getPort(synchronicityServer)),
+                        new ConfigEntry(GrpcSampleServicePlace.GRPC_PORT + SYNCHRONICITY_2_ID, getPort(endpointTwoServer)));
+
+                IBaseDataObject o = new BaseDataObject(INPUT_DATA, FILENAME);
+
+                AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+                Thread clientThread = new Thread(() -> {
+                    try {
+                        Objects.requireNonNull(samplePlace).processAllTargetsSequentially(o);
+                    } catch (Throwable t) {
+                        errorRef.set(t);
+                    }
+                });
+
+                clientThread.start();
+
+                assertTrue(startedLatch.await(1, TimeUnit.SECONDS), "Server should have received request");
+                assertNull(errorRef.get());
+
+                clientThread.interrupt();
+                clientThread.join(1000);
+                assertFalse(clientThread.isAlive(), "Client thread should exit after interruption");
+
+                Throwable error = errorRef.get();
+                assertInstanceOf(StatusRuntimeException.class, error);
+                assertEquals(Status.Code.CANCELLED, Status.fromThrowable(error).getCode());
+                assertTrue(o.getAlternateViews().isEmpty());
+            } finally {
+                releaseLatch.countDown();
+                if (synchronicityServer != null) {
+                    synchronicityServer.shutdownNow();
+                }
+            }
+        }
+
+        @Test
         void testBlockedResponsesAreProcessedSequentially() throws IOException, InterruptedException {
             Server synchronicityOneServer = null;
             Server synchronicityTwoServer = null;
@@ -380,13 +431,11 @@ class GrpcSampleServicePlaceTest extends UnitTest {
 
                 IBaseDataObject o = new BaseDataObject(INPUT_DATA, FILENAME);
 
-                AtomicReference<Map<String, byte[]>> viewRef = new AtomicReference<>();
                 AtomicReference<Throwable> errorRef = new AtomicReference<>();
 
                 Thread clientThread = new Thread(() -> {
                     try {
                         samplePlace.processAllTargetsSequentially(o);
-                        viewRef.set(o.getAlternateViews());
                     } catch (Throwable t) {
                         errorRef.set(t);
                     }
@@ -396,14 +445,14 @@ class GrpcSampleServicePlaceTest extends UnitTest {
 
                 assertTrue(startedLatchOne.await(1, TimeUnit.SECONDS), "First server should have received request");
                 assertEquals(1L, startedLatchTwo.getCount(), "Second server should be waiting to receive request");
-                assertNull(viewRef.get());
+                assertTrue(o.getAlternateViews().isEmpty());
                 assertNull(errorRef.get());
 
                 assertTrue(clientThread.isAlive());
                 releaseLatchOne.countDown();
 
                 assertTrue(startedLatchTwo.await(1, TimeUnit.SECONDS));
-                assertNull(viewRef.get());
+                assertEquals(1, o.getAlternateViews().size());
                 assertNull(errorRef.get());
 
                 assertTrue(clientThread.isAlive());
@@ -412,11 +461,66 @@ class GrpcSampleServicePlaceTest extends UnitTest {
                 clientThread.join(1000); // Wait for thread to die
                 assertFalse(clientThread.isAlive());
 
-                assertEquals(2, viewRef.get().size());
-                assertArrayEquals(INPUT_DATA, viewRef.get().get(SYNCHRONICITY_1_ID));
-                assertArrayEquals(INPUT_DATA, viewRef.get().get(SYNCHRONICITY_2_ID));
+                assertEquals(2, o.getAlternateViews().size());
+                assertArrayEquals(INPUT_DATA, o.getAlternateViews().get(SYNCHRONICITY_1_ID));
+                assertArrayEquals(INPUT_DATA, o.getAlternateViews().get(SYNCHRONICITY_2_ID));
                 assertNull(errorRef.get());
             } finally {
+                if (synchronicityOneServer != null) {
+                    synchronicityOneServer.shutdownNow();
+                }
+                if (synchronicityTwoServer != null) {
+                    synchronicityTwoServer.shutdownNow();
+                }
+            }
+        }
+
+        @Test
+        void testThreadInterruptCancelsParallelGrpc() throws IOException, InterruptedException {
+            CountDownLatch startedLatch = new CountDownLatch(2);
+            CountDownLatch releaseLatch = new CountDownLatch(1);
+            Server synchronicityOneServer = null;
+            Server synchronicityTwoServer = null;
+
+            try {
+                synchronicityOneServer = startSynchronicityServer(startedLatch, releaseLatch);
+                synchronicityTwoServer = startSynchronicityServer(startedLatch, releaseLatch);
+
+                samplePlace = placeFactory.buildPlace(
+                        new ConfigEntry(GrpcSampleServicePlace.GRPC_HOST + ENDPOINT_1_ID, null),
+                        new ConfigEntry(GrpcSampleServicePlace.GRPC_HOST + ENDPOINT_2_ID, null),
+                        new ConfigEntry(GrpcSampleServicePlace.GRPC_HOST + SYNCHRONICITY_1_ID, ENDPOINT_HOST),
+                        new ConfigEntry(GrpcSampleServicePlace.GRPC_HOST + SYNCHRONICITY_2_ID, ENDPOINT_HOST),
+                        new ConfigEntry(GrpcSampleServicePlace.GRPC_PORT + SYNCHRONICITY_1_ID, getPort(synchronicityOneServer)),
+                        new ConfigEntry(GrpcSampleServicePlace.GRPC_PORT + SYNCHRONICITY_2_ID, getPort(synchronicityTwoServer)));
+
+                IBaseDataObject o = new BaseDataObject(INPUT_DATA, FILENAME);
+
+                AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+                Thread clientThread = new Thread(() -> {
+                    try {
+                        samplePlace.processAllTargetsInParallel(o);
+                    } catch (Throwable t) {
+                        errorRef.set(t);
+                    }
+                });
+
+                clientThread.start();
+
+                assertTrue(startedLatch.await(2, TimeUnit.SECONDS), "Not all servers received requests");
+                assertNull(errorRef.get());
+
+                clientThread.interrupt();
+                clientThread.join(2000);
+                assertFalse(clientThread.isAlive(), "Client thread should exit after interruption");
+
+                Throwable error = errorRef.get();
+                assertInstanceOf(StatusRuntimeException.class, error);
+                assertEquals(Status.Code.CANCELLED, Status.fromThrowable(error).getCode());
+                assertTrue(o.getAlternateViews().isEmpty());
+            } finally {
+                releaseLatch.countDown();
                 if (synchronicityOneServer != null) {
                     synchronicityOneServer.shutdownNow();
                 }
@@ -448,13 +552,11 @@ class GrpcSampleServicePlaceTest extends UnitTest {
 
                 IBaseDataObject o = new BaseDataObject(INPUT_DATA, FILENAME);
 
-                AtomicReference<Map<String, byte[]>> viewRef = new AtomicReference<>();
                 AtomicReference<Throwable> errorRef = new AtomicReference<>();
 
                 Thread clientThread = new Thread(() -> {
                     try {
                         samplePlace.processAllTargetsInParallel(o);
-                        viewRef.set(o.getAlternateViews());
                     } catch (Throwable t) {
                         errorRef.set(t);
                     }
@@ -463,7 +565,7 @@ class GrpcSampleServicePlaceTest extends UnitTest {
                 clientThread.start();
 
                 assertTrue(startedLatch.await(2, TimeUnit.SECONDS), "Not all servers received requests");
-                assertNull(viewRef.get());
+                assertTrue(o.getAlternateViews().isEmpty());
                 assertNull(errorRef.get());
 
                 assertTrue(clientThread.isAlive());
@@ -472,9 +574,9 @@ class GrpcSampleServicePlaceTest extends UnitTest {
                 clientThread.join(1000); // Wait for thread to die
                 assertFalse(clientThread.isAlive());
 
-                assertEquals(2, viewRef.get().size());
-                assertArrayEquals(INPUT_DATA, viewRef.get().get(SYNCHRONICITY_1_ID));
-                assertArrayEquals(INPUT_DATA, viewRef.get().get(SYNCHRONICITY_2_ID));
+                assertEquals(2, o.getAlternateViews().size());
+                assertArrayEquals(INPUT_DATA, o.getAlternateViews().get(SYNCHRONICITY_1_ID));
+                assertArrayEquals(INPUT_DATA, o.getAlternateViews().get(SYNCHRONICITY_2_ID));
                 assertNull(errorRef.get());
             } finally {
                 if (synchronicityOneServer != null) {

--- a/src/test/java/emissary/grpc/sample/GrpcSampleServicePlaceTest.java
+++ b/src/test/java/emissary/grpc/sample/GrpcSampleServicePlaceTest.java
@@ -358,6 +358,7 @@ class GrpcSampleServicePlaceTest extends UnitTest {
         }
 
         @Test
+        @SuppressWarnings("Interruption")
         void testThreadInterruptCancelsSequentialGrpc() throws IOException, InterruptedException {
             CountDownLatch startedLatch = new CountDownLatch(1);
             CountDownLatch releaseLatch = new CountDownLatch(1);
@@ -476,6 +477,7 @@ class GrpcSampleServicePlaceTest extends UnitTest {
         }
 
         @Test
+        @SuppressWarnings("Interruption")
         void testThreadInterruptCancelsParallelGrpc() throws IOException, InterruptedException {
             CountDownLatch startedLatch = new CountDownLatch(2);
             CountDownLatch releaseLatch = new CountDownLatch(1);

--- a/src/test/java/emissary/grpc/sample/GrpcSampleServicePlaceTest.java
+++ b/src/test/java/emissary/grpc/sample/GrpcSampleServicePlaceTest.java
@@ -395,13 +395,13 @@ class GrpcSampleServicePlaceTest extends UnitTest {
                 clientThread.interrupt();
                 clientThread.join(500);
                 assertFalse(clientThread.isAlive(), "Client thread should exit after interruption");
+                assertTrue(releaseLatch.await(1, TimeUnit.SECONDS), "RPC should be canceled with resources released");
 
                 Throwable error = errorRef.get();
                 assertInstanceOf(StatusRuntimeException.class, error);
                 assertEquals(Status.Code.CANCELLED, Status.fromThrowable(error).getCode());
                 assertTrue(o.getAlternateViews().isEmpty());
             } finally {
-                releaseLatch.countDown();
                 if (synchronicityServer != null) {
                     synchronicityServer.shutdownNow();
                 }
@@ -516,13 +516,13 @@ class GrpcSampleServicePlaceTest extends UnitTest {
                 clientThread.interrupt();
                 clientThread.join(500);
                 assertFalse(clientThread.isAlive(), "Client thread should exit after interruption");
+                assertTrue(releaseLatch.await(1, TimeUnit.SECONDS), "RPC should be canceled with resources released");
 
                 Throwable error = errorRef.get();
                 assertInstanceOf(StatusRuntimeException.class, error);
                 assertEquals(Status.Code.CANCELLED, Status.fromThrowable(error).getCode());
                 assertTrue(o.getAlternateViews().isEmpty());
             } finally {
-                releaseLatch.countDown();
                 if (synchronicityOneServer != null) {
                     synchronicityOneServer.shutdownNow();
                 }


### PR DESCRIPTION
`CompletableFuture#get()` and `CompletableFuture#join()` both have the same functionality. Both block the calling thread while waiting for a future to complete and then return the result. The difference between them is that:
* `CompletableFuture#get()`
  * Throws checked and unchecked exceptions and needs to be wrapped in a `try` block
  * Throws an `InterruptedException` if the thread is interrupted and stops waiting for the future to complete
* `CompletableFuture#join()`
  * Only throws unchecked exceptions
  * Ignores interrupted threads

Switching the finalizer method to `get` because if a place times out, we want the thread interrupt to cancel the RPC. Note that sequential RPCs using gRPC blocking stubs are already thread interruptible. 
