### PR TITLE
regression-test :: cleanup; update err messages

### DIFF
--- a/src/test/java/emissary/core/IBaseDataObjectDiffHelper.java
+++ b/src/test/java/emissary/core/IBaseDataObjectDiffHelper.java
@@ -23,8 +23,11 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import static emissary.core.constants.IbdoXmlElementNames.BROKEN;
+import static emissary.core.constants.IbdoXmlElementNames.CLASSIFICATION;
+import static emissary.core.constants.IbdoXmlElementNames.PARAMETER;
+
 public class IBaseDataObjectDiffHelper {
-    private static final String DIFF_OUTPUT_FORMAT = "%s%s: %s : %s";
     private static final String DIFF_NOT_NULL_MSG = "Required: differences not null";
     private static final String ID_NOT_NULL_MSG = "Required: identifier not null";
     private static final String ARE_NOT_EQUAL = " are not equal";
@@ -40,96 +43,96 @@ public class IBaseDataObjectDiffHelper {
     /**
      * This method compares two IBaseDataObject's and adds any differences to the provided string list.
      *
-     * @param ibdo1 the first IBaseDataObject to compare.
-     * @param ibdo2 the second IBaseDataObject to compare.
+     * @param expected the first IBaseDataObject to compare.
+     * @param actual the second IBaseDataObject to compare.
      * @param differences the string list differences are to be added to.
      * @param options {@link DiffCheckConfiguration} containing config to specify whether to check data etc.
      */
-    public static void diff(final IBaseDataObject ibdo1, final IBaseDataObject ibdo2,
+    public static void diff(final IBaseDataObject expected, final IBaseDataObject actual,
             final List<String> differences, final DiffCheckConfiguration options) {
-        Validate.notNull(ibdo1, "Required: ibdo1 not null");
-        Validate.notNull(ibdo2, "Required: ibdo2 not null");
+        Validate.notNull(expected, "Required: expected not null");
+        Validate.notNull(actual, "Required: actual not null");
         Validate.notNull(differences, DIFF_NOT_NULL_MSG);
 
         if (options.checkData()) {
-            final SeekableByteChannelFactory sbcf1 = ibdo1.getChannelFactory();
-            final SeekableByteChannelFactory sbcf2 = ibdo2.getChannelFactory();
+            final SeekableByteChannelFactory sbcf1 = expected.getChannelFactory();
+            final SeekableByteChannelFactory sbcf2 = actual.getChannelFactory();
             diff(sbcf1, sbcf2, IbdoXmlElementNames.DATA, differences);
         }
 
-        diff(ibdo1.getFilename(), ibdo2.getFilename(), IbdoXmlElementNames.FILENAME, differences);
-        diff(ibdo1.shortName(), ibdo2.shortName(), SHORT_NAME, differences);
+        diff(expected.getFilename(), actual.getFilename(), IbdoXmlElementNames.FILENAME, differences);
+        diff(expected.shortName(), actual.shortName(), SHORT_NAME, differences);
         if (options.checkInternalId()) {
-            diff(ibdo1.getInternalId(), ibdo2.getInternalId(), INTERNAL_ID, differences);
+            diff(expected.getInternalId(), actual.getInternalId(), INTERNAL_ID, differences);
         }
-        diff(ibdo1.currentForm(), ibdo2.currentForm(), IbdoXmlElementNames.CURRENT_FORM, differences);
-        diff(ibdo1.getProcessingError(), ibdo2.getProcessingError(), IbdoXmlElementNames.PROCESSING_ERROR, differences);
+        diff(expected.currentForm(), actual.currentForm(), IbdoXmlElementNames.CURRENT_FORM, differences);
+        diff(expected.getProcessingError(), actual.getProcessingError(), IbdoXmlElementNames.PROCESSING_ERROR, differences);
 
         if (options.checkTransformHistory()) {
-            diff(ibdo1.transformHistory(), ibdo2.transformHistory(), TRANSFORM_HISTORY, differences);
+            diff(expected.transformHistory(), actual.transformHistory(), TRANSFORM_HISTORY, differences);
         }
 
-        diff(ibdo1.getFontEncoding(), ibdo2.getFontEncoding(), IbdoXmlElementNames.FONT_ENCODING, differences);
+        diff(expected.getFontEncoding(), actual.getFontEncoding(), IbdoXmlElementNames.FONT_ENCODING, differences);
 
         if (options.performDetailedParameterDiff()) {
-            diff(convertMap(ibdo1.getParameters()), convertMap(ibdo2.getParameters()), IbdoXmlElementNames.PARAMETER, differences);
+            diff(convertMap(expected.getParameters()), convertMap(actual.getParameters()), PARAMETER, differences);
         } else if (options.performKeyValueParameterDiff()) {
-            keyValueMapDiff(convertMap(ibdo1.getParameters()), convertMap(ibdo2.getParameters()), IbdoXmlElementNames.PARAMETER, differences);
+            keyValueMapDiff(convertMap(expected.getParameters()), convertMap(actual.getParameters()), PARAMETER, differences);
         } else {
-            minimalMapDiff(convertMap(ibdo1.getParameters()), convertMap(ibdo2.getParameters()), IbdoXmlElementNames.PARAMETER, differences);
+            minimalMapDiff(convertMap(expected.getParameters()), convertMap(actual.getParameters()), PARAMETER, differences);
         }
 
-        diff(ibdo1.getNumChildren(), ibdo2.getNumChildren(), IbdoXmlElementNames.NUM_CHILDREN, differences);
-        diff(ibdo1.getNumSiblings(), ibdo2.getNumSiblings(), IbdoXmlElementNames.NUM_SIBLINGS, differences);
-        diff(ibdo1.getBirthOrder(), ibdo2.getBirthOrder(), IbdoXmlElementNames.BIRTH_ORDER, differences);
-        diff(ibdo1.getAlternateViews(), ibdo2.getAlternateViews(), IbdoXmlElementNames.VIEW, differences);
-        diff(ibdo1.header(), ibdo2.header(), IbdoXmlElementNames.HEADER, differences);
-        diff(ibdo1.footer(), ibdo2.footer(), IbdoXmlElementNames.FOOTER, differences);
-        diff(ibdo1.getHeaderEncoding(), ibdo2.getHeaderEncoding(), IbdoXmlElementNames.HEADER_ENCODING, differences);
-        diff(ibdo1.getClassification(), ibdo2.getClassification(), IbdoXmlElementNames.CLASSIFICATION, differences);
-        diff(ibdo1.isBroken(), ibdo2.isBroken(), IbdoXmlElementNames.BROKEN, differences);
-        diff(ibdo1.isFileTypeEmpty(), ibdo2.isFileTypeEmpty(), FILE_TYPE_EMPTY, differences);
-        diff(ibdo1.getPriority(), ibdo2.getPriority(), IbdoXmlElementNames.PRIORITY, differences);
+        diff(expected.getNumChildren(), actual.getNumChildren(), IbdoXmlElementNames.NUM_CHILDREN, differences);
+        diff(expected.getNumSiblings(), actual.getNumSiblings(), IbdoXmlElementNames.NUM_SIBLINGS, differences);
+        diff(expected.getBirthOrder(), actual.getBirthOrder(), IbdoXmlElementNames.BIRTH_ORDER, differences);
+        diff(expected.getAlternateViews(), actual.getAlternateViews(), IbdoXmlElementNames.VIEW, differences);
+        diff(expected.header(), actual.header(), IbdoXmlElementNames.HEADER, differences);
+        diff(expected.footer(), actual.footer(), IbdoXmlElementNames.FOOTER, differences);
+        diff(expected.getHeaderEncoding(), actual.getHeaderEncoding(), IbdoXmlElementNames.HEADER_ENCODING, differences);
+        diff(expected.getClassification(), actual.getClassification(), CLASSIFICATION, differences);
+        diff(expected.isBroken(), actual.isBroken(), BROKEN, differences);
+        diff(expected.isFileTypeEmpty(), actual.isFileTypeEmpty(), FILE_TYPE_EMPTY, differences);
+        diff(expected.getPriority(), actual.getPriority(), IbdoXmlElementNames.PRIORITY, differences);
         if (options.checkTimestamp()) {
-            diff(ibdo1.getCreationTimestamp(), ibdo2.getCreationTimestamp(), CREATION_TIMESTAMP, differences);
+            diff(expected.getCreationTimestamp(), actual.getCreationTimestamp(), CREATION_TIMESTAMP, differences);
         }
-        diff(ibdo1.isOutputable(), ibdo2.isOutputable(), IbdoXmlElementNames.OUTPUTABLE, differences);
-        diff(ibdo1.getId(), ibdo2.getId(), IbdoXmlElementNames.ID, differences);
-        diff(ibdo1.getWorkBundleId(), ibdo2.getWorkBundleId(), IbdoXmlElementNames.WORK_BUNDLE_ID, differences);
-        diff(ibdo1.getTransactionId(), ibdo2.getTransactionId(), IbdoXmlElementNames.TRANSACTION_ID, differences);
+        diff(expected.isOutputable(), actual.isOutputable(), IbdoXmlElementNames.OUTPUTABLE, differences);
+        diff(expected.getId(), actual.getId(), IbdoXmlElementNames.ID, differences);
+        diff(expected.getWorkBundleId(), actual.getWorkBundleId(), IbdoXmlElementNames.WORK_BUNDLE_ID, differences);
+        diff(expected.getTransactionId(), actual.getTransactionId(), IbdoXmlElementNames.TRANSACTION_ID, differences);
 
         // Special case - pass through DiffCheckConfiguration options. This also ensures the right method is called (Object vs
         // List<IBDO>)
-        diff(ibdo1.getExtractedRecords(), ibdo2.getExtractedRecords(), EXTRACTED_RECORDS, differences, options);
+        diff(expected.getExtractedRecords(), actual.getExtractedRecords(), EXTRACTED_RECORDS, differences, options);
     }
 
     /**
      * This method compares two lists of IBaseDataObject's and adds any differences to the provided string list.
      *
-     * @param ibdoList1 the first list of IBaseDataObjects to compare.
-     * @param ibdoList2 the second list of IBaseDataObjects to compare.
+     * @param expected the first list of IBaseDataObjects to compare.
+     * @param actual the second list of IBaseDataObjects to compare.
      * @param identifier a string that helps identify the context of comparing these two list of IBaseDataObjects.
      * @param differences the string list differences are to be added to.
      * @param options {@link DiffCheckConfiguration} containing config to specify whether to check data etc.
      */
-    public static void diff(final List<IBaseDataObject> ibdoList1, final List<IBaseDataObject> ibdoList2,
+    public static void diff(final List<IBaseDataObject> expected, final List<IBaseDataObject> actual,
             final String identifier, final List<String> differences, final DiffCheckConfiguration options) {
         Validate.notNull(identifier, ID_NOT_NULL_MSG);
         Validate.notNull(differences, DIFF_NOT_NULL_MSG);
 
-        final int ibdoList1Size = (ibdoList1 == null) ? 0 : ibdoList1.size();
-        final int ibdoList2Size = (ibdoList2 == null) ? 0 : ibdoList2.size();
+        final int expectedSize = (expected == null) ? 0 : expected.size();
+        final int actualSize = (actual == null) ? 0 : actual.size();
 
-        if (ibdoList1Size != ibdoList2Size) {
-            differences.add(String.format("%s%s: 1.s=%s 2.s=%s", identifier, ARE_NOT_EQUAL, ibdoList1Size, ibdoList2Size));
-        } else if (ibdoList1 != null && ibdoList2 != null) {
+        if (expectedSize != actualSize) {
+            differences.add(String.format("%s list size mismatch -> Expected: %d, Actual: %d", identifier, expectedSize, actualSize));
+        } else if (expected != null && actual != null) {
             final List<String> childDifferences = new ArrayList<>();
-            for (int i = 0; i < ibdoList1.size(); i++) {
+            for (int i = 0; i < expected.size(); i++) {
                 childDifferences.clear();
 
-                diff(ibdoList1.get(i), ibdoList2.get(i), childDifferences, options);
+                diff(expected.get(i), actual.get(i), childDifferences, options);
 
-                final String prefix = identifier + " : " + i + " : ";
+                final String prefix = String.format("%s[index %d] : ", identifier, i);
                 while (!childDifferences.isEmpty()) {
                     differences.add(prefix + childDifferences.remove(0)); // NOSONAR Used correctly
                 }
@@ -141,106 +144,107 @@ public class IBaseDataObjectDiffHelper {
      * This method compares two {@link SeekableByteChannelFactory} (SBCF) objects and adds any differences to the provided
      * string list.
      *
-     * @param sbcf1 the first SBCF to compare.
-     * @param sbcf2 the second SBCF to compare.
+     * @param expected the first SBCF to compare.
+     * @param actual the second SBCF to compare.
      * @param identifier an identifier to describe the context of this SBCF comparison.
      * @param differences the string list differences are to be added to.
      */
-    public static void diff(final SeekableByteChannelFactory sbcf1, final SeekableByteChannelFactory sbcf2,
+    public static void diff(final SeekableByteChannelFactory expected, final SeekableByteChannelFactory actual,
             final String identifier, final List<String> differences) {
         Validate.notNull(identifier, ID_NOT_NULL_MSG);
         Validate.notNull(differences, DIFF_NOT_NULL_MSG);
 
-        if (sbcf1 != null && sbcf2 != null) {
-            try (SeekableByteChannel sbc1 = sbcf1.create();
-                    SeekableByteChannel sbc2 = sbcf2.create();
+        if (expected != null && actual != null) {
+            try (SeekableByteChannel sbc1 = expected.create();
+                    SeekableByteChannel sbc2 = actual.create();
                     InputStream is1 = Channels.newInputStream(sbc1);
                     InputStream is2 = Channels.newInputStream(sbc2)) {
                 if (!IOUtils.contentEquals(is1, is2)) {
-                    differences.add(String.format("%s not equal. 1.cs=%s 2.cs=%s",
+                    differences.add(String.format("%s content mismatch -> Expected size: %d, Actual size: %d",
                             identifier, sbc1.size(), sbc2.size()));
                 }
             } catch (IOException e) {
-                differences.add(String.format("Failed to compare %s: %s", identifier, e.getMessage()));
+                differences.add(String.format("IO Error comparing %s: %s", identifier, e.getMessage()));
             }
-        } else if (sbcf1 == null && sbcf2 == null) {
+        } else if (expected == null && actual == null) {
             // Do nothing as they are considered equal.
         } else {
-            differences.add(String.format("%s not equal. sbcf1=%s sbcf2=%s", identifier, sbcf1, sbcf2));
+            differences.add(String.format("%s not equal. Expected SeekableByteChannelFactory=%s Actual SeekableByteChannelFactory=%s", identifier,
+                    expected, actual));
         }
     }
 
     /**
      * This method compares two Objects and adds any differences to the provided string list.
      *
-     * @param object1 the first Object to compare.
-     * @param object2 the second Object to compare.
+     * @param expected the first Object to compare.
+     * @param actual the second Object to compare.
      * @param identifier an identifier to describe the context of this Object comparison.
      * @param differences the string list differences are to be added to.
      */
-    public static void diff(final Object object1, final Object object2, final String identifier,
+    public static void diff(final Object expected, final Object actual, final String identifier,
             final List<String> differences) {
         Validate.notNull(identifier, ID_NOT_NULL_MSG);
         Validate.notNull(differences, DIFF_NOT_NULL_MSG);
 
-        if (!Objects.deepEquals(object1, object2)) {
-            differences.add(String.format(DIFF_OUTPUT_FORMAT, identifier, ARE_NOT_EQUAL, object1, object2));
+        if (!Objects.deepEquals(expected, actual)) {
+            differences.add(String.format("%s%s -> Expected: %s, Actual: %s", identifier, ARE_NOT_EQUAL, expected, actual));
         }
     }
 
     /**
      * This method compares two integers and adds any differences to the provided string list.
      *
-     * @param integer1 the first integer to compare.
-     * @param integer2 the second integer to compare.
+     * @param expected the first integer to compare.
+     * @param actual the second integer to compare.
      * @param identifier an identifier to describe the context of this integer comparison.
      * @param differences the string list differences are to be added to.
      */
-    public static void diff(final int integer1, final int integer2, final String identifier,
+    public static void diff(final int expected, final int actual, final String identifier,
             final List<String> differences) {
         Validate.notNull(identifier, ID_NOT_NULL_MSG);
         Validate.notNull(differences, DIFF_NOT_NULL_MSG);
 
-        if (integer1 != integer2) {
-            differences.add(identifier + ARE_NOT_EQUAL);
+        if (expected != actual) {
+            differences.add(String.format("%s value mismatch -> Expected: %d, Actual: %d", identifier, expected, actual));
         }
     }
 
     /**
      * This method compares two booleans and adds any differences to the provided string list.
      *
-     * @param boolean1 the first boolean to compare.
-     * @param boolean2 the second boolean to compare.
+     * @param expected the first boolean to compare.
+     * @param actual the second boolean to compare.
      * @param identifier an identifier to describe the context of this boolean comparison.
      * @param differences the string list differences are to be added to.
      */
-    public static void diff(final boolean boolean1, final boolean boolean2, final String identifier,
+    public static void diff(final boolean expected, final boolean actual, final String identifier,
             final List<String> differences) {
         Validate.notNull(identifier, ID_NOT_NULL_MSG);
         Validate.notNull(differences, DIFF_NOT_NULL_MSG);
 
-        if (boolean1 != boolean2) {
-            differences.add(identifier + ARE_NOT_EQUAL);
+        if (expected != actual) {
+            differences.add(String.format("%s boolean mismatch -> Expected: %b, Actual: %b", identifier, expected, actual));
         }
     }
 
     /**
      * This method compares two maps and adds any differences to the provided string list.
      *
-     * @param map1 the first map to compare.
-     * @param map2 the second map to compare.
+     * @param expected the first map to compare.
+     * @param actual the second map to compare.
      * @param identifier an identifier to describe the context of this map comparison.
      * @param differences the string list of differences to be added to.
      */
-    public static void diff(final Map<String, byte[]> map1, final Map<String, byte[]> map2, final String identifier,
+    public static void diff(final Map<String, byte[]> expected, final Map<String, byte[]> actual, final String identifier,
             final List<String> differences) {
-        Validate.notNull(map1, "Required: map1 not null!");
-        Validate.notNull(map2, "Required: map2 not null!");
+        Validate.notNull(expected, "Required: expected not null!");
+        Validate.notNull(actual, "Required: actual not null!");
         Validate.notNull(identifier, ID_NOT_NULL_MSG);
         Validate.notNull(differences, DIFF_NOT_NULL_MSG);
 
-        if (map1.size() != map2.size() ||
-                !map1.entrySet().stream().allMatch(e -> Arrays.equals(e.getValue(), map2.get(e.getKey())))) {
+        if (expected.size() != actual.size() ||
+                !expected.entrySet().stream().allMatch(e -> Arrays.equals(e.getValue(), actual.get(e.getKey())))) {
             differences.add(identifier + ARE_NOT_EQUAL);
         }
     }
@@ -248,54 +252,75 @@ public class IBaseDataObjectDiffHelper {
     /**
      * This method compares two maps and adds only the key/value pairs that differ to the provided string list.
      * 
-     * @param parameter1 the first map to compare.
-     * @param parameter2 the second map to compare.
+     * @param expected the first map to compare.
+     * @param actual the second map to compare.
      * @param identifier an identifier to describe the context of this map comparison.
      * @param differences the string list of differences to be added to.
      */
-    public static void keyValueMapDiff(final Map<String, Collection<String>> parameter1, final Map<String, Collection<String>> parameter2,
+    public static void keyValueMapDiff(final Map<String, Collection<String>> expected, final Map<String, Collection<String>> actual,
             final String identifier, final List<String> differences) {
-        final Set<Entry<String, Collection<String>>> p1Entries = new HashSet<>(parameter1.entrySet());
-        final Set<Entry<String, Collection<String>>> p2Entries = new HashSet<>(parameter2.entrySet());
-        final Map<String, Collection<String>> p1 = new HashMap<>(parameter1);
-        final Map<String, Collection<String>> p2 = new HashMap<>(parameter2);
+        Map<String, Collection<String>> missingInActual = new HashMap<>(expected);
+        Map<String, Collection<String>> extraInActual = new HashMap<>(actual);
+        Map<String, String> mismatchedValues = new HashMap<>();
 
-        for (Entry<String, Collection<String>> p1Entry : p1Entries) {
-            if (p2Entries.contains(p1Entry)) {
-                p1.remove(p1Entry.getKey());
-                p2.remove(p1Entry.getKey());
+        for (Entry<String, Collection<String>> entry : expected.entrySet()) {
+            String key = entry.getKey();
+            if (actual.containsKey(key)) {
+                Collection<String> expectedColl = entry.getValue();
+                Collection<String> actualColl = actual.get(key);
+
+                boolean areEqual = (expectedColl == null && actualColl == null) ||
+                        (expectedColl != null && actualColl != null &&
+                                new ArrayList<>(expectedColl).equals(new ArrayList<>(actualColl)));
+
+                if (!areEqual) {
+                    mismatchedValues.put(key, String.format("Expected: %s, Actual: %s", expectedColl, actualColl));
+                }
+
+                missingInActual.remove(key);
+                extraInActual.remove(key);
             }
         }
 
-        if (!p1.isEmpty() || !p2.isEmpty()) {
-            differences.add(String.format(DIFF_OUTPUT_FORMAT, identifier, ARE_NOT_EQUAL + "-Differing Keys/Values", p1, p2));
+        if (!missingInActual.isEmpty() || !extraInActual.isEmpty() || !mismatchedValues.isEmpty()) {
+            StringBuilder sb = new StringBuilder(identifier).append(" map differences:");
+            if (!missingInActual.isEmpty()) {
+                sb.append(" | Missing keys: ").append(missingInActual.keySet());
+            }
+            if (!extraInActual.isEmpty()) {
+                sb.append(" | Unexpected keys: ").append(extraInActual.keySet());
+            }
+            if (!mismatchedValues.isEmpty()) {
+                sb.append(" | Value mismatches: ").append(mismatchedValues);
+            }
+            differences.add(sb.toString());
         }
     }
 
     /**
      * This method compares two maps and adds only the keys that differ to the provided string list.
      * 
-     * @param parameter1 the first map to compare.
-     * @param parameter2 the second map to compare.
+     * @param expected the first map to compare.
+     * @param actual the second map to compare.
      * @param identifier an identifier to describe the context of this map comparison.
      * @param differences the string list of differences to be added to.
      */
-    public static void minimalMapDiff(final Map<String, Collection<String>> parameter1, final Map<String, Collection<String>> parameter2,
+    public static void minimalMapDiff(final Map<String, Collection<String>> expected, final Map<String, Collection<String>> actual,
             final String identifier, final List<String> differences) {
-        final Set<Entry<String, Collection<String>>> p1Entries = new HashSet<>(parameter1.entrySet());
-        final Set<Entry<String, Collection<String>>> p2Entries = new HashSet<>(parameter2.entrySet());
-        final Set<String> p1Keys = new TreeSet<>(parameter1.keySet());
-        final Set<String> p2Keys = new TreeSet<>(parameter2.keySet());
+        final Set<Entry<String, Collection<String>>> expectedEntries = new HashSet<>(expected.entrySet());
+        final Set<Entry<String, Collection<String>>> actualEntries = new HashSet<>(actual.entrySet());
+        final Set<String> expectedKeys = new TreeSet<>(expected.keySet());
+        final Set<String> actualKeys = new TreeSet<>(actual.keySet());
 
-        for (Entry<String, Collection<String>> p1Entry : p1Entries) {
-            if (p2Entries.contains(p1Entry)) {
-                p1Keys.remove(p1Entry.getKey());
-                p2Keys.remove(p1Entry.getKey());
+        for (Entry<String, Collection<String>> p1Entry : expectedEntries) {
+            if (actualEntries.contains(p1Entry)) {
+                expectedKeys.remove(p1Entry.getKey());
+                actualKeys.remove(p1Entry.getKey());
             }
         }
 
-        if (!p1Keys.isEmpty() || !p2Keys.isEmpty()) {
-            differences.add(String.format(DIFF_OUTPUT_FORMAT, identifier, ARE_NOT_EQUAL + "-Differing Keys", p1Keys, p2Keys));
+        if (!expectedKeys.isEmpty() || !actualKeys.isEmpty()) {
+            differences.add(String.format("%s key set mismatch -> Expected: %s, Actual: %s", identifier, expectedKeys, actualKeys));
         }
     }
 

--- a/src/test/java/emissary/core/IBaseDataObjectDiffHelper.java
+++ b/src/test/java/emissary/core/IBaseDataObjectDiffHelper.java
@@ -50,8 +50,8 @@ public class IBaseDataObjectDiffHelper {
      */
     public static void diff(final IBaseDataObject expected, final IBaseDataObject actual,
             final List<String> differences, final DiffCheckConfiguration options) {
-        Validate.notNull(expected, "Required: expected not null");
-        Validate.notNull(actual, "Required: actual not null");
+        Validate.notNull(expected, "Required: \"expected\" ibdo not null");
+        Validate.notNull(actual, "Required: \"actual\" ibdo not null");
         Validate.notNull(differences, DIFF_NOT_NULL_MSG);
 
         if (options.checkData()) {
@@ -238,8 +238,8 @@ public class IBaseDataObjectDiffHelper {
      */
     public static void diff(final Map<String, byte[]> expected, final Map<String, byte[]> actual, final String identifier,
             final List<String> differences) {
-        Validate.notNull(expected, "Required: expected not null!");
-        Validate.notNull(actual, "Required: actual not null!");
+        Validate.notNull(expected, "Required: \"expected\" map not null!");
+        Validate.notNull(actual, "Required: \"actual\" map not null!");
         Validate.notNull(identifier, ID_NOT_NULL_MSG);
         Validate.notNull(differences, DIFF_NOT_NULL_MSG);
 

--- a/src/test/java/emissary/core/IBaseDataObjectDiffHelperTest.java
+++ b/src/test/java/emissary/core/IBaseDataObjectDiffHelperTest.java
@@ -121,13 +121,15 @@ class IBaseDataObjectDiffHelperTest extends UnitTest {
     @Test
     void testDiffChannelFactory() {
         ibdo2.setData(new byte[1]);
-        verifyDiff(List.of("data not equal. sbcf1=null sbcf2=emissary.core.channels.ImmutableChannelFactory$ImmutableChannelFactoryImpl@xxxxxxxx"),
-                List.of("data not equal. sbcf1=emissary.core.channels.ImmutableChannelFactory$ImmutableChannelFactoryImpl@xxxxxxxx sbcf2=null"),
+        verifyDiff(List.of(
+                "data not equal. Expected SeekableByteChannelFactory=null Actual SeekableByteChannelFactory=emissary.core.channels.ImmutableChannelFactory$ImmutableChannelFactoryImpl@xxxxxxxx"),
+                List.of("data not equal. Expected SeekableByteChannelFactory=emissary.core.channels.ImmutableChannelFactory$ImmutableChannelFactoryImpl@xxxxxxxx Actual SeekableByteChannelFactory=null"),
                 CHECK_DATA);
 
         ibdo1.setChannelFactory(InMemoryChannelFactory.create("0123456789".getBytes(StandardCharsets.US_ASCII)));
         ibdo2.setChannelFactory(InMemoryChannelFactory.create("9876543210".getBytes(StandardCharsets.US_ASCII)));
-        verifyDiff(List.of("data not equal. 1.cs=10 2.cs=10"), List.of("data not equal. 1.cs=10 2.cs=10"), CHECK_DATA);
+        verifyDiff(List.of("data content mismatch -> Expected size: 10, Actual size: 10"),
+                List.of("data content mismatch -> Expected size: 10, Actual size: 10"), CHECK_DATA);
 
         ibdo2.setChannelFactory(new SeekableByteChannelFactory() {
             @Override
@@ -151,8 +153,8 @@ class IBaseDataObjectDiffHelperTest extends UnitTest {
             }
         });
 
-        verifyDiff(List.of("Failed to compare data: Test SBC that always throws IOException!"),
-                List.of("Failed to compare data: Test SBC that always throws IOException!"), CHECK_DATA);
+        verifyDiff(List.of("IO Error comparing data: Test SBC that always throws IOException!"),
+                List.of("IO Error comparing data: Test SBC that always throws IOException!"), CHECK_DATA);
     }
 
     @Test
@@ -160,7 +162,7 @@ class IBaseDataObjectDiffHelperTest extends UnitTest {
         ibdo1.pushCurrentForm("AAA");
         ibdo1.pushCurrentForm("BBB");
         ibdo1.pushCurrentForm("CCC");
-        verifyDiff(List.of("currentForm are not equal: CCC : "), List.of("currentForm are not equal:  : CCC"));
+        verifyDiff(List.of("currentForm are not equal -> Expected: CCC, Actual: "), List.of("currentForm are not equal -> Expected: , Actual: CCC"));
     }
 
     @Test
@@ -168,7 +170,8 @@ class IBaseDataObjectDiffHelperTest extends UnitTest {
         ibdo1.appendTransformHistory("AAA", false);
         ibdo1.appendTransformHistory("BBB", true);
         final DiffCheckConfiguration checkTransformHistory = DiffCheckConfiguration.configure().enableTransformHistory().build();
-        verifyDiff(List.of("transformHistory are not equal: [AAA] : []"), List.of("transformHistory are not equal: [] : [AAA]"),
+        verifyDiff(List.of("transformHistory are not equal -> Expected: [AAA], Actual: []"),
+                List.of("transformHistory are not equal -> Expected: [], Actual: [AAA]"),
                 checkTransformHistory);
     }
 
@@ -180,13 +183,13 @@ class IBaseDataObjectDiffHelperTest extends UnitTest {
         ibdo1.putParameter("STRING", "string");
         ibdo1.putParameter("LIST", Arrays.asList("first", "second", "third"));
 
-        verifyDiff(List.of("meta are not equal-Differing Keys: [LIST, STRING] : []"),
-                List.of("meta are not equal-Differing Keys: [] : [LIST, STRING]"));
-        verifyDiff(List.of("meta are not equal-Differing Keys/Values: {LIST=[first, second, third], STRING=[string]} : {}"),
-                List.of("meta are not equal-Differing Keys/Values: {} : {LIST=[first, second, third], STRING=[string]}"),
+        verifyDiff(List.of("meta key set mismatch -> Expected: [LIST, STRING], Actual: []"),
+                List.of("meta key set mismatch -> Expected: [], Actual: [LIST, STRING]"));
+        verifyDiff(List.of("meta map differences: | Missing keys: [LIST, STRING]"),
+                List.of("meta map differences: | Unexpected keys: [LIST, STRING]"),
                 checkKeyValueDiffParameter);
-        verifyDiff(List.of("meta are not equal: {LIST=[first, second, third], STRING=[string]} : {}"),
-                List.of("meta are not equal: {} : {LIST=[first, second, third], STRING=[string]}"), checkDetailedDiffParameter);
+        verifyDiff(List.of("meta are not equal -> Expected: {LIST=[first, second, third], STRING=[string]}, Actual: {}"),
+                List.of("meta are not equal -> Expected: {}, Actual: {LIST=[first, second, third], STRING=[string]}"), checkDetailedDiffParameter);
 
         ibdo1.clearParameters();
         ibdo2.clearParameters();
@@ -194,11 +197,12 @@ class IBaseDataObjectDiffHelperTest extends UnitTest {
         ibdo1.putParameter("Integer", Integer.valueOf(1));
         ibdo2.putParameter("STRING", "string");
 
-        verifyDiff(List.of("meta are not equal-Differing Keys: [Integer] : []"), List.of("meta are not equal-Differing Keys: [] : [Integer]"));
-        verifyDiff(List.of("meta are not equal-Differing Keys/Values: {Integer=[1]} : {}"),
-                List.of("meta are not equal-Differing Keys/Values: {} : {Integer=[1]}"), checkKeyValueDiffParameter);
-        verifyDiff(List.of("meta are not equal: {Integer=[1], STRING=[string]} : {STRING=[string]}"),
-                List.of("meta are not equal: {STRING=[string]} : {Integer=[1], STRING=[string]}"), checkDetailedDiffParameter);
+        verifyDiff(List.of("meta key set mismatch -> Expected: [Integer], Actual: []"),
+                List.of("meta key set mismatch -> Expected: [], Actual: [Integer]"));
+        verifyDiff(List.of("meta map differences: | Missing keys: [Integer]"),
+                List.of("meta map differences: | Unexpected keys: [Integer]"), checkKeyValueDiffParameter);
+        verifyDiff(List.of("meta are not equal -> Expected: {Integer=[1], STRING=[string]}, Actual: {STRING=[string]}"),
+                List.of("meta are not equal -> Expected: {STRING=[string]}, Actual: {Integer=[1], STRING=[string]}"), checkDetailedDiffParameter);
 
         ibdo1.clearParameters();
         ibdo2.clearParameters();
@@ -206,11 +210,12 @@ class IBaseDataObjectDiffHelperTest extends UnitTest {
         ibdo2.putParameter("STRING", "string");
         ibdo2.putParameter("Integer", Integer.valueOf(1));
 
-        verifyDiff(List.of("meta are not equal-Differing Keys: [] : [Integer]"), List.of("meta are not equal-Differing Keys: [Integer] : []"));
-        verifyDiff(List.of("meta are not equal-Differing Keys/Values: {} : {Integer=[1]}"),
-                List.of("meta are not equal-Differing Keys/Values: {Integer=[1]} : {}"), checkKeyValueDiffParameter);
-        verifyDiff(List.of("meta are not equal: {STRING=[string]} : {Integer=[1], STRING=[string]}"),
-                List.of("meta are not equal: {Integer=[1], STRING=[string]} : {STRING=[string]}"), checkDetailedDiffParameter);
+        verifyDiff(List.of("meta key set mismatch -> Expected: [], Actual: [Integer]"),
+                List.of("meta key set mismatch -> Expected: [Integer], Actual: []"));
+        verifyDiff(List.of("meta map differences: | Unexpected keys: [Integer]"),
+                List.of("meta map differences: | Missing keys: [Integer]"), checkKeyValueDiffParameter);
+        verifyDiff(List.of("meta are not equal -> Expected: {STRING=[string]}, Actual: {Integer=[1], STRING=[string]}"),
+                List.of("meta are not equal -> Expected: {Integer=[1], STRING=[string]}, Actual: {STRING=[string]}"), checkDetailedDiffParameter);
 
         ibdo1.clearParameters();
         ibdo2.clearParameters();
@@ -238,7 +243,7 @@ class IBaseDataObjectDiffHelperTest extends UnitTest {
     @Test
     void testDiffPriority() {
         ibdo1.setPriority(13);
-        verifyDiff(List.of("priority are not equal"), List.of("priority are not equal"));
+        verifyDiff(List.of("priority value mismatch -> Expected: 13, Actual: 10"), List.of("priority value mismatch -> Expected: 10, Actual: 13"));
     }
 
     @Test
@@ -246,8 +251,8 @@ class IBaseDataObjectDiffHelperTest extends UnitTest {
         ibdo1.setCreationTimestamp(Instant.ofEpochSecond(1234567890));
         ibdo2.setCreationTimestamp(Instant.ofEpochSecond(1234567891));
         final DiffCheckConfiguration options = DiffCheckConfiguration.configure().enableTimestamp().build();
-        verifyDiff(List.of("creationTimestamp are not equal: 2009-02-13T23:31:30Z : 2009-02-13T23:31:31Z"),
-                List.of("creationTimestamp are not equal: 2009-02-13T23:31:31Z : 2009-02-13T23:31:30Z"), options);
+        verifyDiff(List.of("creationTimestamp are not equal -> Expected: 2009-02-13T23:31:30Z, Actual: 2009-02-13T23:31:31Z"),
+                List.of("creationTimestamp are not equal -> Expected: 2009-02-13T23:31:31Z, Actual: 2009-02-13T23:31:30Z"), options);
     }
 
     @Test
@@ -255,107 +260,121 @@ class IBaseDataObjectDiffHelperTest extends UnitTest {
         ibdo1.addExtractedRecord(new BaseDataObject());
         ibdo1.addExtractedRecord(new BaseDataObject());
         ibdo1.addExtractedRecord(new BaseDataObject());
-        verifyDiff(List.of("extractedRecords are not equal: 1.s=3 2.s=0"), List.of("extractedRecords are not equal: 1.s=0 2.s=3"));
+        verifyDiff(List.of("extractedRecords list size mismatch -> Expected: 3, Actual: 0"),
+                List.of("extractedRecords list size mismatch -> Expected: 0, Actual: 3"));
     }
 
     @Test
     void testDiffFilename() {
         ibdo1.setFilename("filename");
-        verifyDiff(List.of("filename are not equal: filename : null", "shortName are not equal: filename : null"),
-                List.of("filename are not equal: null : filename", "shortName are not equal: null : filename"));
+        verifyDiff(
+                List.of("filename are not equal -> Expected: filename, Actual: null", "shortName are not equal -> Expected: filename, Actual: null"),
+                List.of("filename are not equal -> Expected: null, Actual: filename", "shortName are not equal -> Expected: null, Actual: filename"));
     }
 
     @Test
     void testDiffInternalId() {
         final DiffCheckConfiguration options = DiffCheckConfiguration.configure().enableInternalId().build();
-        verifyDiff(List.of("internalId are not equal: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx : xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
-                List.of("internalId are not equal: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx : xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
+        verifyDiff(
+                List.of("internalId are not equal -> Expected: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx, Actual: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
+                List.of("internalId are not equal -> Expected: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx, Actual: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
                 options);
     }
 
     @Test
     void testDiffProcessingError() {
         ibdo1.addProcessingError("processing_error");
-        verifyDiff(List.of("processingError are not equal: processing_error\n : null"),
-                List.of("processingError are not equal: null : processing_error\n"));
+        verifyDiff(List.of("processingError are not equal -> Expected: processing_error\n, Actual: null"),
+                List.of("processingError are not equal -> Expected: null, Actual: processing_error\n"));
     }
 
     @Test
     void testDiffFontEncoding() {
         ibdo1.setFontEncoding("font_encoding");
-        verifyDiff(List.of("fontEncoding are not equal: font_encoding : null"), List.of("fontEncoding are not equal: null : font_encoding"));
+        verifyDiff(List.of("fontEncoding are not equal -> Expected: font_encoding, Actual: null"),
+                List.of("fontEncoding are not equal -> Expected: null, Actual: font_encoding"));
     }
 
     @Test
     void testDiffNumChildren() {
         ibdo1.setNumChildren(13);
-        verifyDiff(List.of("numChildren are not equal"), List.of("numChildren are not equal"));
+        verifyDiff(List.of("numChildren value mismatch -> Expected: 13, Actual: 0"),
+                List.of("numChildren value mismatch -> Expected: 0, Actual: 13"));
     }
 
     @Test
     void testDiffNumSiblings() {
         ibdo1.setNumSiblings(13);
-        verifyDiff(List.of("numSiblings are not equal"), List.of("numSiblings are not equal"));
+        verifyDiff(List.of("numSiblings value mismatch -> Expected: 13, Actual: 0"),
+                List.of("numSiblings value mismatch -> Expected: 0, Actual: 13"));
     }
 
     @Test
     void testDiffBirthOrder() {
         ibdo1.setBirthOrder(13);
-        verifyDiff(List.of("birthOrder are not equal"), List.of("birthOrder are not equal"));
+        verifyDiff(List.of("birthOrder value mismatch -> Expected: 13, Actual: 0"), List.of("birthOrder value mismatch -> Expected: 0, Actual: 13"));
     }
 
     @Test
     void testDiffHeader() {
         ibdo1.setHeader("header".getBytes(StandardCharsets.US_ASCII));
-        verifyDiff(List.of("header are not equal: [B@xxxxxxxx : null"), List.of("header are not equal: null : [B@xxxxxxxx"));
+        verifyDiff(List.of("header are not equal -> Expected: [B@xxxxxxxx, Actual: null"),
+                List.of("header are not equal -> Expected: null, Actual: [B@xxxxxxxx"));
     }
 
     @Test
     void testDiffFooter() {
         ibdo1.setFooter("footer".getBytes(StandardCharsets.US_ASCII));
-        verifyDiff(List.of("footer are not equal: [B@xxxxxxxx : null"), List.of("footer are not equal: null : [B@xxxxxxxx"));
+        verifyDiff(List.of("footer are not equal -> Expected: [B@xxxxxxxx, Actual: null"),
+                List.of("footer are not equal -> Expected: null, Actual: [B@xxxxxxxx"));
     }
 
     @Test
     void testDiffHeaderEncoding() {
         ibdo1.setHeaderEncoding("header_encoding");
-        verifyDiff(List.of("headerEncoding are not equal: header_encoding : null"), List.of("headerEncoding are not equal: null : header_encoding"));
+        verifyDiff(List.of("headerEncoding are not equal -> Expected: header_encoding, Actual: null"),
+                List.of("headerEncoding are not equal -> Expected: null, Actual: header_encoding"));
     }
 
     @Test
     void testDiffClassification() {
         ibdo1.setClassification("classification");
-        verifyDiff(List.of("classification are not equal: classification : null"), List.of("classification are not equal: null : classification"));
+        verifyDiff(List.of("classification are not equal -> Expected: classification, Actual: null"),
+                List.of("classification are not equal -> Expected: null, Actual: classification"));
     }
 
     @Test
     void testDiffBroken() {
         ibdo1.setBroken("broken");
-        verifyDiff(List.of("broken are not equal"), List.of("broken are not equal"));
+        verifyDiff(List.of("broken boolean mismatch -> Expected: true, Actual: false"),
+                List.of("broken boolean mismatch -> Expected: false, Actual: true"));
     }
 
     @Test
     void testDiffOutputable() {
         ibdo1.setOutputable(false);
-        verifyDiff(List.of("outputable are not equal"), List.of("outputable are not equal"));
+        verifyDiff(List.of("outputable boolean mismatch -> Expected: false, Actual: true"),
+                List.of("outputable boolean mismatch -> Expected: true, Actual: false"));
     }
 
     @Test
     void testDiffId() {
         ibdo1.setId("id");
-        verifyDiff(List.of("id are not equal: id : null"), List.of("id are not equal: null : id"));
+        verifyDiff(List.of("id are not equal -> Expected: id, Actual: null"), List.of("id are not equal -> Expected: null, Actual: id"));
     }
 
     @Test
     void testDiffWorkBundleId() {
         ibdo1.setWorkBundleId("workbundle_id");
-        verifyDiff(List.of("workBundleId are not equal: workbundle_id : null"), List.of("workBundleId are not equal: null : workbundle_id"));
+        verifyDiff(List.of("workBundleId are not equal -> Expected: workbundle_id, Actual: null"),
+                List.of("workBundleId are not equal -> Expected: null, Actual: workbundle_id"));
     }
 
     @Test
     void testDiffTransactionId() {
         ibdo1.setTransactionId("transaction_id");
-        verifyDiff(List.of("transactionId are not equal: transaction_id : null"), List.of("transactionId are not equal: null : transaction_id"));
+        verifyDiff(List.of("transactionId are not equal -> Expected: transaction_id, Actual: null"),
+                List.of("transactionId are not equal -> Expected: null, Actual: transaction_id"));
     }
 
     @Test
@@ -365,11 +384,11 @@ class IBaseDataObjectDiffHelperTest extends UnitTest {
         verifyDiffList(Collections.emptyList(), new ArrayList<>(), null);
         verifyDiffList(Collections.emptyList(), null, new ArrayList<>());
         verifyDiffList(Collections.emptyList(), ibdoList1, ibdoList1);
-        verifyDiffList(List.of("test are not equal: 1.s=2 2.s=1"), ibdoList3, ibdoList2);
-        verifyDiffList(List.of("test are not equal: 1.s=1 2.s=2"), ibdoList1, ibdoList3);
+        verifyDiffList(List.of("test list size mismatch -> Expected: 2, Actual: 1"), ibdoList3, ibdoList2);
+        verifyDiffList(List.of("test list size mismatch -> Expected: 1, Actual: 2"), ibdoList1, ibdoList3);
 
         ibdo2.setClassification("classification");
-        verifyDiffList(List.of("test : 0 : classification are not equal: null : classification"), ibdoList1, ibdoList2);
+        verifyDiffList(List.of("test[index 0] : classification are not equal -> Expected: null, Actual: classification"), ibdoList1, ibdoList2);
     }
 
     @Test

--- a/src/test/java/emissary/place/ComparisonPlaceTest.java
+++ b/src/test/java/emissary/place/ComparisonPlaceTest.java
@@ -59,14 +59,14 @@ class ComparisonPlaceTest extends UnitTest {
 
     @Test
     void testProcessPlaceAChanges() throws Exception {
-        final String logMessage = "COMPARISONPLACETEST: PDiff: meta are not equal-Differing Keys: [] : [KEY]";
+        final String logMessage = "COMPARISONPLACETEST: Parent Diff: meta key set mismatch -> Expected: [], Actual: [KEY]";
 
         testComparisonPlace(PROCESS_PLACE_A_CHANGES, logMessage);
     }
 
     @Test
     void testProcessPlaceBChanges() throws Exception {
-        final String logMessage = "COMPARISONPLACETEST: PDiff: meta are not equal-Differing Keys: [KEY] : []";
+        final String logMessage = "COMPARISONPLACETEST: Parent Diff: meta key set mismatch -> Expected: [KEY], Actual: []";
 
         testComparisonPlace(PROCESS_PLACE_B_CHANGES, logMessage);
     }
@@ -78,16 +78,16 @@ class ComparisonPlaceTest extends UnitTest {
 
     @Test
     void testProcessHDPlaceAChanges() throws Exception {
-        final String logMessage = "COMPARISONPLACETEST: PDiff: meta are not equal-Differing Keys: [] : [KEY]\n" +
-                "COMPARISONPLACETEST: CDiff: COMPARISONPLACETEST : 0 : meta are not equal-Differing Keys: [] : [KEY]";
+        final String logMessage = "COMPARISONPLACETEST: Parent Diff: meta key set mismatch -> Expected: [], Actual: [KEY]\n" +
+                "COMPARISONPLACETEST: Child Diff: COMPARISONPLACETEST[index 0] : meta key set mismatch -> Expected: [], Actual: [KEY]";
 
         testComparisonPlace(PROCESSHD_PLACE_A_CHANGES, logMessage);
     }
 
     @Test
     void testProcessHDPlaceBChanges() throws Exception {
-        final String logMessage = "COMPARISONPLACETEST: PDiff: meta are not equal-Differing Keys: [KEY] : []\n" +
-                "COMPARISONPLACETEST: CDiff: COMPARISONPLACETEST : 0 : meta are not equal-Differing Keys: [KEY] : []";
+        final String logMessage = "COMPARISONPLACETEST: Parent Diff: meta key set mismatch -> Expected: [KEY], Actual: []\n" +
+                "COMPARISONPLACETEST: Child Diff: COMPARISONPLACETEST[index 0] : meta key set mismatch -> Expected: [KEY], Actual: []";
 
         testComparisonPlace(PROCESSHD_PLACE_B_CHANGES, logMessage);
     }

--- a/src/test/java/emissary/util/PlaceComparisonHelper.java
+++ b/src/test/java/emissary/util/PlaceComparisonHelper.java
@@ -55,76 +55,76 @@ public class PlaceComparisonHelper {
     /**
      * Used to compare a 'new' place with another, usually during development aimed at replacing the 'old' place.
      * 
-     * @param newResults an empty list to add results into from running the newPlace
-     * @param ibdoForNewPlace the actual BDO being passed in for comparison
-     * @param newPlace the new place we're comparing 'from'
-     * @param newMethodName to use when comparing (e.g. processHeavyDuty)
-     * @param oldPlace to compare against
-     * @param oldMethodName to use when comparing (e.g. processHeavyDuty)
+     * @param actualChildren an empty list to add results into from running the actual (new) place
+     * @param actualParentIbdo the actual BDO being passed in for comparison
+     * @param actualPlace the new place we're comparing 'from'
+     * @param actualMethodName to use when comparing (e.g. processHeavyDuty)
+     * @param expectedPlace to compare against (the old place)
+     * @param expectedMethodName to use when comparing (e.g. processHeavyDuty)
      * @param options {@link DiffCheckConfiguration} to configure diffing options
      * @return a readable string of differences to log or use elsewhere.
      * @throws ReflectiveOperationException if there is a problem.
      */
     @SuppressWarnings("unchecked")
-    public static String compareToPlace(final List<IBaseDataObject> newResults, final IBaseDataObject ibdoForNewPlace,
-            final ServiceProviderPlace newPlace, final String newMethodName, final ServiceProviderPlace oldPlace, final String oldMethodName,
-            final DiffCheckConfiguration options) throws ReflectiveOperationException {
+    public static String compareToPlace(final List<IBaseDataObject> actualChildren, final IBaseDataObject actualParentIbdo,
+            final ServiceProviderPlace actualPlace, final String actualMethodName, final ServiceProviderPlace expectedPlace,
+            final String expectedMethodName, final DiffCheckConfiguration options) throws ReflectiveOperationException {
 
-        Validate.notNull(newResults, "Required: newResults not null");
-        Validate.notNull(ibdoForNewPlace, "Required: ibdoForNewPlace not null");
-        Validate.notNull(newPlace, "Required: newPlace not null");
-        Validate.notNull(newMethodName, "newMethodName: newResults not null");
-        Validate.notNull(oldPlace, "Required: oldPlace not null");
-        Validate.notNull(oldMethodName, "Required: oldMethodName not null");
+        Validate.notNull(actualChildren, "Required: actualChildren not null");
+        Validate.notNull(actualParentIbdo, "Required: actualParentIbdo not null");
+        Validate.notNull(actualPlace, "Required: actualPlace not null");
+        Validate.notNull(actualMethodName, "actualMethodName: actualChildren not null");
+        Validate.notNull(expectedPlace, "Required: expectedPlace not null");
+        Validate.notNull(expectedMethodName, "Required: expectedMethodName not null");
         Validate.notNull(options, "Required: options not null");
 
         // Generate an identifier from the simple class names, e.g. Comparison[ColorPlace==ColourPlace]
-        final String oldPlaceName = oldPlace.getClass().getSimpleName();
-        final String newPlaceName = newPlace.getClass().getSimpleName();
+        final String oldPlaceName = expectedPlace.getClass().getSimpleName();
+        final String newPlaceName = actualPlace.getClass().getSimpleName();
         final String identifier = String.format("Comparison[%s==%s]", oldPlaceName, newPlaceName);
 
         // Get the method to run (e.g. processHeavyDuty)
-        final Method oldProcess = oldPlace.getClass().getDeclaredMethod(oldMethodName, IBaseDataObject.class);
-        final Method newProcess = newPlace.getClass().getDeclaredMethod(newMethodName, IBaseDataObject.class);
+        final Method oldProcess = expectedPlace.getClass().getDeclaredMethod(expectedMethodName, IBaseDataObject.class);
+        final Method newProcess = actualPlace.getClass().getDeclaredMethod(actualMethodName, IBaseDataObject.class);
 
         // Clone the data before running old or new methods
-        final IBaseDataObject ibdoForOldPlace = IBaseDataObjectHelper.clone(ibdoForNewPlace, true);
+        final IBaseDataObject ibdoForOldPlace = IBaseDataObjectHelper.clone(actualParentIbdo);
 
         // Actually run the places to get results
-        final List<IBaseDataObject> oldResults = (List<IBaseDataObject>) oldProcess.invoke(oldPlace, ibdoForOldPlace);
-        newResults.addAll((List<IBaseDataObject>) newProcess.invoke(newPlace, ibdoForNewPlace));
+        final List<IBaseDataObject> oldResults = (List<IBaseDataObject>) oldProcess.invoke(expectedPlace, ibdoForOldPlace);
+        actualChildren.addAll((List<IBaseDataObject>) newProcess.invoke(actualPlace, actualParentIbdo));
 
         // Now generate the 'diff' for the results
-        return checkDifferences(ibdoForOldPlace, ibdoForNewPlace, oldResults, newResults, identifier, options);
+        return checkDifferences(ibdoForOldPlace, actualParentIbdo, oldResults, actualChildren, identifier, options);
     }
 
     /**
      * Given two BDOs and results from two processing place runs, compare them and log any differences.
      * 
-     * @param ibdoForOldPlace likely a cloned object of the 'new' place object
-     * @param ibdoForNewPlace the 'main' BDO that was originally passed in from upstream
-     * @param oldResults from the 'old' run with the 'ibdoForOldPlace' object
-     * @param newResults from the 'new' run with the 'ibdoForNewPlace' object
+     * @param expectedIbdo likely a cloned object of the 'new' place object
+     * @param actualIbdo the 'main' BDO that was originally passed in from upstream
+     * @param expectedChildren from the 'old' run with the 'expectedIbdo' object
+     * @param actualChildren from the 'new' run with the 'actualIbdo' object
      * @param identifier to highlight any differences in logs
      * @param options {@link DiffCheckConfiguration} to configure diffing options
      * @return the string of differences, or null if there aren't any
      */
     @Nullable
-    public static String checkDifferences(final IBaseDataObject ibdoForOldPlace, final IBaseDataObject ibdoForNewPlace,
-            final List<IBaseDataObject> oldResults, final List<IBaseDataObject> newResults, final String identifier,
+    public static String checkDifferences(final IBaseDataObject expectedIbdo, final IBaseDataObject actualIbdo,
+            final List<IBaseDataObject> expectedChildren, final List<IBaseDataObject> actualChildren, final String identifier,
             final DiffCheckConfiguration options) {
-        Validate.notNull(ibdoForOldPlace, "Required: ibdoForOldPlace not null");
-        Validate.notNull(ibdoForNewPlace, "Required: ibdoForNewPlace not null");
-        Validate.notNull(oldResults, "Required: oldResults not null");
-        Validate.notNull(newResults, "Required: newResults not null");
+        Validate.notNull(expectedIbdo, "Required: expectedIbdo not null");
+        Validate.notNull(actualIbdo, "Required: actualIbdo not null");
+        Validate.notNull(expectedChildren, "Required: expectedChildren not null");
+        Validate.notNull(actualChildren, "Required: actualChildren not null");
         Validate.notNull(identifier, "Required: identifier not null");
         Validate.notNull(options, "Required: options not null");
 
         final List<String> parentDifferences = new ArrayList<>();
         final List<String> childDifferences = new ArrayList<>();
 
-        IBaseDataObjectDiffHelper.diff(ibdoForOldPlace, ibdoForNewPlace, parentDifferences, options);
-        IBaseDataObjectDiffHelper.diff(oldResults, newResults, identifier, childDifferences, options);
+        IBaseDataObjectDiffHelper.diff(expectedIbdo, actualIbdo, parentDifferences, options);
+        IBaseDataObjectDiffHelper.diff(expectedChildren, actualChildren, identifier, childDifferences, options);
 
         if (!parentDifferences.isEmpty() || !childDifferences.isEmpty()) {
             final StringBuilder sb = new StringBuilder();
@@ -132,7 +132,7 @@ public class PlaceComparisonHelper {
                 if (i != 0) {
                     sb.append(StringUtils.LF);
                 }
-                sb.append(identifier).append(": PDiff: ");
+                sb.append(identifier).append(": Parent Diff: ");
                 sb.append(parentDifferences.get(i));
             }
             if (!parentDifferences.isEmpty() && !childDifferences.isEmpty()) {
@@ -142,7 +142,7 @@ public class PlaceComparisonHelper {
                 if (i != 0) {
                     sb.append(StringUtils.LF);
                 }
-                sb.append(identifier).append(": CDiff: ");
+                sb.append(identifier).append(": Child Diff: ");
                 sb.append(childDifferences.get(i));
             }
 


### PR DESCRIPTION
Attempting to consolidate ExtractionTest checkAnswers and IBaseDataObjectDiffHelper functionality. This first step is cleaning up the IBaseDataObjectDiffHelper class and adding better logging statements when errors/differences occur. 

Instead of having something like `data not equal. 1.cs=10 2.cs=3` the message is updated to `data content mismatch -> Expected size: 10, Actual size: 3`