### PR TITLE
update netty dependency to version 4.2.13.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <dep.logback.version>1.5.32</dep.logback.version>
     <dep.logstash-logback-encoder.version>7.4</dep.logstash-logback-encoder.version>
     <dep.mockito.version>5.23.0</dep.mockito.version>
-    <dep.netty.version>4.2.12.Final</dep.netty.version>
+    <dep.netty.version>4.2.13.Final</dep.netty.version>
     <dep.opentest4j.version>1.3.0</dep.opentest4j.version>
     <dep.picocli.version>4.7.7</dep.picocli.version>
     <dep.proto-google-common-protos.version>2.67.0</dep.proto-google-common-protos.version>


### PR DESCRIPTION
https://github.com/NationalSecurityAgency/emissary/security/dependabot/60
https://github.com/NationalSecurityAgency/emissary/security/dependabot/63
https://github.com/NationalSecurityAgency/emissary/security/dependabot/64