### PR TITLE
httpclient5 :: migrate HTTP connection handling to HttpClient 5.6

### DIFF
--- a/src/main/java/emissary/client/EmissaryClient.java
+++ b/src/main/java/emissary/client/EmissaryClient.java
@@ -21,7 +21,7 @@ import org.apache.hc.client5.http.entity.EntityBuilder;
 import org.apache.hc.client5.http.impl.auth.BasicAuthCache;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.http.HttpStatus;
@@ -156,7 +156,7 @@ public class EmissaryClient {
         CONNECTION_MANAGER.setDefaultConnectionConfig(staticConnectionConfig);
 
         staticClient =
-                HttpClientBuilder.create().setConnectionManager(CONNECTION_MANAGER).setDefaultCredentialsProvider(CRED_PROV)
+                HttpClients.custom().setConnectionManager(CONNECTION_MANAGER).setDefaultCredentialsProvider(CRED_PROV)
                         .setDefaultRequestConfig(staticRequestConfig).build();
 
     }
@@ -197,7 +197,7 @@ public class EmissaryClient {
         }
 
         HttpClientContext localContext = HttpClientContext.create();
-        localContext.setAttribute(HttpClientContext.AUTH_CACHE, EmissaryClient.AUTH_CACHE);
+        localContext.setAuthCache(EmissaryClient.AUTH_CACHE);
 
         if (cookie != null) {
             localContext.getCookieStore().addCookie(cookie);
@@ -209,7 +209,7 @@ public class EmissaryClient {
             // to use a different context and request config per request
             method.setConfig(requestConfig);
             CloseableHttpClient thisClient = getHttpClient();
-            return thisClient.execute(method, localContext, new EmissaryResponseHandler());
+            return thisClient.execute(method, localContext, response -> new EmissaryResponseHandler().handleResponse(response));
         } catch (IOException e) {
             LOGGER.debug("Problem processing request:", e);
             BasicClassicHttpResponse response = new BasicClassicHttpResponse(HttpStatus.SC_INTERNAL_SERVER_ERROR, e.getMessage());

--- a/src/main/java/emissary/client/HTTPConnectionFactory.java
+++ b/src/main/java/emissary/client/HTTPConnectionFactory.java
@@ -15,6 +15,7 @@ import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
 import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.TrustAllStrategy;
 import org.apache.hc.core5.http.ConnectionReuseStrategy;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.log4j.Logger;
@@ -133,7 +134,7 @@ public class HTTPConnectionFactory {
 
         // custom ssl context populated with our trust and key materials
         return SSLContexts.custom()
-                .loadTrustMaterial(trustStore, (chain, authType) -> true)
+                .loadTrustMaterial(trustStore, TrustAllStrategy.INSTANCE)
                 .loadKeyMaterial(keyStore, kpChar)
                 .setProtocol(cfg.findStringEntry(CFG_SSLCONTEXT_TYPE, DFLT_CONTEXT_TYPE))
                 .setSecureRandom(new SecureRandom())

--- a/src/main/java/emissary/client/HTTPConnectionFactory.java
+++ b/src/main/java/emissary/client/HTTPConnectionFactory.java
@@ -8,22 +8,22 @@ import com.google.common.annotations.VisibleForTesting;
 import jakarta.annotation.Nullable;
 import org.apache.hc.client5.http.impl.DefaultClientConnectionReuseStrategy;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
-import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
-import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
+import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
-import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.apache.hc.core5.http.ConnectionReuseStrategy;
-import org.apache.hc.core5.http.config.Registry;
-import org.apache.hc.core5.http.config.RegistryBuilder;
+import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.SecureRandom;
+import java.util.Objects;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -61,15 +61,10 @@ public class HTTPConnectionFactory {
     static final String CFG_HTTP_MAXCONNS = "http.maxConnections";
     static final String CFG_HTTP_AGENT = "http.agent";
     static final String CFG_NOOP_VERIFIER = "https.useNoopHostnameVerifier";
-    static final String CFG_SSLCONTEXT_TYPE = "emissary.sslcontext.type";
     static final String DEFAULT_HTTP_AGENT = "emissary";
     static final int DFLT_MAXCONNS = 200;
     static final boolean DFLT_KEEPALIVE = true;
     static final String DFLT_STORE_TYPE = "JKS";
-    static final String DFLT_CONTEXT_TYPE = "TLS";
-    // meaningful constants
-    private static final String HTTP = "http";
-    private static final String HTTPS = "https";
 
     private static final Logger log = Logger.getLogger(HTTPConnectionFactory.class);
 
@@ -90,7 +85,7 @@ public class HTTPConnectionFactory {
 
     @VisibleForTesting
     HTTPConnectionFactory(@Nullable final Configurator config) {
-        Registry<ConnectionSocketFactory> registry = null;
+        PoolingHttpClientConnectionManager connectionManager = null;
         try {
             final Configurator cfg = config == null ? ConfigUtil.getConfigInfo(HTTPConnectionFactory.class) : config;
             // if someone doesn't want keep alives...
@@ -102,24 +97,21 @@ public class HTTPConnectionFactory {
             final SSLContext sslContext = build(cfg);
             // mainly for using in test environments where cert name may not match host name
             final HostnameVerifier v = cfg.findBooleanEntry(CFG_NOOP_VERIFIER, false) ? new NoopHostnameVerifier() : new DefaultHostnameVerifier();
-            registry =
-                    RegistryBuilder.<ConnectionSocketFactory>create().register(HTTP, PlainConnectionSocketFactory.getSocketFactory())
-                            .register(HTTPS, new SSLConnectionSocketFactory(sslContext, v)).build();
+
+            // This automatically handles "http" via plain sockets and "https" via the tlsStrategy
+            connectionManager = PoolingHttpClientConnectionManagerBuilder.create()
+                    .setTlsSocketStrategy(new DefaultClientTlsStrategy(sslContext, HostnameVerificationPolicy.CLIENT, v))
+                    .build();
         } catch (IOException | GeneralSecurityException ex) {
             log.error("Error configuring HTTPConnectionFactory. The connection factory will use HTTP Client default settings", ex);
         }
-        if (registry == null) {
-            this.connMan = new PoolingHttpClientConnectionManager();
-        } else {
-            this.connMan = new PoolingHttpClientConnectionManager(registry);
-        }
-
+        this.connMan = Objects.requireNonNullElseGet(connectionManager, PoolingHttpClientConnectionManager::new);
         this.connMan.setMaxTotal(this.maxConns);
     }
 
     /**
-     * This method will attempt to configure an SSLSocketFactory using configuration parameters from the
-     * HTTPConnectionFactory.cfg.
+     * This method will attempt to configure an SSLContext using configuration parameters from the HTTPConnectionFactory.cfg
+     * so we can properly build a PoolingHttpClientConnectionManager.
      *
      * @param cfg The configurator.
      * @return the SSLContext
@@ -145,10 +137,12 @@ public class HTTPConnectionFactory {
         final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         kmf.init(keyStore, kpChar);
 
-        final SSLContext sc = SSLContext.getInstance(cfg.findStringEntry(CFG_SSLCONTEXT_TYPE, DFLT_CONTEXT_TYPE));
-        sc.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
-
-        return sc;
+        // custom ssl context populated with our trust and key materials
+        return SSLContexts.custom()
+                .loadTrustMaterial(trustStore, (chain, authType) -> true)
+                .loadKeyMaterial(keyStore, kpChar)
+                .setSecureRandom(new SecureRandom())
+                .build();
     }
 
 
@@ -172,7 +166,7 @@ public class HTTPConnectionFactory {
      * @return a CloseableHttpClient
      */
     public CloseableHttpClient buildDefaultClient() {
-        return HttpClientBuilder.create().setConnectionManager(this.connMan).setConnectionManagerShared(true).setUserAgent(this.userAgent)
+        return HttpClients.custom().setConnectionManager(this.connMan).setConnectionManagerShared(true).setUserAgent(this.userAgent)
                 .setConnectionReuseStrategy(this.connReuseStrategy).build();
     }
 

--- a/src/main/java/emissary/client/HTTPConnectionFactory.java
+++ b/src/main/java/emissary/client/HTTPConnectionFactory.java
@@ -25,9 +25,7 @@ import java.security.KeyStore;
 import java.security.SecureRandom;
 import java.util.Objects;
 import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManagerFactory;
 
 /**
  * Emissary HTTP Connection Factory. This is a singleton class that allows for the central configuration of an Apache
@@ -61,10 +59,12 @@ public class HTTPConnectionFactory {
     static final String CFG_HTTP_MAXCONNS = "http.maxConnections";
     static final String CFG_HTTP_AGENT = "http.agent";
     static final String CFG_NOOP_VERIFIER = "https.useNoopHostnameVerifier";
+    static final String CFG_SSLCONTEXT_TYPE = "emissary.sslcontext.type";
     static final String DEFAULT_HTTP_AGENT = "emissary";
     static final int DFLT_MAXCONNS = 200;
     static final boolean DFLT_KEEPALIVE = true;
     static final String DFLT_STORE_TYPE = "JKS";
+    static final String DFLT_CONTEXT_TYPE = "TLS";
 
     private static final Logger log = Logger.getLogger(HTTPConnectionFactory.class);
 
@@ -105,7 +105,7 @@ public class HTTPConnectionFactory {
         } catch (IOException | GeneralSecurityException ex) {
             log.error("Error configuring HTTPConnectionFactory. The connection factory will use HTTP Client default settings", ex);
         }
-        this.connMan = Objects.requireNonNullElseGet(connectionManager, PoolingHttpClientConnectionManager::new);
+        this.connMan = Objects.requireNonNullElseGet(connectionManager, () -> PoolingHttpClientConnectionManagerBuilder.create().build());
         this.connMan.setMaxTotal(this.maxConns);
     }
 
@@ -131,16 +131,11 @@ public class HTTPConnectionFactory {
             return SSLContext.getDefault();
         }
 
-        final TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-        tmf.init(trustStore);
-
-        final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        kmf.init(keyStore, kpChar);
-
         // custom ssl context populated with our trust and key materials
         return SSLContexts.custom()
                 .loadTrustMaterial(trustStore, (chain, authType) -> true)
                 .loadKeyMaterial(keyStore, kpChar)
+                .setProtocol(cfg.findStringEntry(CFG_SSLCONTEXT_TYPE, DFLT_CONTEXT_TYPE))
                 .setSecureRandom(new SecureRandom())
                 .build();
     }


### PR DESCRIPTION
**Upgrading all deprecated HttpClient/HttpCore 5 pieces to use the new TLS/SSL protocol pieces.**
_Some important details for this PR:_  
  
`Registry<ConnectionSocketFactory>` has been mainly replaced by `setTlsSocketStrategy`.
`setTlsSocketStrategy` method in the builder automatically applies your custom TLS/SSL strategy to the https protocol handler. The `PoolingHttpClientConnectionManagerBuilder` creates a default registry that includes standard "http" and "https" support.
  
Was getting errors originally with these updates in `EmissaryServerIT.testSSLWorks()`. This test was failing at line 47 for `client.send(new HttpGet(endpoint)).getContent(MapResponseEntity.class)`, and the error was:
```
Bad request -> status: 500 message: class javax.net.ssl.SSLHandshakeException: No name matching localhost found
```
This required me to add the `HostnameVerificationPolicy` to the `setTlsSocketStrategy`. The different strategies for this are as follows:
- BUILTIN: Delegated to the JSSE provider, typically executed during the TLS handshake.
- CLIENT: Executed by the HTTP client after the TLS handshake.
- BOTH: verifies both above policies to ensure the server is authorized for that hostname.
  
In order for it to work by default, or without `HostnameVerificationPolicy.CLIENT` set, we'd have to add `localhost` to the keystore.jks. This is something we can do if we feel is necessary, but for now felt setting it to the CLIENT policy works fine.

`SSLContext.getInstance()` and `init()` is recommended to be replaced by `SSLContexts.custom().build()`.
This is also applicable to `HttpClientBuilder.create()` to `HttpClients.custom().build()`, so I implemented both of these where applicable (_though not necessarily complained about or marked as deprecated_).