### PR TITLE
Remove preflight gRPC channel validation calls

### DIFF
--- a/src/main/java/emissary/grpc/GrpcRoutingPlace.java
+++ b/src/main/java/emissary/grpc/GrpcRoutingPlace.java
@@ -14,7 +14,6 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.AbstractBlockingStub;
 import io.grpc.stub.AbstractFutureStub;
-import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.apache.commons.pool2.ObjectPool;
 
@@ -153,29 +152,8 @@ public abstract class GrpcRoutingPlace extends ServiceProviderPlace implements I
     }
 
     private ConnectionFactory newConnectionFactory(String id) {
-        return newConnectionFactory(hostnameTable.get(id), portNumberTable.get(id), Objects.requireNonNull(configG));
+        return new ConnectionFactory(hostnameTable.get(id), portNumberTable.get(id), Objects.requireNonNull(configG));
     }
-
-    private ConnectionFactory newConnectionFactory(String host, int port, @Nonnull Configurator cfg) {
-        return new ConnectionFactory(host, port, cfg, this::validateConnection, this::passivateConnection);
-    }
-
-    /**
-     * Validates whether a given {@link ManagedChannel} is capable of successfully communicating with its associated gRPC
-     * server.
-     *
-     * @param managedChannel the gRPC channel to validate
-     * @return {@code true} if the channel is healthy and the server responds successfully, else {@code false}
-     */
-    protected abstract boolean validateConnection(ManagedChannel managedChannel);
-
-    /**
-     * Called after a gRPC call to clean up the channel. No-op by default, since gRPC channels are designed to remain ready
-     * for reuse. Override this if using a stub that requires channels be reset or cleared between uses.
-     *
-     * @param managedChannel the gRPC channel to clean up
-     */
-    protected void passivateConnection(ManagedChannel managedChannel) { /* No-op */ }
 
     /**
      * Wrapper method for {@link GrpcInvoker#invoke(ObjectPool, Function, BiFunction, Message)} that executes a unary gRPC

--- a/src/main/java/emissary/grpc/pool/ConnectionFactory.java
+++ b/src/main/java/emissary/grpc/pool/ConnectionFactory.java
@@ -228,15 +228,15 @@ public class ConnectionFactory extends BasePooledObjectFactory<ManagedChannel> {
     }
 
     /**
-     * Required by {@link BasePooledObjectFactory}. Channels naturally check for server health upon RPC so a custom method
-     * is unnecessary.
+     * Required by {@link BasePooledObjectFactory}. Channels naturally check for server health upon RPC so a custom
+     * implementation is unnecessary.
      *
      * @param pooledObject the pooled gRPC channel
-     * @return true, because a channel may always be borrowed
+     * @return always throws an {@link UnsupportedOperationException}
      */
     @Override
     public boolean validateObject(PooledObject<ManagedChannel> pooledObject) {
-        return true;
+        throw new UnsupportedOperationException("This method should not be called");
     }
 
     /**

--- a/src/main/java/emissary/grpc/pool/ConnectionFactory.java
+++ b/src/main/java/emissary/grpc/pool/ConnectionFactory.java
@@ -18,8 +18,6 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
 
 /**
  * Abstract base class for managing a pool of gRPC {@link ManagedChannel} connections.
@@ -42,8 +40,6 @@ import java.util.function.Predicate;
  * <li>{@code GRPC_POOL_MAX_SIZE} - Maximum total connections allowed, default={@code 8}</li>
  * <li>{@code GRPC_POOL_MIN_IDLE_CONNECTIONS} - Minimum idle connections in the pool, default={@code 0}</li>
  * <li>{@code GRPC_POOL_RETRIEVAL_ORDER} - Whether pool behaves LIFO or FIFO, default={@code "LIFO"}</li>
- * <li>{@code GRPC_POOL_TEST_BEFORE_BORROW} - If {@code true}, validates pooled connections before use with
- * {@link #validateObject(PooledObject)}, default={@code true}</li>
  * </ul>
  * <a href="https://docs.microsoft.com/en-us/aspnet/core/grpc/performance?view=aspnetcore-5.0">Source</a> for default
  * gRPC configurations.
@@ -62,13 +58,10 @@ public class ConnectionFactory extends BasePooledObjectFactory<ManagedChannel> {
     public static final String GRPC_POOL_MAX_SIZE = "GRPC_POOL_MAX_SIZE";
     public static final String GRPC_POOL_MIN_IDLE_CONNECTIONS = "GRPC_POOL_MIN_IDLE_CONNECTIONS";
     public static final String GRPC_POOL_RETRIEVAL_ORDER = "GRPC_POOL_RETRIEVAL_ORDER";
-    public static final String GRPC_POOL_TEST_BEFORE_BORROW = "GRPC_POOL_TEST_BEFORE_BORROW";
 
     protected static final Logger logger = LoggerFactory.getLogger(ConnectionFactory.class);
 
     private final GenericObjectPoolConfig<ManagedChannel> poolConfig = new GenericObjectPoolConfig<>();
-    private final Predicate<ManagedChannel> channelValidator;
-    private final Consumer<ManagedChannel> channelPassivator;
 
     private final String host;
     private final int port;
@@ -90,17 +83,11 @@ public class ConnectionFactory extends BasePooledObjectFactory<ManagedChannel> {
      * @param host gRPC service hostname or DNS target
      * @param port gRPC service port
      * @param configG configuration provider for channel and pool parameters
-     * @param channelValidator method to determine if channel can successfully communicate with its associated server
-     * @param channelPassivator method that cleans up a channel after a gRPC call
      */
-    public ConnectionFactory(String host, int port, Configurator configG,
-            Predicate<ManagedChannel> channelValidator, Consumer<ManagedChannel> channelPassivator) {
+    public ConnectionFactory(String host, int port, Configurator configG) {
         this.host = host;
         this.port = port;
         this.target = host + ":" + port; // target may be a host or dns service
-
-        this.channelValidator = channelValidator;
-        this.channelPassivator = channelPassivator;
 
         // How often (in milliseconds) to send pings when the connection is idle
         this.keepAliveMillis = configG.findLongEntry(GRPC_KEEP_ALIVE_MILLIS, 60000L);
@@ -144,9 +131,6 @@ public class ConnectionFactory extends BasePooledObjectFactory<ManagedChannel> {
         PoolRetrievalOrdering retrievalOrdering = configG.findObjectEntry(
                 GRPC_POOL_RETRIEVAL_ORDER, PoolRetrievalOrdering::valueOf, PoolRetrievalOrdering.LIFO);
         this.poolConfig.setLifo(retrievalOrdering.equals(PoolRetrievalOrdering.LIFO));
-
-        // Whether to validate channels when borrowing from the pool
-        this.poolConfig.setTestOnBorrow(configG.findBooleanEntry(GRPC_POOL_TEST_BEFORE_BORROW, true));
     }
 
     /**
@@ -244,28 +228,15 @@ public class ConnectionFactory extends BasePooledObjectFactory<ManagedChannel> {
     }
 
     /**
-     * Called when a {@link ManagedChannel} is returned to the pool. Since gRPC channels are designed to remain ready for
-     * reuse without needing to be reset or cleared, a no-op passivator is fine for most use cases. Custom behavior may
-     * become necessary if using a stub or channel wrapper that requires cleanup between uses.
+     * Required by {@link BasePooledObjectFactory}. Channels naturally check for server health upon RPC so a custom method
+     * is unnecessary.
      *
-     * @param pooledObject the pooled channel being passivated
-     */
-    @Override
-    public void passivateObject(PooledObject<ManagedChannel> pooledObject) {
-        channelPassivator.accept(pooledObject.getObject());
-    }
-
-    /**
-     * Validates whether the {@link ManagedChannel} is healthy and can be reused. Called by the pool before returning a
-     * channel to a caller. Implementations should check connection state or channel health as needed. For example, you
-     * might verify that the channel is not shutdown or terminated.
-     *
-     * @param pooledObject the pooled gRPC channel to validate
-     * @return true if the channel is valid and safe to reuse, false otherwise
+     * @param pooledObject the pooled gRPC channel
+     * @return true, because a channel may always be borrowed
      */
     @Override
     public boolean validateObject(PooledObject<ManagedChannel> pooledObject) {
-        return channelValidator.test(pooledObject.getObject());
+        return true;
     }
 
     /**

--- a/src/main/java/emissary/grpc/sample/GrpcSamplePlace.java
+++ b/src/main/java/emissary/grpc/sample/GrpcSamplePlace.java
@@ -11,8 +11,6 @@ import emissary.grpc.sample.v1.SampleServiceGrpc.SampleServiceBlockingStub;
 import emissary.grpc.sample.v1.SampleServiceGrpc.SampleServiceFutureStub;
 
 import com.google.protobuf.ByteString;
-import com.google.protobuf.Empty;
-import io.grpc.ManagedChannel;
 import jakarta.annotation.Nullable;
 
 import java.io.IOException;
@@ -61,17 +59,5 @@ public class GrpcSamplePlace extends GrpcRoutingPlace {
                         k, SampleServiceGrpc::newFutureStub, SampleServiceFutureStub::callSampleService, generateRequest(o))));
         Map<String, SampleResponse> responseMap = CompletableFutureFinalizers.awaitAllAndGet(futureMap, HashMap::new, exceptionally);
         responseMap.forEach((k, v) -> o.addAlternateView(k, v.getResult().toByteArray()));
-    }
-
-    /**
-     * Calls a health check to the external service before borrowing the channel from the pool.
-     *
-     * @param managedChannel the gRPC channel to validate
-     * @return {@code true} if channel is healthy, otherwise {@code false}
-     */
-    @Override
-    protected boolean validateConnection(ManagedChannel managedChannel) {
-        SampleServiceBlockingStub stub = SampleServiceGrpc.newBlockingStub(managedChannel);
-        return stub.callSampleHealthCheck(Empty.getDefaultInstance()).getOk();
     }
 }

--- a/src/main/proto/emissary/grpc/sample/v1/sample_service.proto
+++ b/src/main/proto/emissary/grpc/sample/v1/sample_service.proto
@@ -15,11 +15,6 @@ message SampleResponse {
   bytes result = 1;
 }
 
-message SampleHealthStatus {
-  bool ok = 1;
-}
-
 service SampleService {
   rpc CallSampleService(SampleRequest) returns (SampleResponse);
-  rpc CallSampleHealthCheck(google.protobuf.Empty) returns (SampleHealthStatus);
 }

--- a/src/test/java/emissary/grpc/pool/ConnectionFactoryTest.java
+++ b/src/test/java/emissary/grpc/pool/ConnectionFactoryTest.java
@@ -20,15 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
 
 class ConnectionFactoryTest extends UnitTest {
     private static ConnectionFactory buildConnectionFactory(Configurator configG) {
-        return new ConnectionFactory("localhost", 2222, configG, channel -> true, channel -> {
-        });
+        return new ConnectionFactory("localhost", 2222, configG);
     }
 
     private static Configurator getDefaultConfigs() {
@@ -99,15 +94,8 @@ class ConnectionFactoryTest extends UnitTest {
         @BeforeEach
         void setUp() {
             Configurator configT = getDefaultConfigs();
-            factory = spy(buildConnectionFactory(configT));
+            factory = buildConnectionFactory(configT);
             pool = factory.newConnectionPool();
-        }
-
-        @Test
-        void testAcquireChannelFails() {
-            doReturn(false).when(factory).validateObject(any());
-            PoolException e = assertThrows(PoolException.class, () -> ConnectionFactory.acquireChannel(pool));
-            assertEquals("Unable to borrow channel from pool: Unable to validate object", e.getMessage());
         }
 
         @Test
@@ -133,23 +121,6 @@ class ConnectionFactoryTest extends UnitTest {
             ManagedChannel c2 = ConnectionFactory.acquireChannel(pool);
             assertSame(c1, c2);
             ConnectionFactory.returnChannel(c2, pool);
-        }
-
-        @Test
-        void testPassivateChannel() {
-            ManagedChannel c1 = ConnectionFactory.acquireChannel(pool);
-            ConnectionFactory.returnChannel(c1, pool);
-            assertFalse(c1.isShutdown());
-
-            doAnswer(invocation -> {
-                PooledObject<ManagedChannel> pooledObject = invocation.getArgument(0);
-                pooledObject.getObject().shutdownNow();
-                return null;
-            }).when(factory).passivateObject(any());
-
-            ManagedChannel c2 = ConnectionFactory.acquireChannel(pool);
-            ConnectionFactory.returnChannel(c2, pool);
-            assertTrue(c2.isShutdown());
         }
 
         @Test

--- a/src/test/java/emissary/grpc/sample/GrpcSamplePlaceTest.java
+++ b/src/test/java/emissary/grpc/sample/GrpcSamplePlaceTest.java
@@ -6,7 +6,6 @@ import emissary.core.BaseDataObject;
 import emissary.core.IBaseDataObject;
 import emissary.core.constants.Configurations;
 import emissary.grpc.GrpcRoutingPlace;
-import emissary.grpc.pool.PoolException;
 import emissary.grpc.retry.RetryHandler;
 import emissary.grpc.sample.v1.SampleRequest;
 import emissary.grpc.sample.v1.SampleResponse;
@@ -358,19 +357,6 @@ class GrpcSamplePlaceTest extends UnitTest {
     @Nested
     class SequentialProcessingTests {
         @Test
-        void testConnectionIsNotValidated() {
-            try (GrpcSampleServer serverOne = GrpcSampleServer.of(false);
-                    GrpcSampleServer serverTwo = GrpcSampleServer.defaultBehavior()) {
-
-                startPlaceWithEndpoints(serverOne, serverTwo);
-
-                Runnable invocation = () -> Objects.requireNonNull(place).processEndpointsSequentially(o);
-                PoolException exception = assertThrows(PoolException.class, invocation::run);
-                assertEquals("Unable to borrow channel from pool: Unable to validate object", exception.getMessage());
-            }
-        }
-
-        @Test
         @SuppressWarnings("Interruption")
         void testThreadInterruptCancelsSequentialGrpc() throws InterruptedException {
             CountDownLatch startedLatch = new CountDownLatch(1);
@@ -476,19 +462,6 @@ class GrpcSamplePlaceTest extends UnitTest {
 
     @Nested
     class ParallelProcessingTests {
-        @Test
-        void testConnectionIsNotValidated() {
-            try (GrpcSampleServer serverOne = GrpcSampleServer.of(false);
-                    GrpcSampleServer serverTwo = GrpcSampleServer.defaultBehavior()) {
-
-                startPlaceWithEndpoints(serverOne, serverTwo);
-
-                Runnable invocation = () -> Objects.requireNonNull(place).processEndpointsInParallel(o, null);
-                PoolException exception = assertThrows(PoolException.class, invocation::run);
-                assertEquals("Unable to borrow channel from pool: Unable to validate object", exception.getMessage());
-            }
-        }
-
         @Test
         @SuppressWarnings("Interruption")
         void testThreadInterruptCancelsParallelGrpc() throws InterruptedException {

--- a/src/test/java/emissary/grpc/sample/GrpcSampleServer.java
+++ b/src/test/java/emissary/grpc/sample/GrpcSampleServer.java
@@ -1,13 +1,11 @@
 package emissary.grpc.sample;
 
-import emissary.grpc.sample.v1.SampleHealthStatus;
 import emissary.grpc.sample.v1.SampleRequest;
 import emissary.grpc.sample.v1.SampleResponse;
 import emissary.grpc.sample.v1.SampleServiceGrpc.SampleServiceImplBase;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.Empty;
 import io.grpc.BindableService;
 import io.grpc.Context;
 import io.grpc.Server;
@@ -34,15 +32,8 @@ public class GrpcSampleServer implements AutoCloseable {
         }
     }
 
-    private static SampleServiceImplBase newService(Function<SampleRequest, ByteString> behavior, boolean healthOk) {
+    private static SampleServiceImplBase newService(Function<SampleRequest, ByteString> behavior) {
         return new SampleServiceImplBase() {
-            @Override
-            public void callSampleHealthCheck(Empty request, StreamObserver<SampleHealthStatus> responseObserver) {
-                SampleHealthStatus status = SampleHealthStatus.newBuilder().setOk(healthOk).build();
-                responseObserver.onNext(status);
-                responseObserver.onCompleted();
-            }
-
             @Override
             public void callSampleService(SampleRequest request, StreamObserver<SampleResponse> responseObserver) {
                 try {
@@ -65,19 +56,11 @@ public class GrpcSampleServer implements AutoCloseable {
     }
 
     public static GrpcSampleServer defaultBehavior() {
-        return GrpcSampleServer.of(true);
-    }
-
-    public static GrpcSampleServer of(boolean healthOk) {
-        return GrpcSampleServer.of(GrpcSampleServer::success, healthOk);
+        return GrpcSampleServer.of(GrpcSampleServer::success);
     }
 
     public static GrpcSampleServer of(Function<SampleRequest, ByteString> behavior) {
-        return GrpcSampleServer.of(behavior, true);
-    }
-
-    public static GrpcSampleServer of(Function<SampleRequest, ByteString> behavior, boolean healthOk) {
-        return new GrpcSampleServer(newService(behavior, healthOk));
+        return new GrpcSampleServer(newService(behavior));
     }
 
     public static GrpcSampleServer alwaysThrow(RuntimeException ex) {


### PR DESCRIPTION
gRPC `ManagedChannel` objects already handle transportation layer health-checks, making most of our manual channel validation redundant. 

While our manual checks are also looking at application readiness, we really don't have any unique process for handling that when it fails. It just triggers a retry, same as when the actual RPC fails. 

In addition, it comes with the following downsides:

- As a separate RPC, it increases latency and doubles request volume
- Due to DNS/load balancing behavior, there's no guarantee that the next RPC would even target the same backend instance 
