### PR TITLE
remove import of google/protobuf/empty.proto

### DIFF
--- a/src/main/proto/emissary/grpc/sample/v1/sample_service.proto
+++ b/src/main/proto/emissary/grpc/sample/v1/sample_service.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package emissary.grpc.sample.v1;
 
-import "google/protobuf/empty.proto";
 option java_multiple_files = true;
 option java_package = "emissary.grpc.sample.v1";
 


### PR DESCRIPTION
```
[WARNING] PROTOC: /opt/emissary/src/main/proto/emissary/grpc/sample/v1/sample_service.proto:5:1: warning: Import google/protobuf/empty.proto is unused.
```