### PR TITLE
refactor: remove deprecated setFileTypeIfEmpty method

### DIFF
--- a/src/main/java/emissary/core/BaseDataObject.java
+++ b/src/main/java/emissary/core/BaseDataObject.java
@@ -1136,18 +1136,12 @@ public class BaseDataObject implements Serializable, Cloneable, Remote, IBaseDat
     }
 
     @Override
-    @Deprecated
-    public boolean setFileTypeIfEmpty(final String v, final String[] empties) {
-        if (isFileTypeEmpty(empties)) {
+    public boolean setFileTypeIfEmpty(final String v) {
+        if (isFileTypeEmpty(this.emptyFileTypes)) {
             setFileType(v);
             return true;
         }
         return false;
-    }
-
-    @Override
-    public boolean setFileTypeIfEmpty(final String v) {
-        return setFileTypeIfEmpty(v, this.emptyFileTypes);
     }
 
     @Override

--- a/src/main/java/emissary/core/IBaseDataObject.java
+++ b/src/main/java/emissary/core/IBaseDataObject.java
@@ -487,18 +487,6 @@ public interface IBaseDataObject {
     void setFileType(String arg1);
 
     /**
-     * Set FILETYPE parameter iff empty.
-     * 
-     * @param arg1 the value of the filetype to set
-     * @param arg2 the list of things caller considers equal to being empty
-     * @return true if it was empty and set
-     * @deprecated Use {@link #setFileType(String)} instead.
-     */
-    @Deprecated
-    @SuppressWarnings("AvoidObjectArrays")
-    boolean setFileTypeIfEmpty(String arg1, String[] arg2);
-
-    /**
      * Set FILETYPE parameter iff empty using the built-in definition of empty
      * 
      * @param arg1 the value of the filetype to set

--- a/src/test/java/emissary/core/BaseDataObjectTest.java
+++ b/src/test/java/emissary/core/BaseDataObjectTest.java
@@ -567,10 +567,6 @@ class BaseDataObjectTest extends UnitTest {
     void testFileTypeIsEmpty() {
         this.b.setFileType(Form.UNKNOWN);
         assertTrue(this.b.isFileTypeEmpty(), "Unknown form must count as empty");
-        this.b.setFileType("BAR");
-        final String[] fakeEmpties = {Form.UNKNOWN, "FOO", "BAR"};
-        assertTrue(this.b.setFileTypeIfEmpty("BAZ", fakeEmpties), "Unknown form must count as empty when passing in list");
-        assertEquals("BAZ", this.b.getFileType(), "Failed to use supplied list of empty forms " + Arrays.asList(fakeEmpties));
 
         this.b.setFileType("TEST-UNWRAPPED");
         assertTrue(this.b.setFileTypeIfEmpty("ZAZ"), "Unknown form must count as empty when passing in list");


### PR DESCRIPTION
Changes:
- Removed deprecated setFileTypeIfEmpty overload and move its code into the remaining implementation of the method
- Remove tests for removed function
To test:
- Tests pass