### PR TITLE
update GitHub Actions workflows to address lint findings

### DIFF
--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set env
         run: |
           echo "CHERRYPICK_COMMITS=$([ -n "$IN_COMMITS" ] && echo "$IN_COMMITS" || echo "$IN_CHERRYPICK_COMMITS")" >> "$GITHUB_ENV"
-          echo "BRANCH=$([ -n "$IN_BRANCH" ] && echo "$IN_BRANCH" || echo "${{ github.ref_name }}")" >> "$GITHUB_ENV"
+          echo "BRANCH=$([ -n "$IN_BRANCH" ] && echo "$IN_BRANCH" || echo "${GITHUB_REF_NAME}")" >> "$GITHUB_ENV"
         env:
           IN_CHERRYPICK_COMMITS: ${{ github.event.inputs.cherrypick_commits }}
           IN_COMMITS: ${{ inputs.commits }}
@@ -50,19 +50,25 @@ jobs:
       - name: Check for valid commit(s)
         if: ${{ env.CHERRYPICK_COMMITS != '' }}
         run: |
-          if [[ ! "${{ env.CHERRYPICK_COMMITS }}" =~ ^([0-9a-f]{7,40})(\s+[0-9a-f]{7,40})*$ ]]; then
+          if [[ ! "${CHERRYPICK_COMMITS}" =~ ^([0-9a-f]{7,40})(\s+[0-9a-f]{7,40})*$ ]]; then
             echo "Invalid commits to cherry-pick: must contain 7- to 40-character hexadecimal SHA separated by a single space."
             exit 1
           fi
 
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Cherry pick to patch branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          gh auth setup-git
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git fetch --all
-          git switch ${{ env.BRANCH }}
-          git cherry-pick ${{ env.CHERRYPICK_COMMITS }}
-          git push -u origin ${{ env.BRANCH }}
+          git switch "${BRANCH}"
+          # shellcheck disable=SC2086 # CHERRYPICK_COMMITS may contain space-separated SHAs
+          git cherry-pick ${CHERRYPICK_COMMITS}
+          git push -u origin "${BRANCH}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/create-patch-branch.yml
+++ b/.github/workflows/create-patch-branch.yml
@@ -13,6 +13,9 @@ env:
   JAVA_VERSION: "11"
   JAVA_DISTRIBUTION: "corretto"
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -33,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5
@@ -43,8 +48,8 @@ jobs:
 
       - name: Configure Git user
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
       - name: Get the version
         run: |
@@ -52,7 +57,7 @@ jobs:
           echo "PATCH_BRANCH=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | grep -v '\[.*' | awk -F. '{print "patch/"$1"."$2".x"}')" >> "$GITHUB_ENV"
 
       - id: set_output
-        run: echo "patch_branch=${{ env.PATCH_BRANCH }}" >> "$GITHUB_OUTPUT"
+        run: echo "patch_branch=${PATCH_BRANCH}" >> "$GITHUB_OUTPUT"
 
       - name: Fail for milestone versions
         if: ${{ contains(env.PROJECT_VERSION, '-M') }}
@@ -61,15 +66,18 @@ jobs:
           exit 1
 
       - name: Branch that patch
-        run: git switch -c ${{ env.PATCH_BRANCH }}
+        run: git switch -c "${PATCH_BRANCH}"
 
       - name: Set the patch version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          gh auth setup-git
           mvn -B -V -e -ntp versions:set -DnextSnapshot=true
           mvn -B -V -e -ntp versions:commit
           git add .
-          git commit -m "[github-actions](${{ github.actor }}) prepare for next patch iteration"
-          git push -u origin ${{ env.PATCH_BRANCH }}
+          git commit -m "[github-actions](${GITHUB_ACTOR}) prepare for next patch iteration"
+          git push -u origin "${PATCH_BRANCH}"
 
   cherry_pick:
     if: ${{ github.event.inputs.cherrypick_commits != '' }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,5 +17,7 @@ jobs:
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v5

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -7,6 +7,9 @@ on: # yamllint disable-line rule:truthy
   pull_request:
     branches: [main, release/**, patch/**]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: RHEL8 standard build on Java 11 with compiler target 11
@@ -14,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -39,6 +44,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -65,6 +72,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -90,12 +99,13 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Configure Java
         uses: actions/setup-java@v5
         with:
           java-version: '21'
-          cache: 'maven'
           distribution: 'corretto'
           overwrite-settings: false
 
@@ -109,12 +119,13 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Configure Java & Maven
         uses: actions/setup-java@v5
         with:
           java-version: 11
-          cache: "maven"
           distribution: "corretto"
 
       - name: Build with Maven

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -25,6 +25,9 @@ env:
   JAVA_DISTRIBUTION: "corretto"
   MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Djava.awt.headless=true"
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -73,6 +76,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Get the version
         run: echo "RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | grep -v '\[.*' | awk -v release_suffix="$IN_RELEASE_SUFFIX" -F- '{print ""$1""release_suffix}')" >> "$GITHUB_ENV"
@@ -92,10 +97,14 @@ jobs:
         shell: bash
     steps:
       - name: Add RELEASE_VERSION to environment variable
-        run: echo "RELEASE_VERSION=${{ needs.get_version.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
+        run: echo "RELEASE_VERSION=${NEEDS_GET_VERSION_OUTPUTS_RELEASE_VERSION}" >> "$GITHUB_ENV"
+        env:
+          NEEDS_GET_VERSION_OUTPUTS_RELEASE_VERSION: ${{ needs.get_version.outputs.RELEASE_VERSION }}
 
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5
@@ -106,42 +115,40 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
 
       - name: Configure Git user
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          gh auth setup-git
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
       - name: Branch that release
-        run: git switch -c release/${{ env.RELEASE_VERSION }}
+        run: git switch -c "release/${RELEASE_VERSION}"
 
       - name: Dry run a release with maven
         run: |
-          mvn -B -V -e -ntp release:prepare -DdryRun -DreleaseVersion=${{ env.RELEASE_VERSION }}
+          mvn -B -V -e -ntp release:prepare -DdryRun "-DreleaseVersion=${RELEASE_VERSION}"
           mvn -B -V -e -ntp release:clean
 
       - name: Release that version
         run: |
-          mvn -V -B -e versions:set -DnewVersion=${{ env.RELEASE_VERSION }} -DprocessAllModules -DgenerateBackupPoms=false
-          mvn -V -B -e versions:set-scm-tag -DnewTag=${{ env.RELEASE_VERSION }} -DgenerateBackupPoms=false
+          mvn -V -B -e versions:set "-DnewVersion=${RELEASE_VERSION}" -DprocessAllModules -DgenerateBackupPoms=false
+          mvn -V -B -e versions:set-scm-tag "-DnewTag=${RELEASE_VERSION}" -DgenerateBackupPoms=false
           mvn -V -B -e sortpom:sort
-          git commit -am "[github-actions](${{ github.actor }}) release ${{ env.RELEASE_VERSION }}"
-          git tag -a ${{ env.RELEASE_VERSION }} -m "${{ env.RELEASE_VERSION }}"
-          git push origin release/${{ env.RELEASE_VERSION }}
-          git push origin ${{ env.RELEASE_VERSION }}
+          git commit -am "[github-actions](${GITHUB_ACTOR}) release ${RELEASE_VERSION}"
+          git tag -a "${RELEASE_VERSION}" -m "${RELEASE_VERSION}"
+          git push origin "release/${RELEASE_VERSION}"
+          git push origin "${RELEASE_VERSION}"
 
       - name: Build release artifacts
         run: mvn -B -V -e -ntp "-Dstyle.color=always" package
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.RELEASE_VERSION }}
-          release_name: ${{ env.RELEASE_VERSION }}
-          draft: false
-          prerelease: false
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${RELEASE_VERSION}" --title "${RELEASE_VERSION}" --target "release/${RELEASE_VERSION}"
 
       - name: Publish to GitHub Packages Apache Maven
         run: mvn deploy -Pgithub-publish -DskipTests
@@ -152,7 +159,11 @@ jobs:
       - name: Delete branch
         continue-on-error: true
         if: ${{ github.event.inputs.release_type == 'patch' && startsWith(github.ref_name, 'patch/') }}
-        run: git push origin :${{ github.ref_name }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh auth setup-git
+          git push origin ":${GITHUB_REF_NAME}"
 
   snapshot-bump:
     if: ${{ github.event.inputs.release_type == 'release' && github.ref_name == 'main' }}
@@ -167,6 +178,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK
         uses: actions/setup-java@v5
@@ -176,9 +189,12 @@ jobs:
           cache: "maven"
 
       - name: Configure Git user
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          gh auth setup-git
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
       - name: Get the version and set the name of the branch
         run: |
@@ -187,18 +203,18 @@ jobs:
           echo "PR_BRANCH=action/${NEXT_DEV_VERSION}" >> "$GITHUB_ENV"
 
       - name: Create a branch
-        run: git switch -c ${{ env.PR_BRANCH }}
+        run: git switch -c "${PR_BRANCH}"
 
       - name: Set the next snapshot version
         run: |
-          mvn -B -V -e -ntp versions:set -DnewVersion=${{ env.NEXT_DEV_VERSION }} -DgenerateBackupPoms=false
+          mvn -B -V -e -ntp versions:set "-DnewVersion=${NEXT_DEV_VERSION}" -DgenerateBackupPoms=false
           mvn -B -V -e -ntp versions:commit
           git add .
-          git commit -m "[github-actions](${{ github.actor }}) next development iteration ${{ env.NEXT_DEV_VERSION }}"
-          git push -u origin ${{ env.PR_BRANCH }}
+          git commit -m "[github-actions](${GITHUB_ACTOR}) next development iteration ${NEXT_DEV_VERSION}"
+          git push -u origin "${PR_BRANCH}"
 
       - name: Create pull request
-        run: gh pr create -B main -H ${{ env.PR_BRANCH }} --title 'next development iteration ${{ env.NEXT_DEV_VERSION }}' --body 'Created by GitHub Action'
+        run: gh pr create -B main -H "${PR_BRANCH}" --title "next development iteration ${NEXT_DEV_VERSION}" --body 'Created by GitHub Action'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -208,7 +224,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add RELEASE_VERSION to environment variable
-        run: echo "RELEASE_VERSION=${{ needs.get_version.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
+        run: echo "RELEASE_VERSION=${NEEDS_GET_VERSION_OUTPUTS_RELEASE_VERSION}" >> "$GITHUB_ENV"
+        env:
+          NEEDS_GET_VERSION_OUTPUTS_RELEASE_VERSION: ${{ needs.get_version.outputs.RELEASE_VERSION }}
 
       - name: Publish to slack channel via bot token
         id: slack
@@ -239,7 +257,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add RELEASE_VERSION to environment variable
-        run: echo "RELEASE_VERSION=${{ needs.get_version.outputs.RELEASE_VERSION }}" >> "$GITHUB_ENV"
+        run: echo "RELEASE_VERSION=${NEEDS_GET_VERSION_OUTPUTS_RELEASE_VERSION}" >> "$GITHUB_ENV"
+        env:
+          NEEDS_GET_VERSION_OUTPUTS_RELEASE_VERSION: ${{ needs.get_version.outputs.RELEASE_VERSION }}
 
       - name: Publish to slack channel via bot token
         id: slack

--- a/.github/workflows/maven-version.yml
+++ b/.github/workflows/maven-version.yml
@@ -15,6 +15,9 @@ env:
   JAVA_DISTRIBUTION: "corretto"
   MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Djava.awt.headless=true"
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -49,6 +52,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK
         uses: actions/setup-java@v5
@@ -59,8 +64,8 @@ jobs:
 
       - name: Configure Git user
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
       - name: Set the name of the branch
         run: echo "PR_BRANCH=action/$IN_NEXT_VERSION" >> "$GITHUB_ENV"
@@ -68,20 +73,22 @@ jobs:
           IN_NEXT_VERSION: ${{ github.event.inputs.next_version }}
 
       - name: Create a branch
-        run: git switch -c ${{ env.PR_BRANCH }}
+        run: git switch -c "${PR_BRANCH}"
 
       - name: Set the next snapshot version
         run: |
+          gh auth setup-git
           mvn -B -V -e -ntp versions:set -DnewVersion="$IN_NEXT_VERSION" -DgenerateBackupPoms=false
           mvn -B -V -e -ntp versions:commit
           git add .
-          git commit -m "[github-actions](${{ github.actor }}) next development iteration"
-          git push -u origin ${{ env.PR_BRANCH }}
+          git commit -m "[github-actions](${GITHUB_ACTOR}) next development iteration"
+          git push -u origin "${PR_BRANCH}"
         env:
           IN_NEXT_VERSION: ${{ github.event.inputs.next_version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create pull request
-        run: gh pr create -B main -H ${{ env.PR_BRANCH }} --title "next development iteration $IN_NEXT_VERSION" --body 'Created by GitHub Action'
+        run: gh pr create -B main -H "${PR_BRANCH}" --title "next development iteration $IN_NEXT_VERSION" --body 'Created by GitHub Action'
         env:
           IN_NEXT_VERSION: ${{ github.event.inputs.next_version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Zizmor Security Fixes

Resolves 119 zizmor findings across 9 workflow files.

### Changes

**`template-injection` (44)** — Replaced `${{ ... }}` inside `run:` blocks with shell env vars. Actions interpolates `${{ }}` before the shell runs, so attacker-controllable values (branch names, `github.actor`, etc.) could inject shell code. Env vars deliver the value as data, not code.

**`artipacked` (14)** — Added `persist-credentials: false` to every `actions/checkout`. Stops `GITHUB_TOKEN` from being written into `.git/config`, where later steps or artifacts could leak it.

**`excessive-permissions` (17)** — Added workflow-level `permissions: contents: read` to 4 files. Jobs that need write still declare their own elevated `permissions:` block.

**`cache-poisoning` (2)** — Removed `cache: 'maven'` from `setup-java` on `macos-build` and `site-build`. These jobs run on both PRs and pushes to protected branches; a fork PR could poison a cache entry that a later main-branch push restores. Trade-off: slower builds on these two jobs.

**`archived-uses` (1)** — Replaced archived `actions/create-release@v1` with `gh release create`.

### Supporting changes

- `persist-credentials: false` breaks `git push`, so every push step now runs `gh auth setup-git` with `GH_TOKEN` in env — equivalent auth without writing the token to disk.
- Quoted bare `${VAR}` references the zizmor auto-fix introduced, to clear `shellcheck SC2086` warnings.

### Review focus

The four push workflows (`cherrypick`, `create-patch-branch`, `maven-release`, `maven-version`) are `workflow_dispatch`-only and aren't exercised by PR CI — worth a careful read of the push steps before the next release.

### Verification

- `zizmor` → No findings (41 still suppressed by config, unchanged)
- `actionlint` → clean
