### PR TITLE
remove takari-lifecycle-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,6 @@
     <plugin.restrict-imports-enforcer-rule.version>3.0.0</plugin.restrict-imports-enforcer-rule.version>
     <plugin.sonar-maven.version>3.11.0.3922</plugin.sonar-maven.version>
     <plugin.sortpom-maven.version>4.0.0</plugin.sortpom-maven.version>
-    <plugin.takari-lifecycle>2.3.3</plugin.takari-lifecycle>
     <plugin.versions-maven.version>2.21.0</plugin.versions-maven.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -842,11 +841,6 @@
               </goals>
             </execution>
           </executions>
-        </plugin>
-        <plugin>
-          <groupId>io.takari.maven.plugins</groupId>
-          <artifactId>takari-lifecycle-plugin</artifactId>
-          <version>${plugin.takari-lifecycle}</version>
         </plugin>
         <plugin>
           <groupId>net.revelc.code</groupId>
@@ -1650,10 +1644,6 @@
       <id>dist</id>
       <build>
         <plugins>
-          <plugin>
-            <groupId>io.takari.maven.plugins</groupId>
-            <artifactId>takari-lifecycle-plugin</artifactId>
-          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
In response to #1433 

I think we can stop managing this? We added it in #1011 because we were having issues with cyclone:
> I did run into an issue where the maven-project-info-reports had errors when using the cyclonedx plugin. I recommend bumping that to the latest 2.9.1 version as well as adding this plugin dependency (in the dist profile config) to try to manage the version being used with cyclone (it uses 2.0.8 now): `<plugin><groupId>io.takari.maven.plugins</groupId> <artifactId>takari-lifecycle-plugin</artifactId><version>2.2.0</version></plugin>`

I removed the plugin and ran: `mvn clean install site -Pcheckstyle,coverage,pmd,dist` and all looked good. 

Thoughts?