### PR TITLE
action :: fix environment variable formatting in Dockerfile and maven-ci.yml

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        with:
+          cache-image: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -49,6 +51,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        with:
+          cache-image: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -77,6 +81,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        with:
+          cache-image: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -4,7 +4,7 @@ ARG target_os=ubi8
 
 FROM redhat/ubi8 AS base_ubi8
 
-ENV JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8
+ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 ENV PROJECT_BASE=/opt/emissary
 
 ARG java_version=11
@@ -25,7 +25,7 @@ RUN rpm --import https://yum.corretto.aws/corretto.key \
 
 FROM centos:7 AS base_centos7
 
-ENV JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8
+ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 ENV PROJECT_BASE=/opt/emissary
 
 ARG java_version=11
@@ -51,7 +51,7 @@ RUN sed -i s/mirrorlist.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-*.
 
 FROM alpine:3 AS base_alpine3
 
-ENV JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8
+ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 ENV PROJECT_BASE=/opt/emissary
 
 ARG java_version=11
@@ -74,8 +74,8 @@ RUN  apk update \
 
 FROM base_${target_os} AS build
 
-ENV MAVEN_OPTS -Xms512M -Xmx1024M -Xss1M -Djava.awt.headless=true
-ENV MAVEN_HOME /opt/maven
+ENV MAVEN_OPTS="-Xms512M -Xmx1024M -Xss1M -Djava.awt.headless=true"
+ENV MAVEN_HOME=/opt/maven
 
 ARG maven_version=3.9.10
 RUN curl -L -o /tmp/maven.tar.gz https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/${maven_version}/apache-maven-${maven_version}-bin.tar.gz \


### PR DESCRIPTION
Address warnings that the action runs report.

Added `cache-image: false `to the three setup-qemu-action steps (build, matrix-build, centos7-build). This stops the parallel jobs from racing to save the same fixed binfmt cache key, clearing the `Failed to save: Unable to reserve cache with key docker.io--tonistiigi--binfmt-latest-linux-x64` warning. These jobs build native linux/amd64 images, so the binfmt cache provided no benefit.