### PR TITLE
WIP: prototype for logging aggregation of output views and counts. 

### DIFF
--- a/src/main/config/logback.xml
+++ b/src/main/config/logback.xml
@@ -69,6 +69,34 @@
     </then>
   </if>
 
+  <!-- Enable drop-off view-count stats logging by creating an environment variable of "LOG_DROPOFF_STATS=true" -->
+  <if condition="&quot;${LOG_DROPOFF_STATS}&quot;.equals(&quot;true&quot;)">
+    <then>
+      <appender name="DROPOFF-STATS" class="emissary.util.CustomRolloverLogbackAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+          <customFields>{"node":"${emissary.node.name}"}</customFields>
+          <includeMdc>false</includeMdc>
+          <fieldNames>
+            <version>[ignore]</version>
+            <logger>[ignore]</logger>
+            <thread>[ignore]</thread>
+            <levelValue>[ignore]</levelValue>
+            <level>[ignore]</level>
+            <message>[ignore]</message>
+          </fieldNames>
+        </encoder>
+        <file>${PROJECT_BASE}/logs/${emissary.node.name}-${emissary.node.port}-dropoff-stats.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+          <fileNamePattern>${PROJECT_BASE}/logs/${emissary.node.name}-${emissary.node.port}-dropoff-stats.log.%d{yyyyMMdd-HHmm}</fileNamePattern>
+        </rollingPolicy>
+      </appender>
+
+      <logger name="dropOffStats" level="INFO" additivity="false">
+        <appender-ref ref="DROPOFF-STATS" />
+      </logger>
+    </then>
+  </if>
+
   <root level="INFO">
     <!-- stop logging to a file in development man, redirect or tee to a file
     <appender-ref ref="TOFILE"/>

--- a/src/main/java/emissary/directory/EmissaryNode.java
+++ b/src/main/java/emissary/directory/EmissaryNode.java
@@ -8,6 +8,7 @@ import emissary.core.EmissaryException;
 import emissary.core.MetricsManager;
 import emissary.core.ResourceWatcher;
 import emissary.core.sentinel.Sentinel;
+import emissary.output.stats.ViewOutputStats;
 import emissary.pool.AgentPool;
 import emissary.pool.MobileAgentFactory;
 import emissary.pool.MoveSpool;
@@ -279,6 +280,13 @@ public class EmissaryNode {
         // The resource watcher
         ResourceWatcher watcher = new ResourceWatcher(metricsManager);
         logger.debug("Started resource watcher...{}", watcher);
+
+        // The drop-off view stats aggregator (opt-in via LOG_DROPOFF_STATS=true)
+        if ("true".equalsIgnoreCase(System.getenv("LOG_DROPOFF_STATS"))) {
+            ViewOutputStats viewStats = ViewOutputStats.fromConfig();
+            viewStats.startAndBind();
+            logger.info("Started drop-off view stats...{}", viewStats);
+        }
 
         // Initialize list of configured spi classes
         SPILoader.load();

--- a/src/main/java/emissary/output/filter/AbstractRollableFilter.java
+++ b/src/main/java/emissary/output/filter/AbstractRollableFilter.java
@@ -3,10 +3,12 @@ package emissary.output.filter;
 import emissary.config.ConfigUtil;
 import emissary.config.Configurator;
 import emissary.core.IBaseDataObject;
+import emissary.output.DropOffUtil;
 import emissary.output.io.DateStampFilenameGenerator;
 import emissary.output.roller.IJournaler;
 import emissary.output.roller.JournaledCoalescer;
 import emissary.output.roller.journal.KeyedOutput;
+import emissary.output.stats.ViewOutputStats;
 import emissary.pool.AgentPool;
 import emissary.roll.RollManager;
 import emissary.roll.Roller;
@@ -208,6 +210,8 @@ public abstract class AbstractRollableFilter extends AbstractFilter {
         // We subtract 1 from the list because the first element is currently assumed to be the TLD
         list.get(0).putParameter("DESCENDANT_COUNT", list.size() - 1);
 
+        recordViewStats(list);
+
         try {
             output.write(convert(list, params));
             if (appendNewLine) {
@@ -220,5 +224,26 @@ public abstract class AbstractRollableFilter extends AbstractFilter {
         return STATUS_SUCCESS;
     }
 
+    /**
+     * Record drop-off view-count stats for every object written by this filter. Rollable filters (JSON/XML) emit an
+     * object's primary view and all of its non-empty alternate views together, so each is counted with status
+     * {@link ViewOutputStats#STATUS_OK}. No-op unless the feature is enabled.
+     *
+     * @param list the payloads being written out
+     */
+    protected void recordViewStats(final List<IBaseDataObject> list) {
+        for (final IBaseDataObject d : list) {
+            final String fileType = DropOffUtil.getFileType(d);
+            if (d.dataLength() > 0) {
+                ViewOutputStats.record(AbstractFilter.PRIMARY_VIEW_NAME, fileType, ViewOutputStats.STATUS_OK);
+            }
+            for (final String viewName : d.getAlternateViewNames()) {
+                final byte[] av = d.getAlternateView(viewName);
+                if (av != null && av.length > 0) {
+                    ViewOutputStats.record(viewName, fileType, ViewOutputStats.STATUS_OK);
+                }
+            }
+        }
+    }
 
 }

--- a/src/main/java/emissary/output/filter/DataFilter.java
+++ b/src/main/java/emissary/output/filter/DataFilter.java
@@ -5,6 +5,7 @@ import emissary.config.Configurator;
 import emissary.core.IBaseDataObject;
 import emissary.output.DropOffPlace;
 import emissary.output.DropOffUtil;
+import emissary.output.stats.ViewOutputStats;
 
 import jakarta.annotation.Nullable;
 
@@ -64,6 +65,8 @@ public class DataFilter extends AbstractFilter {
             final byte[] data = d.data();
             final boolean status = writeDataFile(d, tld, baseFileName, data, null);
             writeCount += (status ? 1 : -1);
+            ViewOutputStats.record(AbstractFilter.PRIMARY_VIEW_NAME, fileType,
+                    status ? ViewOutputStats.STATUS_OK : ViewOutputStats.STATUS_WRITE_FAILED);
         }
 
         // Check each alt view
@@ -72,6 +75,9 @@ public class DataFilter extends AbstractFilter {
                 final String fixedViewName = viewName.replace(" ", "_");
                 final boolean status = writeDataFile(d, tld, baseFileName, d.getAlternateView(viewName), fixedViewName);
                 writeCount += (status ? 1 : -1);
+                ViewOutputStats.record(viewName, fileType, status ? ViewOutputStats.STATUS_OK : ViewOutputStats.STATUS_WRITE_FAILED);
+            } else {
+                ViewOutputStats.record(viewName, fileType, ViewOutputStats.STATUS_NOT_OUTPUTTABLE);
             }
         }
 
@@ -105,6 +111,8 @@ public class DataFilter extends AbstractFilter {
             final byte[] data = d.data();
             final boolean status = writeDataStream(d, tld, output, data, null);
             writeCount += (status ? 1 : -1);
+            ViewOutputStats.record(AbstractFilter.PRIMARY_VIEW_NAME, fileType,
+                    status ? ViewOutputStats.STATUS_OK : ViewOutputStats.STATUS_WRITE_FAILED);
         }
 
         // Check each alt view
@@ -113,6 +121,9 @@ public class DataFilter extends AbstractFilter {
                 final String fixedViewName = viewName.replace(" ", "_");
                 final boolean status = writeDataStream(d, tld, output, d.getAlternateView(viewName), fixedViewName);
                 writeCount += (status ? 1 : -1);
+                ViewOutputStats.record(viewName, fileType, status ? ViewOutputStats.STATUS_OK : ViewOutputStats.STATUS_WRITE_FAILED);
+            } else {
+                ViewOutputStats.record(viewName, fileType, ViewOutputStats.STATUS_NOT_OUTPUTTABLE);
             }
         }
 

--- a/src/main/java/emissary/output/stats/ViewOutputStats.java
+++ b/src/main/java/emissary/output/stats/ViewOutputStats.java
@@ -1,0 +1,199 @@
+package emissary.output.stats;
+
+import emissary.config.ConfigUtil;
+import emissary.config.Configurator;
+import emissary.core.Namespace;
+import emissary.core.NamespaceException;
+
+import jakarta.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
+
+import static net.logstash.logback.marker.Markers.appendEntries;
+
+/**
+ * Aggregates counts of named views emitted at drop-off/output time, broken down by
+ * {@code viewName x fileType x status}, and periodically flushes an aggregated summary to a dedicated logfile before
+ * resetting - so each flush line represents a rolling window (e.g. "objects in the last 10 minutes").
+ *
+ * <p>
+ * This mirrors the {@link emissary.core.ResourceWatcher} (placeStats) pattern: a Namespace-bound singleton that
+ * accumulates counts in memory and exposes {@link #logStats(Logger)} to flush-and-reset. It is deliberately decoupled
+ * from any concrete output schema - callers hand it plain strings, so downstream projects can attribu`te their own view
+ * names and processing statuses without this class depending on their types.
+ *
+ * <p>
+ * The feature is off by default. It is created and bound only when enabled (see {@link #startAndBind()} callers), so
+ * {@link #record(String, String, String)} is a cheap no-op whenever the singleton is not bound.
+ */
+public class ViewOutputStats {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(ViewOutputStats.class);
+
+    /** Dedicated logger name, routed to its own file appender via logback (mirrors {@code objectTrace}). */
+    protected static final Logger STATS_LOGGER = LoggerFactory.getLogger("dropOffStats");
+
+    public static final String DEFAULT_NAMESPACE_NAME = "ViewOutputStats";
+
+    /** Status values recorded against a view emission. Callers may also supply their own status strings. */
+    public static final String STATUS_OK = "OK";
+    public static final String STATUS_NOT_OUTPUTTABLE = "NOT_OUTPUTTABLE";
+    public static final String STATUS_WRITE_FAILED = "WRITE_FAILED";
+
+    /** Separator between the composite key components. Tab avoids collision with view/type names. */
+    protected static final String KEY_SEP = "\t";
+
+    protected final int interval;
+    protected final TimeUnit intervalUnit;
+    protected final long windowSeconds;
+
+    /** Swapped out wholesale on each flush so accumulation and reset are atomic. */
+    protected final AtomicReference<ConcurrentHashMap<String, LongAdder>> counts =
+            new AtomicReference<>(new ConcurrentHashMap<>());
+
+    @Nullable
+    protected ScheduledExecutorService scheduler;
+
+    @Nullable
+    protected ScheduledFuture<?> scheduledTask;
+
+    public ViewOutputStats(final int interval, final TimeUnit intervalUnit) {
+        this.interval = interval;
+        this.intervalUnit = intervalUnit;
+        this.windowSeconds = intervalUnit.toSeconds(interval);
+    }
+
+    /**
+     * Build an instance from {@code ViewOutputStats.cfg} (keys {@code INTERVAL}, {@code INTERVAL_UNIT}). Falls back to
+     * defaults (10 MINUTES) if the config cannot be found, so the feature always starts when enabled.
+     */
+    public static ViewOutputStats fromConfig() {
+        int interval = 10;
+        TimeUnit unit = TimeUnit.MINUTES;
+        try {
+            final Configurator conf = ConfigUtil.getConfigInfo(ViewOutputStats.class);
+            interval = conf.findIntEntry("INTERVAL", interval);
+            unit = TimeUnit.valueOf(conf.findStringEntry("INTERVAL_UNIT", unit.name()));
+        } catch (IOException e) {
+            LOG.warn("No ViewOutputStats.cfg found, using defaults ({} {})", interval, unit);
+        }
+        return new ViewOutputStats(interval, unit);
+    }
+
+    /**
+     * Bind this instance into the Namespace and start the periodic flush-and-reset thread.
+     */
+    public void startAndBind() {
+        Namespace.bind(DEFAULT_NAMESPACE_NAME, this);
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            final Thread t = new Thread(r, "ViewOutputStats");
+            t.setDaemon(true);
+            return t;
+        });
+        this.scheduledTask = this.scheduler.scheduleAtFixedRate(() -> {
+            try {
+                flush();
+            } catch (RuntimeException e) {
+                LOG.error("Issue flushing ViewOutputStats", e);
+            }
+        }, interval, interval, intervalUnit);
+    }
+
+    @Override
+    public String toString() {
+        return "ViewOutputStats flushing every " + interval + " " + intervalUnit;
+    }
+
+    /**
+     * Lookup the bound singleton and record a view emission. No-op if the feature is disabled (not bound).
+     *
+     * @param viewName the emitted view's name
+     * @param fileType the payload's file type
+     * @param status the processing status of the emitted view (e.g. OK, NOT_OUTPUTTABLE)
+     */
+    public static void record(final String viewName, final String fileType, final String status) {
+        try {
+            lookup().count(viewName, fileType, status);
+        } catch (NamespaceException ignored) {
+            // feature disabled / not bound - nothing to do
+        }
+    }
+
+    public static ViewOutputStats lookup() throws NamespaceException {
+        return (ViewOutputStats) Namespace.lookup(DEFAULT_NAMESPACE_NAME);
+    }
+
+    /**
+     * Increment the counter for a single view emission.
+     */
+    public void count(final String viewName, final String fileType, final String status) {
+        final String key = viewName + KEY_SEP + fileType + KEY_SEP + status;
+        this.counts.get().computeIfAbsent(key, k -> new LongAdder()).increment();
+    }
+
+    /**
+     * Flush the current window to the dedicated {@code dropOffStats} logfile and reset.
+     */
+    public void flush() {
+        logStats(STATS_LOGGER);
+    }
+
+    /**
+     * Atomically swap in a fresh accumulator and return the counts observed in the window just closed, keyed by the
+     * composite {@code viewName KEY_SEP fileType KEY_SEP status}. Only non-zero entries are returned.
+     */
+    protected Map<String, Long> snapshotAndReset() {
+        final Map<String, LongAdder> window = this.counts.getAndSet(new ConcurrentHashMap<>());
+        final Map<String, Long> result = new HashMap<>();
+        for (final Map.Entry<String, LongAdder> e : window.entrySet()) {
+            final long count = e.getValue().sum();
+            if (count > 0) {
+                result.put(e.getKey(), count);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Flush the current window: emit one structured line per non-zero {@code viewName x fileType x status} and reset the
+     * accumulator so the next window starts from zero.
+     */
+    public void logStats(final Logger loggerArg) {
+        for (final Map.Entry<String, Long> e : snapshotAndReset().entrySet()) {
+            final String[] parts = e.getKey().split(KEY_SEP, -1);
+            final Map<String, Object> fields = new HashMap<>();
+            fields.put("viewName", parts[0]);
+            fields.put("fileType", parts[1]);
+            fields.put("status", parts[2]);
+            fields.put("count", e.getValue());
+            fields.put("windowSeconds", windowSeconds);
+            loggerArg.info(appendEntries(fields), "");
+        }
+    }
+
+    /**
+     * Stop the periodic flush thread and unbind from the Namespace. Callers should invoke {@link #logStats(Logger)} for a
+     * final flush beforehand if the tail window matters.
+     */
+    public void shutdown() {
+        if (this.scheduler != null) {
+            this.scheduler.shutdown();
+        }
+        try {
+            Namespace.unbind(DEFAULT_NAMESPACE_NAME);
+        } catch (RuntimeException e) {
+            LOG.debug("ViewOutputStats was not bound at shutdown", e);
+        }
+    }
+}

--- a/src/main/java/emissary/server/EmissaryServer.java
+++ b/src/main/java/emissary/server/EmissaryServer.java
@@ -18,6 +18,7 @@ import emissary.core.ResourceWatcher;
 import emissary.core.sentinel.Sentinel;
 import emissary.directory.DirectoryPlace;
 import emissary.directory.EmissaryNode;
+import emissary.output.stats.ViewOutputStats;
 import emissary.place.IServiceProviderPlace;
 import emissary.place.ServiceProviderRefreshablePlace;
 import emissary.pool.AgentPool;
@@ -454,6 +455,15 @@ public class EmissaryServer {
             rw.quit();
         } catch (Exception ex) {
             LOG.warn("No resource statistics available");
+        }
+
+        // Final flush of drop-off view stats (if enabled)
+        try {
+            ViewOutputStats viewStats = ViewOutputStats.lookup();
+            viewStats.flush();
+            viewStats.shutdown();
+        } catch (Exception ex) {
+            LOG.debug("No drop-off view statistics available");
         }
 
         try {

--- a/src/main/resources/emissary/output/stats/ViewOutputStats.cfg
+++ b/src/main/resources/emissary/output/stats/ViewOutputStats.cfg
@@ -1,0 +1,11 @@
+# Configuration for ViewOutputStats - periodic aggregation of drop-off/output
+# view counts (viewName x fileType x status) to the dedicated "dropOffStats" logfile.
+#
+# The feature is enabled by setting the environment variable LOG_DROPOFF_STATS=true
+# (this both wires up the aggregator and enables the logback file appender).
+# The settings below control the flush cadence once enabled.
+
+# How often to flush-and-reset the accumulated counts. Each flushed line therefore
+# represents counts observed within the most recent INTERVAL window.
+INTERVAL = 1
+INTERVAL_UNIT = "MINUTES"

--- a/src/test/java/emissary/output/filter/DataFilterTest.java
+++ b/src/test/java/emissary/output/filter/DataFilterTest.java
@@ -4,17 +4,26 @@ import emissary.config.Configurator;
 import emissary.config.ServiceConfigGuide;
 import emissary.core.DataObjectFactory;
 import emissary.core.IBaseDataObject;
+import emissary.output.stats.ViewOutputStats;
 import emissary.test.core.junit5.UnitTest;
 import emissary.util.shell.Executrix;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
 
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 class DataFilterTest extends UnitTest {
 
@@ -55,5 +64,40 @@ class DataFilterTest extends UnitTest {
         assertEquals(new String(payload.data()), output, "Output must be the payload and nothing else");
 
         expected.delete();
+    }
+
+    @Test
+    void testViewOutputStatsRecorded() {
+        Configurator config = new ServiceConfigGuide();
+        config.addEntry("OUTPUT_SPEC_FOO", "/tmp/%S%.%F%");
+        config.addEntry("OUTPUT_TYPE", "FTYPE.PrimaryView");
+        config.addEntry("OUTPUT_TYPE", "FTYPE.GoodView");
+
+        IDropOffFilter f = new DataFilter();
+        f.initialize(config, "FOO", config);
+
+        IBaseDataObject payload = DataObjectFactory.getInstance();
+        payload.setData("This is the data".getBytes());
+        payload.setFileType("FTYPE");
+        payload.setFilename("/this/is/a/testfile");
+        payload.addAlternateView("GoodView", "good view data".getBytes());
+        payload.addAlternateView("BadView", "suppressed view data".getBytes());
+
+        ViewOutputStats stats = new ViewOutputStats(10, TimeUnit.MINUTES);
+        stats.startAndBind();
+        try {
+            int status = f.filter(payload, new HashMap<>());
+            assertEquals(IDropOffFilter.STATUS_SUCCESS, status);
+
+            // PrimaryView (OK) + GoodView (OK) + BadView (NOT_OUTPUTTABLE) => three distinct keys.
+            // Getting three lines proves the NOT_OUTPUTTABLE branch recorded the suppressed view.
+            Logger logger = mock(Logger.class);
+            stats.logStats(logger);
+            verify(logger, times(3)).info(any(Marker.class), eq(""));
+        } finally {
+            stats.shutdown();
+            new File("/tmp/testfile.FTYPE").delete();
+            new File("/tmp/testfile.FTYPE.GoodView").delete();
+        }
     }
 }

--- a/src/test/java/emissary/output/filter/JsonOutputFilterTest.java
+++ b/src/test/java/emissary/output/filter/JsonOutputFilterTest.java
@@ -3,6 +3,7 @@ package emissary.output.filter;
 import emissary.config.ServiceConfigGuide;
 import emissary.core.DataObjectFactory;
 import emissary.core.IBaseDataObject;
+import emissary.output.stats.ViewOutputStats;
 import emissary.test.core.junit5.UnitTest;
 
 import jakarta.annotation.Nullable;
@@ -11,6 +12,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -22,10 +25,16 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 class JsonOutputFilterTest extends UnitTest {
 
@@ -83,6 +92,27 @@ class JsonOutputFilterTest extends UnitTest {
         assertEquals(IDropOffFilter.STATUS_SUCCESS, status, "Filter should return success");
         assertTrue(output.toString().contains("\"FILETYPE\":[\"FTYPE\"]"), "Filter output should have file type");
         assertTrue(output.toString().contains("\"payload\":\"VGhpcyBpcyB0aGUgZGF0YQ==\""), "Filter should have payload");
+    }
+
+    @Test
+    void testViewOutputStatsRecorded() {
+        f.initialize(config, "FOO", config);
+        payload.addAlternateView("NormalizedText", "some normalized text".getBytes());
+
+        ViewOutputStats stats = new ViewOutputStats(10, TimeUnit.MINUTES);
+        stats.startAndBind();
+        try {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            int status = f.filter(Collections.singletonList(payload), new HashMap<>(), output);
+            assertEquals(IDropOffFilter.STATUS_SUCCESS, status);
+
+            // PrimaryView (payload present) + NormalizedText alt view => two distinct keys
+            Logger logger = mock(Logger.class);
+            stats.logStats(logger);
+            verify(logger, times(2)).info(any(Marker.class), eq(""));
+        } finally {
+            stats.shutdown();
+        }
     }
 
     @Test

--- a/src/test/java/emissary/output/stats/ViewOutputStatsTest.java
+++ b/src/test/java/emissary/output/stats/ViewOutputStatsTest.java
@@ -1,0 +1,111 @@
+package emissary.output.stats;
+
+import emissary.core.Namespace;
+import emissary.test.core.junit5.UnitTest;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class ViewOutputStatsTest extends UnitTest {
+
+    @Test
+    void testCountAndFlushEmitsOneLinePerKey() {
+        ViewOutputStats stats = new ViewOutputStats(10, TimeUnit.MINUTES);
+
+        // two objects had PrimaryView (PDF, OK), one had NormalizedText (PDF, OK),
+        // one had NormalizedText that was suppressed (PDF, NOT_OUTPUTTABLE)
+        stats.count("PrimaryView", "PDF", "OK");
+        stats.count("PrimaryView", "PDF", "OK");
+        stats.count("NormalizedText", "PDF", "OK");
+        stats.count("NormalizedText", "PDF", "NOT_OUTPUTTABLE");
+
+        Logger logger = mock(Logger.class);
+        stats.logStats(logger);
+
+        // one structured line per distinct viewName x fileType x status key
+        verify(logger, times(3)).info(any(Marker.class), eq(""));
+    }
+
+    @Test
+    void testFlushResetsWindow() {
+        ViewOutputStats stats = new ViewOutputStats(10, TimeUnit.MINUTES);
+        stats.count("PrimaryView", "PDF", "OK");
+
+        Logger logger1 = mock(Logger.class);
+        stats.logStats(logger1);
+        verify(logger1, times(1)).info(any(Marker.class), eq(""));
+
+        // second flush with no new counts should emit nothing (reset worked)
+        Logger logger2 = mock(Logger.class);
+        stats.logStats(logger2);
+        verifyNoInteractions(logger2);
+    }
+
+    @Test
+    void testConcurrentCounting() throws InterruptedException {
+        ViewOutputStats stats = new ViewOutputStats(10, TimeUnit.MINUTES);
+        int threads = 8;
+        int perThread = 1000;
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+        for (int i = 0; i < threads; i++) {
+            new Thread(() -> {
+                try {
+                    start.await();
+                    for (int j = 0; j < perThread; j++) {
+                        stats.count("PrimaryView", "PDF", "OK");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            }).start();
+        }
+        start.countDown();
+        assertTrue(done.await(30, TimeUnit.SECONDS));
+
+        // exact aggregate, proving no updates were lost under contention
+        Map<String, Long> snapshot = stats.snapshotAndReset();
+        assertEquals(1, snapshot.size());
+        assertEquals((long) threads * perThread, snapshot.get("PrimaryView\tPDF\tOK"));
+    }
+
+    @Test
+    void testRecordIsNoOpWhenNotBound() {
+        // not bound in the Namespace -> must not throw
+        assertFalse(Namespace.exists(ViewOutputStats.DEFAULT_NAMESPACE_NAME));
+        ViewOutputStats.record("PrimaryView", "PDF", "OK");
+    }
+
+    @Test
+    void testStartBindAndShutdown() {
+        ViewOutputStats stats = new ViewOutputStats(10, TimeUnit.MINUTES);
+        stats.startAndBind();
+        assertTrue(Namespace.exists(ViewOutputStats.DEFAULT_NAMESPACE_NAME));
+
+        // record via the static path now that it is bound
+        ViewOutputStats.record("PrimaryView", "PDF", "OK");
+        Logger logger = mock(Logger.class);
+        stats.logStats(logger);
+        verify(logger, times(1)).info(any(Marker.class), eq(""));
+
+        stats.shutdown();
+        assertFalse(Namespace.exists(ViewOutputStats.DEFAULT_NAMESPACE_NAME));
+    }
+}


### PR DESCRIPTION
# Add drop-off view-count stats (`placeStats` for output)

## Motivation
When someone changes the drop-off/output config (`OUTPUT_TYPE` / `DENYLIST`) that controls which views get written, there's currently no way to see the effect at runtime — you either diff output files by hand or wait for a downstream consumer to notice. This adds an always-available, low-overhead counter that answers *"in the last N minutes, how many objects had view X written, broken down by file type and status?"* — for live verification of drop-off config changes.

It mirrors the existing `placeStats`/`ResourceWatcher` pattern: accumulate counts in memory, flush an aggregated summary to a dedicated logfile on an interval, then reset — so each line is a rolling window.

## What it does
A new Namespace-bound singleton, `emissary.output.stats.ViewOutputStats`, accumulates counts keyed by **`viewName × fileType × status`** and a daemon scheduler flushes-and-resets them to a dedicated `dropOffStats` logfile every interval. Each flush emits one structured (Logstash JSON) line per non-zero key:

```json
{"node":"localhost","viewName":"NormalizedText","fileType":"PDF","status":"OK","count":42,"windowSeconds":60}
```

Hooks are wired into the framework's default output filters so it works out of the box:

- **`DataFilter`** (raw output) — records each view with `OK` / `WRITE_FAILED` when written, and **`NOT_OUTPUTTABLE`** for views present but suppressed by config (the key config-verification signal, since `DataFilter` gates per-view).
- **`AbstractRollableFilter`** (`JsonOutputFilter`, `XmlOutputFilter`) — records each output object's primary view + non-empty alternate views as `OK`. These filters gate at the object level (all views or none), so there's no `NOT_OUTPUTTABLE` breakdown on this path.

The API is deliberately schema-agnostic (`record(viewName, fileType, status)` takes plain strings), so downstream projects can feed their own view names and statuses without emissary depending on their types.

## Enablement
Off by default. Enable with env var **`LOG_DROPOFF_STATS=true`**, which both wires up the aggregator (`EmissaryNode`) and enables the logback file appender. Flush cadence is configured in `emissary/output/stats/ViewOutputStats.cfg` (`INTERVAL`, `INTERVAL_UNIT`; currently `1 MINUTE`). When disabled, `ViewOutputStats.record(...)` is a cheap no-op (singleton not bound).

## Files
- **New:** `emissary/output/stats/ViewOutputStats.java`, `ViewOutputStats.cfg`, `ViewOutputStatsTest.java`
- `directory/EmissaryNode.java` — create/bind when enabled
- `server/EmissaryServer.java` — final flush + shutdown alongside `ResourceWatcher`
- `output/filter/DataFilter.java`, `output/filter/AbstractRollableFilter.java` — counting hooks
- `config/logback.xml` — `dropOffStats` appender + logger (mirrors `objectTrace`)

## How to test / evaluate
1. Start with the feature on:
   ```bash
   LOG_DROPOFF_STATS=true ./emissary server -a 2
   ```
2. Confirm the startup line:
   `INFO emissary.directory.EmissaryNode - Started drop-off view stats...ViewOutputStats flushing every 1 MINUTES`
3. Drop files into `target/data/InputData/`, wait ≤1 minute.
4. Inspect the logfile: `${emissary.output.root}/dropOffStats/<node>-<port>-dropoff-stats.log` — expect one JSON line per `viewName × fileType × status` window.
5. **Verify the use case:** flip an `OUTPUT_TYPE`/`DENYLIST` entry for the active filter and confirm the next window shows counts move between `OK` and `NOT_OUTPUTTABLE` (on the `DataFilter` path).

Unit coverage: `ViewOutputStatsTest` (accumulation, flush-and-reset window, concurrent counting with exact totals, no-op-when-unbound, lifecycle); `DataFilterTest#testViewOutputStatsRecorded` and `JsonOutputFilterTest#testViewOutputStatsRecorded` drive the hooks end-to-end.

## Notes
- A zero-count window writes nothing (no empty lines). Counts also flush on graceful server shutdown.
- No new dependencies (reuses Codahale-style pattern, logback Logstash encoder already used by `objectTrace`).


## AI Disclosure
- [x] AI assistance used
- Tool(s): Open Code (qwen3-coder-30b)
- Scope:
  - Explored the codebase and created the implementation plan
  - Implemented the feature (aggregator, filter hooks, lifecycle wiring, logback)
  - Suggested and wrote unit tests
  - Summarized PR Description
- Human verification:
  - I reviewed and edited all generated code
  - I ran tests, checkstyle, and PMD locally, and evaluated the feature end-to-end locally with upstream intergration
  - I understand and can explain all changes
- Risk areas touched:
  - Output filter write path and server startup/shutdown wiring — all gated behind `LOG_DROPOFF_STATS` and off by default