### PR TITLE
added two-decimal precision fractional-second datetime format configs

### DIFF
--- a/src/main/resources/emissary/util/FlexibleDateTimeParser.cfg
+++ b/src/main/resources/emissary/util/FlexibleDateTimeParser.cfg
@@ -325,6 +325,15 @@ FORMAT_DATETIME_EXTRA = "yyyy:MM:dd[ H:m[:ss[.S]][ ][Z][ ][z][ ][Z]]"
 FORMAT_DATETIME_EXTRA = "yyyy:MM:dd[ H:m[:ss[.S]][ ][Z][ ][X]]"
 FORMAT_DATETIME_EXTRA = "yyyy:MM:dd[ H:m[:ss[.S]][ ][X][ ][z][ ][Z]]"
 
+# yyyy_MM_ddHHmmssSS
+FORMAT_DATETIME_MAIN = "yyyy:MM:dd[ H:m[:ss[.SS]][ ][z][ ][Z][ ][Z]]"
+FORMAT_DATETIME_EXTRA = "yyyy:MM:dd[ H:m[:ss[.SS]][ ][z][ ][z][ ][Z]]"
+FORMAT_DATETIME_EXTRA = "yyyy:MM:dd[ H:m[:ss[.SS]][ ][z][ ][Z][ ][z]]"
+FORMAT_DATETIME_EXTRA = "yyyy:MM:dd[ H:m[:ss[.SS]][ ][z][ ][Z][ ][X]]"
+FORMAT_DATETIME_EXTRA = "yyyy:MM:dd[ H:m[:ss[.SS]][ ][Z][ ][z][ ][Z]]"
+FORMAT_DATETIME_EXTRA = "yyyy:MM:dd[ H:m[:ss[.SS]][ ][Z][ ][X]]"
+FORMAT_DATETIME_EXTRA = "yyyy:MM:dd[ H:m[:ss[.SS]][ ][X][ ][z][ ][Z]]"
+
 
 # yyyyMMddHHmmss
 FORMAT_DATETIME_MAIN = "yyyyMMddHHmmss"

--- a/src/test/java/emissary/util/FlexibleDateTimeParserTest.java
+++ b/src/test/java/emissary/util/FlexibleDateTimeParserTest.java
@@ -619,6 +619,24 @@ class FlexibleDateTimeParserTest extends UnitTest {
     }
 
     @Test
+    void parse_yyyy_MM_ddHHmmssSS() {
+        DateTimeFormatter pattern = DateTimeFormatter.ofPattern("yyyy:MM:dd[ H:m[:ss[.SS]][ ][z][ ][Z][ ][Z]]", Locale.getDefault());
+        test("2016:01:04 18:20:30.00", EXPECTED_FULL, pattern);
+        test("2016:01:04 18:20:30", EXPECTED_FULL, pattern);
+        test("2016:01:04 18:20:30 +0000", EXPECTED_FULL, pattern);
+        test("2016:01:04 18:20:30 GMT+0000", EXPECTED_FULL, pattern);
+        test("2016:01:04 18:20:30 GMT", EXPECTED_FULL, pattern);
+        test("2016:01:04 18:20:30+0000", EXPECTED_FULL, pattern);
+        test("2016:01:04 18:20", EXPECTED_NO_SECS, pattern);
+        test("2016:01:04", EXPECTED_NO_TIME, pattern);
+    }
+
+    @Test
+    void parse_yyyy_MM_ddHHmmssSS_Extra() {
+        testAllOffsets("2016:01:04 13:20:30.00", EXPECTED_FULL);
+    }
+
+    @Test
     void parse_yyyyMMddHHmmss() {
         DateTimeFormatter pattern = DateTimeFormatter.ofPattern("yyyyMMddHHmmss", Locale.getDefault());
         test("20160104182030", EXPECTED_FULL, pattern);


### PR DESCRIPTION
See configuration block immediately preceding the new addition as a reference