### PR TITLE
added gRPC retry on response logic

### DIFF
--- a/src/main/java/emissary/grpc/GrpcRoutingPlace.java
+++ b/src/main/java/emissary/grpc/GrpcRoutingPlace.java
@@ -108,7 +108,7 @@ public abstract class GrpcRoutingPlace extends ServiceProviderPlace implements I
                     "Missing required arguments: %s${Target-ID} and %s${Target-ID}", GRPC_HOST, GRPC_PORT));
         }
 
-        RetryHandler retryHandler = new RetryHandler(configG, this.getPlaceName(), this::retryOnException);
+        RetryHandler retryHandler = new RetryHandler(configG, this.getPlaceName(), this::retryOnException, this::retryOnResult);
         for (String id : targetIds) {
             ChannelManager channelManager = new ChannelManager(hosts.get(id), ports.get(id), configG);
             GrpcInvoker grpcInvoker = new GrpcInvoker(channelManager, retryHandler);
@@ -139,6 +139,17 @@ public abstract class GrpcRoutingPlace extends ServiceProviderPlace implements I
             return RETRY_GRPC_CODES.contains(e.getStatus().getCode());
         }
         return t instanceof PoolException;
+    }
+
+    /**
+     * Determines if the {@link RetryHandler} should try again when a given result is returned during gRPC invocation.
+     * Default behavior always returns {@code false}. Subclasses may override this behavior.
+     *
+     * @param response the response object to check
+     * @return {@code true} if the {@link RetryHandler} should try again, otherwise {@code false}
+     */
+    protected boolean retryOnResult(Object response) {
+        return false;
     }
 
     /**

--- a/src/main/java/emissary/grpc/retry/RetryHandler.java
+++ b/src/main/java/emissary/grpc/retry/RetryHandler.java
@@ -77,7 +77,8 @@ public final class RetryHandler {
      * @param retryName unique name to internally identify the retry policy
      * @param retryOnException a function that takes a Throwable and determines if it should trigger a retry
      */
-    public RetryHandler(Configurator configG, String retryName, Predicate<Throwable> retryOnException) {
+    public RetryHandler(Configurator configG, String retryName,
+            Predicate<Throwable> retryOnException, Predicate<Object> retryOnResult) {
         internalName = retryName;
         maxAttempts = configG.findIntEntry(GRPC_RETRY_MAX_ATTEMPTS, 4);
         numFailsBeforeWarn = configG.findIntEntry(GRPC_RETRY_NUM_FAILS_BEFORE_WARN, 3);
@@ -89,6 +90,7 @@ public final class RetryHandler {
                         configG.findDoubleEntry(GRPC_RETRY_MULTIPLIER, 2.0),
                         configG.findLongEntry(GRPC_RETRY_MAX_WAIT_MILLIS, 1000)))
                 .retryOnException(retryOnException)
+                .retryOnResult(retryOnResult)
                 .build());
 
         retry.getEventPublisher()

--- a/src/main/java/emissary/grpc/sample/GrpcSamplePlace.java
+++ b/src/main/java/emissary/grpc/sample/GrpcSamplePlace.java
@@ -29,6 +29,15 @@ public class GrpcSamplePlace extends GrpcRoutingPlace {
         super(configs);
     }
 
+    @Override
+    protected boolean retryOnResult(Object response) {
+        if (response instanceof SampleResponse) {
+            ByteString result = ((SampleResponse) response).getResult();
+            return new String(result.toByteArray()).equals("retry");
+        }
+        return false;
+    }
+
     protected SampleRequest generateRequest(IBaseDataObject o) {
         return SampleRequest.newBuilder()
                 .setQuery(ByteString.copyFrom(o.data()))

--- a/src/test/java/emissary/grpc/sample/GrpcSamplePlaceTest.java
+++ b/src/test/java/emissary/grpc/sample/GrpcSamplePlaceTest.java
@@ -352,6 +352,23 @@ class GrpcSamplePlaceTest extends UnitTest {
                 assertTrue(1 >= baselineCounter.get());
             }
         }
+
+        @Test
+        void testRetryResponse() {
+            byte[] retryMessage = "retry".getBytes();
+            byte[] baselineMessage = "baseline".getBytes();
+            try (GrpcSampleServer serverOne = GrpcSampleServer.countTries(ByteString.copyFrom(retryMessage), retryCounter);
+                    GrpcSampleServer serverTwo = GrpcSampleServer.countTries(ByteString.copyFrom(baselineMessage), baselineCounter)) {
+
+                startPlaceWithEndpoints(serverOne, serverTwo, retryConfigs);
+                process(place, o);
+
+                assertArrayEquals(retryMessage, o.getAlternateView(ENDPOINT_1));
+                assertArrayEquals(baselineMessage, o.getAlternateView(ENDPOINT_2));
+                assertEquals(5, retryCounter.get());
+                assertEquals(1, baselineCounter.get());
+            }
+        }
     }
 
     @Nested

--- a/src/test/java/emissary/grpc/sample/GrpcSampleServer.java
+++ b/src/test/java/emissary/grpc/sample/GrpcSampleServer.java
@@ -105,6 +105,13 @@ public class GrpcSampleServer implements AutoCloseable {
         });
     }
 
+    public static GrpcSampleServer countTries(ByteString message, AtomicInteger counter) {
+        return GrpcSampleServer.of(request -> {
+            counter.incrementAndGet();
+            return message;
+        });
+    }
+
     @Override
     public void close() {
         server.shutdownNow();


### PR DESCRIPTION
Sometimes a gRPC service may run into issues and return something bad, without actually throwing an exception. This PR gives us the option to retry in this scenario.