### PR TITLE
magic :: bug fixes

### DIFF
--- a/src/main/java/emissary/util/UnixFile.java
+++ b/src/main/java/emissary/util/UnixFile.java
@@ -9,17 +9,17 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Behaves like the UNIX file command. Magic number entries are loaded from one or more magic configuration files and
+ * samples are evaluated against them, falling back to a simple ASCII or binary test when nothing matches.
+ */
 public class UnixFile {
 
     private static final Logger log = LoggerFactory.getLogger(UnixFile.class);
 
-    /** The magic number configuration file. The file which contains all magic number entries */
-    private final List<File> magicFiles = new ArrayList<>();
-
-    /** The Magic number helper class */
+    /** The magic number helper class */
     private final MagicNumberUtil util = new MagicNumberUtil();
 
     /** The Binary file type description */
@@ -38,7 +38,7 @@ public class UnixFile {
      * @param magicFile the <code>File</code> containing magic number entries
      */
     public UnixFile(File magicFile) throws IOException {
-        new UnixFile(magicFile, false);
+        this(magicFile, false);
     }
 
     /**
@@ -53,7 +53,6 @@ public class UnixFile {
             throw new IllegalArgumentException("Magic file not found at: " + magicFile.getAbsolutePath());
         }
 
-        this.magicFiles.add(magicFile);
         util.load(magicFile, swallowParseException);
     }
 
@@ -63,12 +62,12 @@ public class UnixFile {
      * @param magicPaths the String names of magic files to load
      */
     public UnixFile(List<String> magicPaths) throws IOException {
-        new UnixFile(magicPaths, false);
+        this(magicPaths, false);
     }
 
     /**
      * Load multiple magic files into one identification engine
-     * 
+     *
      * @param magicPaths the String names of magic files to load
      * @param swallowParseException should we swallow Ignorable ParseException or bubble them up
      */
@@ -78,11 +77,9 @@ public class UnixFile {
             if (!mFile.exists() || !mFile.canRead()) {
                 throw new IllegalArgumentException("Magic file not found at " + mFile.getAbsolutePath());
             }
-            this.magicFiles.add(mFile);
             util.load(mFile, swallowParseException);
         }
     }
-
 
     public int magicEntryCount() {
         return util.size();
@@ -90,9 +87,11 @@ public class UnixFile {
 
     /**
      * Behaves just like the UNIX file command. First performs a magic number test, then an ascii or binary file test. This
-     * is also the same as calling <code>evaluateByMagicNumber (bytes :
-     * byte[])</code> and then calling <code>evaluateBinaryProperty
-     * (bytes : byte[])</code>
+     * is also the same as calling {@link #evaluateByMagicNumber(byte[])} and then calling
+     * {@link #evaluateBinaryProperty(byte[])}.
+     *
+     * @param bytes the data to identify
+     * @return the identified description or null when no entry matched and the data is not empty
      */
     public String execute(@Nullable byte[] bytes) throws IOException {
         if (bytes == null || bytes.length < 1) {
@@ -109,8 +108,11 @@ public class UnixFile {
     }
 
     /**
-     * Statically tests a byte array to determine if the file representation can be of type ASCII or is binary. Simply
-     * checks each byte value to be less then greater/equal then 127.
+     * Statically tests a byte array to determine if the file representation can be of type ASCII or is binary. Any byte
+     * value below 32 marks the data as binary.
+     *
+     * @param bytes the data to test
+     * @return the empty, binary or ascii file type description
      */
     public static String evaluateBinaryProperty(@Nullable byte[] bytes) {
         if (bytes == null || bytes.length < 1) {
@@ -127,6 +129,9 @@ public class UnixFile {
 
     /**
      * Evaluates the byte array against the collection of Magic numbers
+     *
+     * @param bytes the data to identify
+     * @return the matching description or null when no entry matched
      */
     public String evaluateByMagicNumber(byte[] bytes) throws IOException {
         return util.describe(bytes);

--- a/src/main/java/emissary/util/magic/MagicDataType.java
+++ b/src/main/java/emissary/util/magic/MagicDataType.java
@@ -1,0 +1,153 @@
+package emissary.util.magic;
+
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Represents the different data types you can find in a "magic number" configuration file (like BYTE, SHORT, STRING,
+ * etc.). Each type defines what it's called in config files, how many bytes it takes up, and whether it reads numbers
+ * from left-to-right (big-endian) or right-to-left (little-endian). Date types are kept so old files can still load,
+ * but they aren't actively parsed.
+ */
+public enum MagicDataType {
+
+    /** A single regular byte of data. */
+    BYTE("BYTE", 0, 1),
+
+    /** A 2-byte number, read with the biggest part first. */
+    SHORT("SHORT", 1, 2),
+
+    /** A 4-byte number, read with the biggest part first. */
+    LONG("LONG", 2, 4),
+
+    /** A chunk of text whose size depends on what is written in the file. */
+    STRING("STRING", 3, -1),
+
+    /** A 4-byte date stamp, stored little-endian, but skipped by the parser. */
+    DATE("DATE", 4, 4, false, false),
+
+    /** A 2-byte big-endian number. */
+    BESHORT("BESHORT", 5, 2),
+
+    /** A 4-byte big-endian number. */
+    BELONG("BELONG", 6, 4),
+
+    /** A 4-byte big-endian date stamp, skipped by the parser. */
+    BEDATE("BEDATE", 7, 4, true, false),
+
+    /** A 2-byte little-endian number (smallest part first). */
+    LESHORT("LESHORT", 8, 2, false, true),
+
+    /** A 4-byte little-endian number (smallest part first). */
+    LELONG("LELONG", 9, 4, false, true),
+
+    /** A 4-byte little-endian date stamp, skipped by the parser. */
+    LEDATE("LEDATE", 10, 4, false, false);
+
+    /** The name of the type as written in the config file (e.g., BESHORT). */
+    private final String key;
+
+    /**
+     * An old numeric ID kept around so legacy code doesn't break. New code should use the enum names instead of these
+     * numbers.
+     */
+    private final int legacyId;
+
+    /** How many bytes this type reads at once, or -1 if the size is variable. */
+    private final int fixedByteLength;
+
+    /** True if multi-byte numbers are read with the most significant byte first. */
+    private final boolean bigEndian;
+
+    /** True if the parser knows how to handle this type. */
+    private final boolean supported;
+
+    /**
+     * Sets up a standard data type, automatically assuming it reads big-endian numbers and is fully supported by the
+     * parser.
+     *
+     * @param key the text name used in configuration files
+     * @param legacyId the old-school identification number for backward compatibility
+     * @param fixedByteLength the exact number of bytes this type occupies, or -1 if it varies
+     */
+    MagicDataType(String key, int legacyId, int fixedByteLength) {
+        this(key, legacyId, fixedByteLength, true, true);
+    }
+
+    /**
+     * Sets up a data type with full custom controls over its byte-reading order and whether the parser currently supports
+     * it.
+     *
+     * @param key the text name used in configuration files
+     * @param legacyId the old-school identification number for backward compatibility
+     * @param fixedByteLength the exact number of bytes this type occupies, or -1 if it varies
+     * @param bigEndian true if numbers are read biggest-part-first, or false for smallest-part-first
+     * @param supported true if the parser is ready to evaluate this type, or false if it should be skipped
+     */
+    MagicDataType(String key, int legacyId, int fixedByteLength, boolean bigEndian, boolean supported) {
+        this.key = key;
+        this.legacyId = legacyId;
+        this.fixedByteLength = fixedByteLength;
+        this.bigEndian = bigEndian;
+        this.supported = supported;
+    }
+
+    /** Returns the configuration text name for this type (e.g., "BESHORT"). */
+    public String getKey() {
+        return key;
+    }
+
+    /** Returns the old-school numeric ID for backwards compatibility. */
+    public int getLegacyId() {
+        return legacyId;
+    }
+
+    /** Returns how many bytes this type takes up, or -1 if it's variable. */
+    public int getFixedByteLength() {
+        return fixedByteLength;
+    }
+
+    /** Checks if this type reads bytes biggest-first. */
+    public boolean isBigEndian() {
+        return bigEndian;
+    }
+
+    /** Checks if the parser actually supports handling this type right now. */
+    public boolean isSupported() {
+        return supported;
+    }
+
+    /**
+     * Finds a data type using its text name (case-insensitive).
+     *
+     * @param key the name of the type (e.g., "leshort")
+     * @return the matching type, if found
+     */
+    public static Optional<MagicDataType> fromKey(String key) {
+        if (key == null) {
+            return Optional.empty();
+        }
+        String upperKey = key.toUpperCase(Locale.ROOT);
+        for (MagicDataType type : values()) {
+            if (type.key.equals(upperKey)) {
+                return Optional.of(type);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Finds a data type using its old numeric ID.
+     *
+     * @param legacyId the old ID number
+     * @return the matching type, if found
+     */
+    public static Optional<MagicDataType> fromLegacyId(int legacyId) {
+        for (MagicDataType type : values()) {
+            if (type.legacyId == legacyId) {
+                return Optional.of(type);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/emissary/util/magic/MagicMath.java
+++ b/src/main/java/emissary/util/magic/MagicMath.java
@@ -26,8 +26,8 @@ public class MagicMath {
             "The new byte array length must fit the existing value.";
 
     /**
-     * Turns each byte into a signed decimal represented in hex format, starting with {@code 0x}. Note: This is meant as a
-     * quick debugging helper rather than strict standard hex formatting.
+     * Turns each byte into a properly formatted hexadecimal string, starting with {@code 0x}. Each byte is written as two
+     * lowercase hex digits.
      *
      * @param b the bytes to convert
      * @return the formatted string representation
@@ -38,7 +38,7 @@ public class MagicMath {
             if (i == 0) {
                 sb.append(HEX_PREFIX);
             }
-            sb.append(Integer.toString((int) b[i], 16));
+            sb.append(String.format("%02x", b[i] & 0xFF));
         }
         return sb.toString();
     }
@@ -158,7 +158,7 @@ public class MagicMath {
             return null;
         }
         if (stringValue.length() > 2 && HEX_PREFIX.equals(stringValue.substring(0, 2))) {
-            return hexStringToByteArray(stringValue);
+            return setLength(hexStringToByteArray(stringValue), arraySize);
         } else {
             return integerToByteArray(arraySize, stringToLong(stringValue));
         }
@@ -277,7 +277,7 @@ public class MagicMath {
             return ZERO;
         }
         byte[] adjustedData = setLength(data, actualSize);
-        BigInteger value = new BigInteger(adjustedData);
+        BigInteger value = new BigInteger(1, adjustedData);
         return value.toString(radix);
     }
 

--- a/src/main/java/emissary/util/magic/MagicMath.java
+++ b/src/main/java/emissary/util/magic/MagicMath.java
@@ -2,49 +2,36 @@ package emissary.util.magic;
 
 import jakarta.annotation.Nullable;
 
+import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.Iterator;
-import java.util.List;
+import java.util.NoSuchElementException;
 
+/**
+ * Utility for the magic number parser. Handles things like decoding escape characters, converting text into fixed-size
+ * byte arrays, formatting bytes into readable text, and flipping endianness.
+ */
 public class MagicMath {
 
-    private static final String EMPTYSTRING = "";
+    /** Prefix used to identify hexadecimal numbers in config entries. */
     public static final String HEX_PREFIX = "0x";
+
     private static final String ZERO = "0";
     private static final String PRE_OCT = "0";
+    private static final char ESCAPE = '\\';
 
-    @SuppressWarnings("NonFinalStaticField")
-    public static int[] literals = new int[] {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 0
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 10
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 20
-            , -1, -1, 32, 33, -1, -1, -1, -1, 38, -1 // 30
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 40
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 70
-            , 60, 61, 62, -1, -1, -1, -1, -1, -1, -1 // 60
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 70
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 80
-            , -1, -1, 92, -1, 94, -1, -1, 97, 98, -1 // 90
-            , -1, -1, 102, -1, -1, -1, -1, -1, -1, -1 // 100
-            , 10, -1, -1, -1, 13, -1, 116, -1, 118, -1 // 110
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 120
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 130
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 140
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 150
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 160
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 170
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 180
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 190
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 200
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 210
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 220
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 230
-            , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 // 240
-            , -1, -1, -1, -1, -1, -1, -1}; // 250
+    /**
+     * Error message used when trying to resize a byte array to be smaller than the actual number inside it.
+     */
+    public static final String BYTEARRAY_PRECISION_ERROR_RULE =
+            "The new byte array length must fit the existing value.";
 
-
+    /**
+     * Turns each byte into a signed decimal represented in hex format, starting with {@code 0x}. Note: This is meant as a
+     * quick debugging helper rather than strict standard hex formatting.
+     *
+     * @param b the bytes to convert
+     * @return the formatted string representation
+     */
     public static String byteArrayToHexString(byte[] b) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < b.length; i++) {
@@ -56,54 +43,97 @@ public class MagicMath {
         return sb.toString();
     }
 
+    /**
+     * Decodes slash-escape sequences inside a magic entry string into raw bytes. How it works:
+     *
+     * <ul>
+     * <li>A slash followed by nothing: treats it as a space and stops.</li>
+     * <li>A slash followed by a special character (like newline): maps it to its intended byte value.</li>
+     * <li>A slash followed by up to three numbers: treats them as octal (e.g., \101 becomes 'A').</li>
+     * <li>\x followed by two characters: treats them as hex (e.g., \xCA).</li>
+     * </ul>
+     *
+     * Note that unlike standard programming languages, letters like \a, \b, \f, and \t just turn into the literal letters
+     * themselves rather than special control codes. Unknown escapes (like \q) just drop the slash and keep the letter.
+     * Running out of data mid-sequence will throw an error.
+     *
+     * @param s the text containing escape sequences
+     * @return the decoded raw bytes
+     */
     public static byte[] parseEscapedString(String s) {
-        List<Number> array = new ArrayList<>();
-        Deque<Character> chars = new ArrayDeque<>();
-        for (int i = s.length() - 1; i >= 0; i--) {
-            chars.push(s.charAt(i));
-        }
-        while (!chars.isEmpty()) {
-            Character c = chars.pop();
-            String val = EMPTYSTRING;
-            if (c == '\\') {
-                if (chars.isEmpty()) {
-                    array.add(32);
-                    break;
-                }
-                Character next = chars.peek();
-                if (literals[next] > 0) {
-                    array.add(literals[next]);
-                    chars.pop();
-                } else if (Character.isDigit(next)) {
-                    int max = 3;
-                    while (!chars.isEmpty() && Character.isDigit(next) && max-- > 0) {
-                        val += chars.pop();
-                        if (!chars.isEmpty()) {
-                            next = chars.peek();
-                        }
-                    }
-                    array.add(new BigInteger(val, 8));
-                    val = EMPTYSTRING;
-                } else if (next == 'x') {
-                    chars.pop(); // pop the hex symbol
-                    val += chars.pop();
-                    val += chars.pop();
-                    array.add(new BigInteger(val, 16));
-                    val = EMPTYSTRING;
-                }
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int i = 0;
+        while (i < s.length()) {
+            char c = s.charAt(i++);
+            if (c != ESCAPE) {
+                out.write(c);
                 continue;
             }
-            array.add((int) c);
+            if (i >= s.length()) {
+                out.write(' ');
+                break;
+            }
+            char next = s.charAt(i);
+            int literal = escapeLiteralValue(next);
+            if (literal > 0) {
+                out.write(literal);
+                i++;
+            } else if (Character.isDigit(next)) {
+                int start = i;
+                int end = Math.min(s.length(), start + 3);
+                while (i < end && Character.isDigit(s.charAt(i))) {
+                    i++;
+                }
+                out.write(new BigInteger(s.substring(start, i), 8).byteValue());
+            } else if (next == 'x') {
+                if ((s.length() - (i + 1)) < 2) {
+                    throw new NoSuchElementException();
+                }
+                out.write(new BigInteger(s.substring(i + 1, i + 3), 16).byteValue());
+                i += 3;
+            } else {
+                // Unknown escape: drop the backslash only, keeping the character as-is
+            }
         }
-        byte[] bytes = new byte[array.size()];
-        Iterator<Number> iter = array.iterator();
-        for (int i = 0; i < bytes.length; i++) {
-            Number num = iter.next();
-            bytes[i] = num.byteValue();
-        }
-        return bytes;
+        return out.toByteArray();
     }
 
+    /**
+     * Checks if a character right after a backslash matches a known literal escape value. Returns -1 if it's not a
+     * recognized special code.
+     */
+    private static int escapeLiteralValue(char c) {
+        switch (c) {
+            case ' ':
+            case '!':
+            case '&':
+            case '<':
+            case '=':
+            case '>':
+            case '\\':
+            case '^':
+            case 'a':
+            case 'b':
+            case 'f':
+            case 't':
+            case 'v':
+                return c;
+            case 'n':
+                return '\n';
+            case 'r':
+                return '\r';
+            default:
+                return -1;
+        }
+    }
+
+    /**
+     * Converts a text number (written in hex starting with 0x, octal starting with 0, or regular decimal) into a compact
+     * byte array.
+     *
+     * @param s the numeric text
+     * @return the value packed into a minimal byte array
+     */
     public static byte[] stringToByteArray(String s) {
         if (s.startsWith(HEX_PREFIX)) {
             return hexStringToByteArray(s);
@@ -114,6 +144,14 @@ public class MagicMath {
         }
     }
 
+    /**
+     * Converts a number into a strict, fixed-size byte array (big-endian). Hex values need the 0x prefix; others are read
+     * as octal if they start with zero, or decimal otherwise.
+     *
+     * @param arraySize the exact output size needed
+     * @param stringValue the numeric text (can be null)
+     * @return the fixed-size byte array, or null if no text was provided
+     */
     @Nullable
     public static byte[] stringToByteArray(int arraySize, @Nullable String stringValue) {
         if (stringValue == null || stringValue.length() == 0) {
@@ -126,17 +164,132 @@ public class MagicMath {
         }
     }
 
+    /**
+     * Converts octal text into a byte array. Large values automatically add an extra leading zero byte to handle
+     * positive/negative signs correctly.
+     *
+     * @param s the octal string
+     * @return the resulting byte array
+     */
     public static byte[] octalStringToByteArray(String s) {
         String sub = s.startsWith(PRE_OCT) ? s.substring(1) : s;
         BigInteger integer = new BigInteger(sub, 8);
         return integer.toByteArray();
     }
 
-    public static final String BYTEARRAY_PRECISION_ERROR_RULE =
-            "The new byte array length must fit the existing value. Such that n*2^8 > valueOf (data[]).";
+    /**
+     * Converts regular decimal text into a byte array, ensuring proper sign handling.
+     *
+     * @param s the decimal string
+     * @return the resulting byte array
+     */
+    public static byte[] decimalStringToByteArray(String s) {
+        return new BigInteger(s).toByteArray();
+    }
 
+    /**
+     * Parses a text number (hex, octal, or decimal) into a standard integer.
+     *
+     * @param s the numeric text
+     * @return the parsed integer value
+     */
+    public static int stringToInt(String s) {
+        if (s.startsWith(HEX_PREFIX)) {
+            return new BigInteger(s.substring(2), 16).intValue();
+        } else if (!s.equals("0") && s.startsWith(PRE_OCT)) {
+            return new BigInteger(s.substring(1), 8).intValue();
+        } else {
+            return new BigInteger(s, 10).intValue();
+        }
+    }
+
+    /**
+     * Parses a text number (hex, octal, or decimal) into a long integer.
+     *
+     * @param stringValue the numeric text
+     * @return the parsed long value
+     */
+    public static long stringToLong(String stringValue) {
+        if (stringValue.length() > 2 && HEX_PREFIX.equals(stringValue.substring(0, 2))) {
+            return Long.parseLong(stringValue.substring(2), 16);
+        } else if (stringValue.length() > 1 && stringValue.charAt(0) == '0') {
+            return Long.parseLong(stringValue.substring(1), 8);
+        } else {
+            return Long.parseLong(stringValue, 10);
+        }
+    }
+
+    /**
+     * Packs a long integer into a fixed-size big-endian byte array, cutting off extra bytes if it's too big to fit.
+     *
+     * @param arraySize the exact output size
+     * @param integerValue the number to pack
+     * @return the resulting byte array
+     */
+    public static byte[] integerToByteArray(int arraySize, long integerValue) {
+        byte[] valueBytes = new byte[arraySize];
+        for (int i = 0; i < arraySize; i++) {
+            valueBytes[arraySize - i - 1] = (byte) (integerValue >>> (i * 8) & 0xff);
+        }
+        return valueBytes;
+    }
+
+    /**
+     * Converts hex text into raw bytes. Odd lengths get a leading zero added automatically.
+     *
+     * @param s the hex text
+     * @return the decoded bytes
+     */
+    public static byte[] hexStringToByteArray(String s) {
+        String subject = s;
+        if (subject.startsWith(HEX_PREFIX)) {
+            subject = subject.substring(2);
+        }
+        if (subject.length() % 2 != 0) {
+            subject = ZERO + subject;
+        }
+        byte[] array = new byte[subject.length() / 2];
+        for (int i = 0; i < array.length; i++) {
+            int b = Integer.parseInt(subject.substring(i * 2, i * 2 + 2), 16);
+            array[i] = (byte) (0xff & b);
+        }
+        return array;
+    }
+
+    /**
+     * Formats a byte array into a decimal number string using a specific number base (radix). Trims leading empty bytes
+     * first; if everything is zero, it just returns "0".
+     *
+     * @param data the byte array
+     * @param radix the number base (e.g., 10 for decimal, 16 for hex)
+     * @return the string representation
+     */
+    public static String byteArrayToString(byte[] data, int radix) {
+        int actualSize = data.length;
+        for (int i = 0; i < data.length; i++) {
+            if (data[i] == 0) {
+                actualSize--;
+            } else {
+                break;
+            }
+        }
+        if (actualSize == 0) {
+            return ZERO;
+        }
+        byte[] adjustedData = setLength(data, actualSize);
+        BigInteger value = new BigInteger(adjustedData);
+        return value.toString(radix);
+    }
+
+    /**
+     * Resizes a byte array to a new length while keeping the data right-aligned (so the smallest part stays at the end).
+     * Throws an error if you try to shrink it smaller than what the number actually requires.
+     *
+     * @param data the original byte array
+     * @param length the target size
+     * @return the resized array
+     */
     public static byte[] setLength(byte[] data, int length) {
-
         int actualSize = data.length;
         for (int i = 0; i < data.length; i++) {
             if (data[i] == 0) {
@@ -167,109 +320,13 @@ public class MagicMath {
         return newValues;
     }
 
-    public static byte[] mask(byte[] data, byte[] maskValues) {
-        byte[] target = new byte[data.length];
-        for (int i = 0; i < data.length; i++) {
-            target[i] = (byte) (data[i] & maskValues[i]);
-        }
-        return target;
-    }
-
-    public static byte[] hexStringToByteArray(String s) {
-        String subject = s;
-        if (subject.startsWith(HEX_PREFIX)) {
-            subject = subject.substring(2);
-        }
-        if (subject.length() % 2 != 0) {
-            subject = ZERO + subject;
-        }
-        byte[] array = new byte[subject.length() / 2];
-        for (int i = 0; i < array.length; i++) {
-            int b = Integer.parseInt(subject.substring(i * 2, i * 2 + 2), 16);
-            array[i] = (byte) (0xff & b);
-        }
-        return array;
-    }
-
-    public static byte[] decimalStringToByteArray(String s) {
-        return new BigInteger(s).toByteArray();
-    }
-
-    public static int stringToInt(String s) {
-        if (s.startsWith(HEX_PREFIX)) {
-            return new BigInteger(s.substring(2), 16).intValue();
-        } else if (!s.equals("0") && s.startsWith(PRE_OCT)) {
-            return new BigInteger(s.substring(1), 8).intValue();
-        } else {
-            return new BigInteger(s, 10).intValue();
-        }
-    }
-
-
-    public static byte[] integerToByteArray(int arraySize, long integerValue) {
-        byte[] valueBytes = new byte[arraySize];
-        for (int i = 0; i < arraySize; i++) {
-            valueBytes[arraySize - i - 1] = (byte) (integerValue >>> (i * 8) & 0xff);
-        }
-        return valueBytes;
-    }
-
-    public static long stringToLong(String stringValue) {
-        if (stringValue.length() > 2 && HEX_PREFIX.equals(stringValue.substring(0, 2))) {
-            return Long.parseLong(stringValue.substring(2), 16);
-        } else if (stringValue.length() > 1 && stringValue.charAt(0) == '0') {
-            return Long.parseLong(stringValue.substring(1), 8);
-        } else {
-            return Long.parseLong(stringValue, 10);
-        }
-    }
-
-
-    public static String byteArrayToString(byte[] bytes) {
-        StringBuilder sb = new StringBuilder("[");
-        for (int i = 0; i < bytes.length; i++) {
-            if (i != 0) {
-                sb.append(", ");
-            }
-            sb.append(Byte.toString(bytes[i]));
-        }
-        return sb.toString();
-    }
-
-    public static String byteArrayToString(byte[] data, int radix) {
-        int actualSize = data.length;
-        for (int i = 0; i < data.length; i++) {
-            if (data[i] == 0) {
-                actualSize--;
-            } else {
-                break;
-            }
-        }
-        if (actualSize == 0) {
-            return ZERO;
-        }
-        byte[] adjustedData = setLength(data, actualSize);
-        BigInteger value = new BigInteger(adjustedData);
-        return value.toString(radix);
-    }
-
-
-    public static long byteArrayToLong(byte[] data) {
-        int actualSize = data.length;
-        for (int i = 0; i < data.length; i++) {
-            if (data[i] == 0) {
-                actualSize--;
-            } else {
-                break;
-            }
-        }
-        byte[] adjustedData = setLength(data, actualSize);
-        BigInteger value = new BigInteger(adjustedData);
-        return value.longValue();
-    }
-
+    /**
+     * Swaps 4 bytes right at the given position to flip a number from big-endian to little-endian (done in-place).
+     *
+     * @param array the byte array to modify
+     * @param offset the starting position of the 4-byte chunk
+     */
     public static void longEndianSwap(byte[] array, int offset) {
-
         if (array.length < (offset + 4)) {
             throw new ArrayIndexOutOfBoundsException(array.length + 1);
         }
@@ -279,19 +336,23 @@ public class MagicMath {
         t = array[offset + 1];
         array[offset + 1] = array[offset + 2];
         array[offset + 2] = t;
-
     }
 
+    /**
+     * Swaps 2 bytes right at the given position to flip a short number's endianness (done in-place).
+     *
+     * @param array the byte array to modify
+     * @param offset the starting position of the 2-byte chunk
+     */
     public static void shortEndianSwap(byte[] array, int offset) {
         if (array.length < (offset + 2)) {
             throw new ArrayIndexOutOfBoundsException(array.length + 1);
         }
-
         byte t = array[offset];
         array[offset] = array[offset + 1];
         array[offset + 1] = t;
     }
 
-    /** This class is not meant to be instantiated. */
+    /** Utility class; prevent direct instantiation. */
     private MagicMath() {}
 }

--- a/src/main/java/emissary/util/magic/MagicNumber.java
+++ b/src/main/java/emissary/util/magic/MagicNumber.java
@@ -268,7 +268,12 @@ public class MagicNumber {
             if (!chars.isEmpty() && next == '%') {
                 char subType = chars.poll();
                 if (dataType == MagicDataType.STRING) {
-                    if (offset < (data.length - 2)) {
+                    if (subType == 'd' || subType == 'l') {
+                        byte[] subData = extractElement(data, offset, dataTypeLength);
+                        if (subData != null) {
+                            sb.append(MagicMath.byteArrayToString(subData, 10));
+                        }
+                    } else if (offset < data.length) {
                         String sub = new String(Objects.requireNonNull(extractElement(data, offset, 1)), DEFAULT_CHARSET);
                         sb.append(sub);
                     }
@@ -378,7 +383,7 @@ public class MagicNumber {
         if (data == null) {
             return null;
         }
-        if (data.length < (offset + length)) {
+        if (offset < 0 || data.length < (offset + length)) {
             return null;
         }
         byte[] subject = new byte[length];

--- a/src/main/java/emissary/util/magic/MagicNumber.java
+++ b/src/main/java/emissary/util/magic/MagicNumber.java
@@ -13,60 +13,97 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
 
+/**
+ * Represents a single matching rule from a file-type configuration file (magic file), along with any sub-rules
+ * (continuations) that follow it.
+ *
+ * <ul>
+ * <li>Column A: How deep the rule is nested and where in the file to look (e.g., {@code >&4})</li>
+ * <li>Column B: The data type to read, optionally with a bit mask (e.g., {@code belong&0xff000000})</li>
+ * <li>Column C: The comparison check and expected value (e.g., {@code >0xCAFEBABE})</li>
+ * <li>Column D: The text description to output, which can include dynamic value placeholders like {@code %d}</li>
+ * </ul>
+ */
 public class MagicNumber {
 
     private static final Logger log = LoggerFactory.getLogger(MagicNumber.class);
 
-    /** The default charset used when loading the config file and when sampling data */
+    /** The default text encoding (charset) used when reading config files and checking data. */
     public static final Charset DEFAULT_CHARSET = StandardCharsets.ISO_8859_1;
-    /** Byte data type */
-    public static final String TYPE_KEY_BYTE = "BYTE"; //
-    /** Short data type */
-    public static final String TYPE_KEY_SHORT = "SHORT"; //
-    /** Long data type */
-    public static final String TYPE_KEY_LONG = "LONG"; //
-    /** String data type */
-    public static final String TYPE_KEY_STRING = "STRING"; //
-    /** Date data type */
-    public static final String TYPE_KEY_DATE = "DATE"; // long integer - seconds since epoch
-    /** Big endian short data type */
-    public static final String TYPE_KEY_BESHORT = "BESHORT"; // big-endian 16-bit
-    /** Big endian long data type */
-    public static final String TYPE_KEY_BELONG = "BELONG"; // big-endian 32-bit
-    /** Big endian date data type */
-    public static final String TYPE_KEY_BEDATE = "BEDATE"; // big-endian 32-bit date
-    /** Little endian short data type */
-    public static final String TYPE_KEY_LESHORT = "LESHORT"; // little-end 16-bit
-    /** Little endian long data type */
-    public static final String TYPE_KEY_LELONG = "LELONG"; // little-end 32-bit
-    /** Little endian long data type */
-    public static final String TYPE_KEY_LEDATE = "LEDATE"; // little-end 32-bit date
 
-    /** Unknown data type id */
+    /** @deprecated use {@code MagicDataType.BYTE.getKey()} */
+    @Deprecated
+    public static final String TYPE_KEY_BYTE = MagicDataType.BYTE.getKey();
+    /** @deprecated use {@code MagicDataType.SHORT.getKey()} */
+    @Deprecated
+    public static final String TYPE_KEY_SHORT = MagicDataType.SHORT.getKey();
+    /** @deprecated use {@code MagicDataType.LONG.getKey()} */
+    @Deprecated
+    public static final String TYPE_KEY_LONG = MagicDataType.LONG.getKey();
+    /** @deprecated use {@code MagicDataType.STRING.getKey()} */
+    @Deprecated
+    public static final String TYPE_KEY_STRING = MagicDataType.STRING.getKey();
+    /** @deprecated use {@code MagicDataType.DATE.getKey()} */
+    @Deprecated
+    public static final String TYPE_KEY_DATE = MagicDataType.DATE.getKey();
+    /** @deprecated use {@code MagicDataType.BESHORT.getKey()} */
+    @Deprecated
+    public static final String TYPE_KEY_BESHORT = MagicDataType.BESHORT.getKey();
+    /** @deprecated use {@code MagicDataType.BELONG.getKey()} */
+    @Deprecated
+    public static final String TYPE_KEY_BELONG = MagicDataType.BELONG.getKey();
+    /** @deprecated use {@code MagicDataType.BEDATE.getKey()} */
+    @Deprecated
+    public static final String TYPE_KEY_BEDATE = MagicDataType.BEDATE.getKey();
+    /** @deprecated use {@code MagicDataType.LESHORT.getKey()} */
+    @Deprecated
+    public static final String TYPE_KEY_LESHORT = MagicDataType.LESHORT.getKey();
+    /** @deprecated use {@code MagicDataType.LELONG.getKey()} */
+    @Deprecated
+    public static final String TYPE_KEY_LELONG = MagicDataType.LELONG.getKey();
+    /** @deprecated use {@code MagicDataType.LEDATE.getKey()} */
+    @Deprecated
+    public static final String TYPE_KEY_LEDATE = MagicDataType.LEDATE.getKey();
+
+    /** @deprecated use {@link MagicDataType#fromLegacyId(int)} */
+    @Deprecated
     public static final int TYPE_UNKNOWN = -1;
-    /** Byte data type id */
-    public static final int TYPE_BYTE = 0;
-    /** Short data type id */
-    public static final int TYPE_SHORT = 1;
-    /** Long data type id */
-    public static final int TYPE_LONG = 2;
-    /** String data type id */
-    public static final int TYPE_STRING = 3;
-    /** Date data type id */
-    public static final int TYPE_DATE = 4;
-    /** Big endian short data type id */
-    public static final int TYPE_BESHORT = 5;
-    /** Big endian long data type id */
-    public static final int TYPE_BELONG = 6;
-    /** Big endian date data type id */
-    public static final int TYPE_BEDATE = 7;
-    /** Little endian short data type id */
-    public static final int TYPE_LESHORT = 8;
-    /** Little endian long data type id */
-    public static final int TYPE_LELONG = 9;
-    /** Little endian date data type id */
-    public static final int TYPE_LEDATE = 10;
-    /** Empty string constant */
+    /** @deprecated use {@link MagicDataType#BYTE} */
+    @Deprecated
+    public static final int TYPE_BYTE = MagicDataType.BYTE.getLegacyId();
+    /** @deprecated use {@link MagicDataType#SHORT} */
+    @Deprecated
+    public static final int TYPE_SHORT = MagicDataType.SHORT.getLegacyId();
+    /** @deprecated use {@link MagicDataType#LONG} */
+    @Deprecated
+    public static final int TYPE_LONG = MagicDataType.LONG.getLegacyId();
+    /** @deprecated use {@link MagicDataType#STRING} */
+    @Deprecated
+    public static final int TYPE_STRING = MagicDataType.STRING.getLegacyId();
+    /** @deprecated use {@link MagicDataType#DATE} */
+    @Deprecated
+    public static final int TYPE_DATE = MagicDataType.DATE.getLegacyId();
+    /** @deprecated use {@link MagicDataType#BESHORT} */
+    @Deprecated
+    public static final int TYPE_BESHORT = MagicDataType.BESHORT.getLegacyId();
+    /** @deprecated use {@link MagicDataType#BELONG} */
+    @Deprecated
+    public static final int TYPE_BELONG = MagicDataType.BELONG.getLegacyId();
+    /** @deprecated use {@link MagicDataType#BEDATE} */
+    @Deprecated
+    public static final int TYPE_BEDATE = MagicDataType.BEDATE.getLegacyId();
+    /** @deprecated use {@link MagicDataType#LESHORT} */
+    @Deprecated
+    public static final int TYPE_LESHORT = MagicDataType.LESHORT.getLegacyId();
+    /** @deprecated use {@link MagicDataType#LELONG} */
+    @Deprecated
+    public static final int TYPE_LELONG = MagicDataType.LELONG.getLegacyId();
+    /** @deprecated use {@link MagicDataType#LEDATE} */
+    @Deprecated
+    public static final int TYPE_LEDATE = MagicDataType.LEDATE.getLegacyId();
+
+    /** @deprecated use a plain string literal */
+    @Deprecated
     public static final String EMPTYSTRING = "";
 
     /** Unary Operator: Equals */
@@ -92,41 +129,82 @@ public class MagicNumber {
 
 
     // Column A Properties
-    protected int depth;
-    protected int offset = -1;
-    protected char offsetUnary = 0;
+    private final int depth;
+    private final int offset;
+    private final char offsetUnary;
 
     // Column B Properties
-    protected int dataType = -1;
-    protected int dataTypeLength = 0;
-    protected byte[] mask;
-    protected boolean signedValue;
+    private final MagicDataType dataType;
+    private final int dataTypeLength;
+    @Nullable
+    private final byte[] mask;
 
     // Column C Properties
-    protected char unaryOperator;
+    private final char unaryOperator;
     @Nullable
-    protected byte[] value = null;
-    protected boolean substitute = false;
+    private final byte[] value;
+    private final boolean substitute;
 
     // Column D Properties
     @Nullable
-    protected String description = null;
+    private final String description;
 
-    // Magic Number Properties
-    protected List<MagicNumber[]> dependencies;
+    private final List<List<MagicNumber>> dependencyLayers = new ArrayList<>();
 
     /**
-     * Recreates the string entry for this magic number plus its child continuations under new lines preceded by a '&gt;'
-     * character at the appropriate depth.
+     * Creates a fully specified rule. Intended to be called exclusively by the factory while parsing config files.
      *
-     * @return String
+     * @param depth how deeply nested this rule is (from column A)
+     * @param offset where to look in the file bytes (from column A)
+     * @param offsetUnary the relative offset symbol, or 0 if none
+     * @param dataType the data type being checked (from column B)
+     * @param dataTypeLength how many bytes this rule tests
+     * @param mask optional bit mask applied before testing
+     * @param unaryOperator the comparison sign (from column C)
+     * @param value the expected value to check against (from column C)
+     * @param substitute true if column C uses the wildcard 'x' to match anything and insert live values into the
+     *        description
+     * @param description the description text (from column D)
      */
-    public String toStringAll() {
-        return toString(null, 0);
+    MagicNumber(int depth, int offset, char offsetUnary, MagicDataType dataType, int dataTypeLength, @Nullable byte[] mask,
+            char unaryOperator, @Nullable byte[] value, boolean substitute, @Nullable String description) {
+        this.depth = depth;
+        this.offset = offset;
+        this.offsetUnary = offsetUnary;
+        this.dataType = dataType;
+        this.dataTypeLength = dataTypeLength;
+        this.mask = mask;
+        this.unaryOperator = unaryOperator;
+        this.value = value;
+        this.substitute = substitute;
+        this.description = description;
+    }
+
+    public boolean isSubstitute() {
+        return substitute;
     }
 
     /**
-     * Tests the sample and if successful provides the description
+     * Recreates the full config text for this rule plus all of its matching sub-rules
+     *
+     * @return the text representation of this rule and its children
+     */
+    public String toStringAll() {
+        StringBuilder sb = new StringBuilder(Objects.toString(description));
+        for (List<MagicNumber> layer : dependencyLayers) {
+            for (MagicNumber dependentItem : layer) {
+                sb.append('\n');
+                sb.append(dependentItem.toString());
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Tests the input data against this rule. If it matches, returns the description combined with any matching sub-rules.
+     *
+     * @param data the raw file bytes to check
+     * @return the combined description text, or null if the rule doesn't match
      */
     @Nullable
     public String describe(byte[] data) {
@@ -139,7 +217,7 @@ public class MagicNumber {
     }
 
     /**
-     * Private formatting method for escaping backspaces
+     * Processes backspace characters (\b) in the description text, deleting the previous character for each one found.
      */
     private static String escapeBackspace(String desc) {
         StringBuilder s = new StringBuilder();
@@ -157,7 +235,10 @@ public class MagicNumber {
     }
 
     /**
-     * Describe this instance only
+     * Tests this rule on its own, without checking sub-rules.
+     *
+     * @param data the raw file bytes
+     * @return the formatted description, or null if it doesn't match
      */
     @Nullable
     private String describeSelf(byte[] data) {
@@ -168,14 +249,15 @@ public class MagicNumber {
     }
 
     /**
-     * Private method to format output - mainly for description substitutions
+     * Fills in dynamic placeholders (like %d or %s) in the description text using values pulled straight from the file
+     * bytes.
      */
-    private String format(String desc, byte[] data) {
+    private String format(@Nullable String desc, byte[] data) {
 
-        if (!substitute) {
+        if (!substitute || desc == null) {
             return desc;
         }
-        Queue<Character> chars = new ArrayDeque<>();
+        Queue<Character> chars = new ArrayDeque<>(desc.length());
         for (int i = 0; i < desc.length(); i++) {
             chars.add(desc.charAt(i));
         }
@@ -185,14 +267,14 @@ public class MagicNumber {
             Character next = chars.poll();
             if (!chars.isEmpty() && next == '%') {
                 char subType = chars.poll();
-                if (dataType == TYPE_STRING) {
+                if (dataType == MagicDataType.STRING) {
                     if (offset < (data.length - 2)) {
-                        String sub = new String(Objects.requireNonNull(getElement(data, offset, 1)), DEFAULT_CHARSET);
+                        String sub = new String(Objects.requireNonNull(extractElement(data, offset, 1)), DEFAULT_CHARSET);
                         sb.append(sub);
                     }
                 } else if (subType == 'c' || subType == 's') {
 
-                    byte[] subData = getElement(data, offset, dataTypeLength);
+                    byte[] subData = extractElement(data, offset, dataTypeLength);
                     if (subData != null) {
                         String sub = new String(subData, DEFAULT_CHARSET);
                         sb.append(sub);
@@ -200,7 +282,7 @@ public class MagicNumber {
 
                 } else {
 
-                    byte[] subData = getElement(data, offset, dataTypeLength);
+                    byte[] subData = extractElement(data, offset, dataTypeLength);
                     if (subData != null) {
                         String sub = MagicMath.byteArrayToString(subData, 10);
                         sb.append(sub);
@@ -218,18 +300,19 @@ public class MagicNumber {
     }
 
     /**
-     * Tests dependent children
+     * Checks sub-rule layers one level at a time, continuing down the chain as long as at least one rule in the current
+     * layer matches.
      */
     private String describeDependents(byte[] data, StringBuilder sb, int layer) {
         log.debug("DESCRIBING DEPENDENTS at layer {}", layer);
-        if (dependencies == null || layer >= dependencies.size()) {
+        if (layer >= dependencyLayers.size()) {
             log.debug("Not enough dependents for layer {}", layer);
             return sb.toString();
         }
 
         boolean shouldContinue = false;
-        MagicNumber[] dependentItems = dependencies.get(layer);
-        log.debug("Found {} items at layer {}", dependentItems.length, layer);
+        List<MagicNumber> dependentItems = dependencyLayers.get(layer);
+        log.debug("Found {} items at layer {}", dependentItems.size(), layer);
         for (MagicNumber dependentItem : dependentItems) {
             String s = dependentItem.describeSelf(data);
 
@@ -249,121 +332,49 @@ public class MagicNumber {
     }
 
     /**
-     * Tests this magic number against the given data
+     * Checks if the file bytes match what this rule expects at the specified offset.
+     *
+     * @param data the raw file bytes
+     * @return true if the bytes match the rule's criteria
      */
     public boolean test(byte[] data) {
-        byte[] subject = getElement(data, offset, dataTypeLength);
-        if (subject == null) {
-            return false;
-        }
-        return testNumeric(subject);
+        byte[] subject = extractElement(data, offset, dataTypeLength);
+        return subject != null && matches(subject);
     }
 
-    /**
-     * Tests numeric byte data only
-     */
-    private boolean testNumeric(byte[] data) {
+    private boolean matches(byte[] subject) {
         if (substitute) {
             return true;
         }
 
-        if (mask != null && mask.length == data.length) {
-            for (int i = 0; i < data.length; i++) {
-                data[i] = (byte) (data[i] & mask[i]);
-            }
+        applyMask(subject);
+
+        if (dataType == MagicDataType.STRING) {
+            return Arrays.equals(subject, value);
         }
 
-        // Short-circuit instantly for strings
-        if (dataType == TYPE_STRING) {
-            return Arrays.equals(data, value);
-        }
-
-        byte[] mValues = value;
-        if (mValues == null || data.length != mValues.length) {
+        if (value == null || subject.length != value.length) {
             return false;
         }
 
-        int end = mValues.length;
-        boolean isBigEndian = dataType == TYPE_BESHORT || dataType == TYPE_BELONG || dataType == TYPE_BEDATE ||
-                dataType == TYPE_SHORT || dataType == TYPE_LONG || dataType == TYPE_BYTE;
-
         log.debug("Unary Operator: {}", unaryOperator);
+        return MatchOperator.forSymbol(unaryOperator).matches(subject, value, dataType.isBigEndian());
+    }
 
-        switch (unaryOperator) {
-            case MAGICOPERATOR_AND:
-            case MAGICOPERATOR_BWAND:
-                for (int i = 0; i < end; i++) {
-                    if (data[i] != mValues[i]) {
-                        return false;
-                    }
-                }
-                return true;
-            case MAGICOPERATOR_OR:
-                for (int i = 0; i < end; i++) {
-                    if ((data[i] & mValues[i]) != 0) {
-                        return true;
-                    }
-                }
-                return false;
-            case MAGICOPERATOR_NOT:
-            case MAGICOPERATOR_BWNOT:
-                for (int i = 0; i < end; i++) {
-                    if (data[i] != mValues[i]) {
-                        return true;
-                    }
-                }
-                return false;
-            case MAGICOPERATOR_GTHAN:
-            case MAGICOPERATOR_EQUAL_GTHAN:
-            case MAGICOPERATOR_LTHAN:
-            case MAGICOPERATOR_EQUAL_LTHAN:
-                int cmp = 0;
-                if (isBigEndian) {
-                    // Big Endian: MSB is at index 0
-                    for (int i = 0; i < end; i++) {
-                        int v1 = data[i] & 0xFF;
-                        int v2 = mValues[i] & 0xFF;
-                        if (v1 != v2) {
-                            cmp = Integer.compare(v1, v2);
-                            break;
-                        }
-                    }
-                } else {
-                    // Little Endian: MSB is at the last index
-                    for (int i = end - 1; i >= 0; i--) {
-                        int v1 = data[i] & 0xFF;
-                        int v2 = mValues[i] & 0xFF;
-                        if (v1 != v2) {
-                            cmp = Integer.compare(v1, v2);
-                            break;
-                        }
-                    }
-                }
-
-                switch (unaryOperator) {
-                    case MAGICOPERATOR_GTHAN:
-                        return cmp > 0;
-                    case MAGICOPERATOR_EQUAL_GTHAN:
-                        return cmp >= 0;
-                    case MAGICOPERATOR_LTHAN:
-                        return cmp < 0;
-                    case MAGICOPERATOR_EQUAL_LTHAN:
-                        return cmp <= 0;
-                    default:
-                        return false;
-                }
-            default:
-                throw new IllegalStateException(
-                        "This MagicNumber instance is configured incorrectly. The unary operator is set to an unknown or unconfigured value.");
+    private void applyMask(byte[] subject) {
+        if (mask != null && mask.length == subject.length) {
+            for (int i = 0; i < subject.length; i++) {
+                subject[i] &= mask[i];
+            }
         }
     }
 
     /**
-     * Retrieves the data sample
+     * Grabs a chunk of bytes from the input data starting at the given offset. Returns null if there aren't enough bytes
+     * available.
      */
     @Nullable
-    @SuppressWarnings("PMD.UnusedPrivateMethod")
-    private static byte[] getElement(@Nullable byte[] data, int offset, int length) {
+    private static byte[] extractElement(@Nullable byte[] data, int offset, int length) {
         if (data == null) {
             return null;
         }
@@ -376,24 +387,22 @@ public class MagicNumber {
     }
 
     /**
-     * Add child continuations
+     * Adds a group of sub-rules that should be checked if this rule succeeds.
+     *
+     * @param dependencyLayer an array of child rules for the next depth level
      */
     @SuppressWarnings("AvoidObjectArrays")
     public void addDependencyLayer(MagicNumber[] dependencyLayer) {
-        if (dependencies == null) {
-            dependencies = new ArrayList<>();
-        }
-        dependencies.add(dependencyLayer);
+        this.dependencyLayers.add(Arrays.asList(dependencyLayer));
     }
 
     /**
-     * Re-creates the string magic number entry for this number only
+     * Recreates the original config file line for this rule
      *
-     * @return a String represention of the entry
+     * @return the config line string
      */
     @Override
     public String toString() {
-
         StringBuilder sb = new StringBuilder();
         sb.append(">".repeat(Math.max(0, depth)));
         if (offsetUnary > 0) {
@@ -408,7 +417,7 @@ public class MagicNumber {
         }
 
         sb.append('\t');
-        sb.append(MagicNumberFactory.resolveReverseDataType(dataType));
+        sb.append(dataType.getKey());
         if (mask != null && mask.length > 0) {
             sb.append('&');
             sb.append(MagicMath.byteArrayToHexString(mask));
@@ -423,7 +432,7 @@ public class MagicNumber {
             sb.append(unaryOperator);
         }
 
-        if (dataType == TYPE_STRING && value != null) {
+        if (dataType == MagicDataType.STRING && value != null) {
             sb.append(new String(value, DEFAULT_CHARSET));
         } else {
             sb.append(MagicMath.byteArrayToHexString(value));
@@ -435,24 +444,85 @@ public class MagicNumber {
     }
 
     /**
-     * Private method to create the string plus continuations
+     * Handles the comparison logic (like equals, greater than, less than) used in rules.
      */
-    private String toString(@Nullable StringBuilder sbuf, int depth) {
-        StringBuilder sb = sbuf;
-        int d = depth;
-        if (sb == null) {
-            sb = new StringBuilder(description);
+    private enum MatchOperator {
+
+        EQUALS, NOT_EQUALS, ANY_BITS_SET, GREATER_THAN, LESS_THAN, GREATER_OR_EQUAL, LESS_OR_EQUAL;
+
+        static MatchOperator forSymbol(char symbol) {
+            switch (symbol) {
+                case MAGICOPERATOR_AND:
+                case MAGICOPERATOR_BWAND:
+                    return EQUALS;
+                case MAGICOPERATOR_NOT:
+                case MAGICOPERATOR_BWNOT:
+                    return NOT_EQUALS;
+                case MAGICOPERATOR_OR:
+                    return ANY_BITS_SET;
+                case MAGICOPERATOR_GTHAN:
+                    return GREATER_THAN;
+                case MAGICOPERATOR_LTHAN:
+                    return LESS_THAN;
+                case MAGICOPERATOR_EQUAL_GTHAN:
+                    return GREATER_OR_EQUAL;
+                case MAGICOPERATOR_EQUAL_LTHAN:
+                    return LESS_OR_EQUAL;
+                default:
+                    throw new IllegalStateException(
+                            "This MagicNumber instance is configured incorrectly. The unary operator is set to an unknown or unconfigured value.");
+            }
         }
-        if (dependencies == null || d >= dependencies.size()) {
-            return sb.toString();
+
+        boolean matches(byte[] subject, byte[] value, boolean mostSignificantByteFirst) {
+            switch (this) {
+                case EQUALS:
+                    return Arrays.equals(subject, value);
+                case NOT_EQUALS:
+                    return !Arrays.equals(subject, value);
+                case ANY_BITS_SET:
+                    for (int i = 0; i < subject.length; i++) {
+                        if ((subject[i] & value[i]) != 0) {
+                            return true;
+                        }
+                    }
+                    return false;
+                default:
+                    int cmp = compare(subject, value, mostSignificantByteFirst);
+                    switch (this) {
+                        case GREATER_THAN:
+                            return cmp > 0;
+                        case GREATER_OR_EQUAL:
+                            return cmp >= 0;
+                        case LESS_THAN:
+                            return cmp < 0;
+                        case LESS_OR_EQUAL:
+                            return cmp <= 0;
+                        default:
+                            throw new IllegalStateException("No comparison semantics for " + name());
+                    }
+            }
         }
-        MagicNumber[] dependentItems = dependencies.get(d);
-        for (MagicNumber dependentItem : dependentItems) {
-            sb.append('\n');
-            sb.append(dependentItem.toString());
+
+        private static int compare(byte[] left, byte[] right, boolean mostSignificantByteFirst) {
+            if (mostSignificantByteFirst) {
+                for (int i = 0; i < left.length; i++) {
+                    int l = left[i] & 0xFF;
+                    int r = right[i] & 0xFF;
+                    if (l != r) {
+                        return Integer.compare(l, r);
+                    }
+                }
+            } else {
+                for (int i = left.length - 1; i >= 0; i--) {
+                    int l = left[i] & 0xFF;
+                    int r = right[i] & 0xFF;
+                    if (l != r) {
+                        return Integer.compare(l, r);
+                    }
+                }
+            }
+            return 0;
         }
-        return toString(sb, d + 1);
     }
-
-
 }

--- a/src/main/java/emissary/util/magic/MagicNumberFactory.java
+++ b/src/main/java/emissary/util/magic/MagicNumberFactory.java
@@ -15,15 +15,20 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TreeMap;
 
+/**
+ * Parses file-type configuration rules (magic style) into ready-to-use {@link MagicNumber} objects.
+ *
+ * <p>
+ * Each rule line is made up of four columns separated by spaces or tabs: the file location/nesting depth, the data type
+ * and optional mask, the comparison check and value, and the description text. Rules with a depth greater than zero act
+ * as sub-rules (continuations) linked to a parent rule.
+ * </p>
+ */
 public class MagicNumberFactory {
 
     private static final Logger log = LoggerFactory.getLogger(MagicNumberFactory.class);
 
-    @Nullable
-    @SuppressWarnings("NonFinalStaticField")
-    private static Map<String, Integer> typeMap = null;
     public static final String EMPTYSTRING = "";
     public static final String ENTRY_NOT_NULL_RULE = "Entry cannot be null";
     public static final String ENTRY_4COLUMN_RULE = "Entry must have four tab separated columns";
@@ -38,29 +43,27 @@ public class MagicNumberFactory {
 
 
     /**
-     * Public method to parse a byte array representing the magic file into a list containing MagicNumber objects which are
-     * also nested with continuations as child MagicNumber instances.
+     * Reads a byte array of configuration data and turns it into a list of organized, nested rule objects.
      *
-     * @param configData the byte[] representing the magic file
-     * @param zeroDepthErrorList logs errors with zero depth entries
-     * @param continuationErrorMap logs errors with continuations - these are entries with depths &gt; 0
-     * @return a {@link List}.
+     * @param configData the raw bytes of the config file
+     * @param zeroDepthErrorList collects error messages for main rules that fail to parse
+     * @param continuationErrorMap collects error messages for sub-rules that fail to parse
+     * @return a list of top-level magic rules
      */
     public static List<MagicNumber> buildMagicNumberList(byte[] configData, List<String> zeroDepthErrorList,
             Map<String, List<String>> continuationErrorMap) {
-        // preserve the old way
         return buildMagicNumberList(configData, zeroDepthErrorList, continuationErrorMap, false);
     }
 
     /**
-     * Public method to parse a byte array representing the magic file into a list containing MagicNumber objects which are
-     * also nested with continuations as child MagicNumber instances.
+     * Reads a byte array of configuration data and turns it into a list of organized, nested rule objects, with an option
+     * to ignore unsupported data types.
      *
-     * @param configData the byte[] representing the magic file
-     * @param zeroDepthErrorList logs errors with zero depth entries
-     * @param continuationErrorMap logs errors with continuations - these are entries with depths &gt; 0
-     * @param swallowParseException boolean whether to swallow or propagate ParseExceptions that are IGNORABLE_DATATYPE_MSGS
-     * @return a {@link List}.
+     * @param configData the raw bytes of the config file
+     * @param zeroDepthErrorList collects error messages for main rules that fail to parse
+     * @param continuationErrorMap collects error messages for sub-rules that fail to parse
+     * @param swallowParseException true to quietly skip unsupported data type errors instead of throwing them
+     * @return a list of top-level magic rules
      */
     public static List<MagicNumber> buildMagicNumberList(byte[] configData, @Nullable List<String> zeroDepthErrorList,
             @Nullable Map<String, List<String>> continuationErrorMap, boolean swallowParseException) {
@@ -129,7 +132,6 @@ public class MagicNumberFactory {
                     if (swallowParseException &&
                             (e.getClass() == ParseException.class) &&
                             IGNORABLE_DATATYPE_MSGS.contains(e.getMessage())) {
-                        // swallow this cause said we don't care
                         continue;
                     }
 
@@ -140,7 +142,6 @@ public class MagicNumberFactory {
                         List<String> failedExtensions = continuationErrorMap.computeIfAbsent(signature, k -> new ArrayList<>());
                         failedExtensions.add("[MAGIC LINE# " + counter + "] " + s);
                     } else {
-                        // depth = 0
                         zeroDepthErrorList.add("[MAGIC LINE# " + counter + "] " + s);
                     }
                 }
@@ -150,22 +151,19 @@ public class MagicNumberFactory {
             }
         } catch (IOException ioe) {
             log.error("Caught IOException on buildMagicNumberList (throwing a runtime exception): {}", ioe.getMessage(), ioe);
-            // Doing all of this in memory - yes, one could erroneously use one of the IO objects but ...
             throw new EmissaryRuntimeException(ioe);
         }
         return magicNumberList;
     }
 
     /**
-     * Private method for parsing entries and storing them into the target storage data structure which is a list.
+     * Parses a single rule line and adds it to the target storage list.
      *
-     *
-     * @param entry the magic number String entry
-     * @param storage a {@link List} where the MagicNumber instances will be placed
-     * @param swallowParseException should we swallow Ignorable ParseException or bubble them up
-     * @return the MagicNumber instance created
-     * @throws Exception if one occurs while parsing the entry
-     * @see #buildMagicNumber(java.lang.String, boolean)
+     * @param storage the list to add the rule to
+     * @param entry the raw text line of the rule
+     * @param swallowParseException whether to ignore unsupported type errors
+     * @return the created rule object, or null if skipped
+     * @throws Exception if parsing fails
      */
     private static MagicNumber parseAndStore(List<MagicNumber> storage, String entry, boolean swallowParseException) throws Exception {
         MagicNumber item = buildMagicNumber(entry, swallowParseException);
@@ -176,54 +174,58 @@ public class MagicNumberFactory {
     }
 
     /**
-     * Private method to store the list of MagicNumber instances and adds them a new layer of continuations in the target
-     * MagicNumber
+     * Attaches a group of sub-rules as a new evaluation layer onto a parent rule.
      *
-     * @param target the MagicNumber instance acting as the parent for the continuations
-     * @param extensions a {@link List} of continuations which are MagicNumber instances
+     * @param extensions the list of child rule objects
+     * @param target the parent rule object
      */
     private static void addExtensionsLayer(List<MagicNumber> extensions, MagicNumber target) {
-        MagicNumber[] extensionArray = extensions.toArray(new MagicNumber[0]);
-        target.addDependencyLayer(extensionArray);
+        target.addDependencyLayer(extensions.toArray(new MagicNumber[0]));
     }
 
     /**
-     * Parses a magic number entry and prepares a magic number item
-     * 
-     * @param entry line to parse
+     * Parses a single configuration line into a rule object.
+     *
+     * @param entry the rule text line
+     * @return the parsed rule object
+     * @throws ParseException if the line format is invalid
      */
     public static MagicNumber buildMagicNumber(String entry) throws ParseException {
         return buildMagicNumber(entry, false);
     }
 
     /**
-     * Parses a magic number entry and prepares a magic number item
-     * 
-     * @param entry line to parse
-     * @param swallowParseException should we swallow Ignorable ParseException or bubble them up
+     * Parses a single configuration line into a rule object, with an option to ignore unsupported data types.
+     *
+     * @param entry the rule text line
+     * @param swallowParseException whether to ignore unsupported types
+     * @return the parsed rule object
+     * @throws ParseException if the line format is invalid
      */
     public static MagicNumber buildMagicNumber(String entry, boolean swallowParseException) throws ParseException {
 
         String[] columns = prepareEntry(entry);
-        MagicNumber item = new MagicNumber();
 
+        int depth;
+        int offset;
+        char offsetUnary;
         try {
-            // column A parsing
-            item.depth = getEntryDepth(columns[0]);
-            item.offsetUnary = resolveOffsetUnary(columns);
-            item.offset = resolveOffset(columns, item);
+            depth = getEntryDepth(columns[0]);
+            offsetUnary = resolveOffsetUnary(columns);
+            offset = resolveOffset(columns, depth);
         } catch (Exception e) {
             throw new ParseException("Error on column 0:" + columns[0] + ". " + e.getMessage());
         }
+
+        MagicDataType dataType;
+        int dataTypeLength;
+        byte[] mask;
         try {
-            // column B parsing
-            item.dataType = resolveDataType(columns);
-            item.dataTypeLength = getDataTypeByteLength(item);
-            item.mask = resolveMask(columns, item);
+            dataType = resolveDataType(columns);
+            dataTypeLength = dataType.getFixedByteLength();
+            mask = resolveMask(columns, dataTypeLength);
         } catch (Exception e) {
             if (swallowParseException) {
-                // This means you put TRUE in SWALLOW_IGNORABLE_EXCEPTIONS in a UnixFilePlace.cfg file
-                // so let's log at debug level, so you can hide these message easily
                 log.debug("Warning unable to read column 1\t: {} - {}", columns[1], e.getMessage());
             } else {
                 log.error("original entry   \t: {}", entry);
@@ -231,24 +233,28 @@ public class MagicNumberFactory {
             }
             throw new ParseException("Parse Error on column 1:" + columns[1] + ". " + e.getMessage());
         }
-        try {
-            // column C parsing
-            item.unaryOperator = resolveUnary(columns, item);
-            item.value = resolveValue(columns, item);
 
-            if (item.dataType == MagicNumber.TYPE_STRING && item.value != null) {
-                item.dataTypeLength = item.value.length;
+        char unaryOperator;
+        byte[] value;
+        boolean substitute;
+        try {
+            unaryOperator = resolveUnary(columns, dataType);
+            value = resolveValue(columns, dataType, dataTypeLength);
+            substitute = isAnyValuePlaceholder(columns[2]);
+
+            if (dataType == MagicDataType.STRING && value != null) {
+                dataTypeLength = value.length;
             }
         } catch (Exception e) {
             throw new ParseException("Error on column 2:" + columns[2] + ". " + e.getMessage());
         }
-        // column D parsing
-        item.description = columns[3];
-        return item;
+
+        return new MagicNumber(depth, offset, offsetUnary, dataType, dataTypeLength, mask, unaryOperator, value,
+                substitute, columns[3]);
     }
 
     /**
-     * Tokenizes an entry into four columns by tab or space while recognizing escape sequences.
+     * Splits a configuration line into four distinct columns by spaces or tabs, taking escape characters into account.
      */
     private static String[] tokenizeEntry(String entry) {
         int index = 0;
@@ -283,7 +289,7 @@ public class MagicNumberFactory {
     }
 
     /**
-     * Corrects some known/common erroneous syntax errors
+     * Cleans up common syntax mistakes or formatting issues in a raw rule line before parsing.
      */
     private static String[] prepareEntry(String entry) throws ParseException {
         if (entry == null) {
@@ -305,13 +311,10 @@ public class MagicNumberFactory {
         return columns;
     }
 
-    // -----------------------------------------------------------------------
-    // COLUMN A: >&offsetValue
-    // -----------------------------------------------------------------------
-    private static int resolveOffset(String[] columns, MagicNumber item) throws ParseException {
+    private static int resolveOffset(String[] columns, int depth) throws ParseException {
         String entry = columns[0];
-        if (item.depth > 0) {
-            entry = entry.substring(item.depth);
+        if (depth > 0) {
+            entry = entry.substring(depth);
         }
         if (entry.charAt(0) == '&') {
             entry = entry.substring(1);
@@ -332,6 +335,12 @@ public class MagicNumberFactory {
         return (char) 0;
     }
 
+    /**
+     * Determines how deeply nested a rule line is based on how many greater-than symbols (&gt;) start the line.
+     *
+     * @param entry the rule line text
+     * @return the nesting depth number, or -1 if invalid
+     */
     public static int getEntryDepth(String entry) {
         if (entry.isEmpty() || (entry.charAt(0) != '>' && !Character.isDigit(entry.charAt(0)))) {
             return -1;
@@ -345,12 +354,7 @@ public class MagicNumberFactory {
         return depth;
     }
 
-    // -----------------------------------------------------------------------
-    // COLUMN B: BYTE&maskValue
-    // -----------------------------------------------------------------------
-    private static int resolveDataType(String[] columns) throws ParseException {
-        initTypeMap();
-
+    private static MagicDataType resolveDataType(String[] columns) throws ParseException {
         String subject = columns[1];
         if (subject.startsWith("search")) {
             throw new ParseException(UNSUPPORTED_DATATYPE_MSG_SEARCH);
@@ -362,53 +366,30 @@ public class MagicNumberFactory {
             throw new ParseException(UNSUPPORTED_DATATYPE_MSG_UNSIGNED);
         }
 
-        // parse out any masking
         int ix = subject.indexOf("&") > 0 ? subject.indexOf("&") : subject.indexOf("/");
-        if (ix > 0) {
-            subject = columns[1].substring(0, ix);
-        }
-        int dataTypeId = lookupDataType(subject);
-        if (dataTypeId < 0) {
-            throw new ParseException("Unsupported Data Type: " + subject);
-        }
-        return dataTypeId;
-    }
+        String typeName = ix > 0 ? columns[1].substring(0, ix) : subject;
 
-    private static int lookupDataType(String arg) {
-        Integer dataTypeIdInt = typeMap.get(arg.toUpperCase(Locale.getDefault()));
-        if (dataTypeIdInt == null) {
-            return -1;
-        }
-        switch (dataTypeIdInt) {
-            case MagicNumber.TYPE_DATE:
-            case MagicNumber.TYPE_BEDATE:
-            case MagicNumber.TYPE_LEDATE:
-                return -1;
-            default:
-                return dataTypeIdInt;
-        }
+        return MagicDataType.fromKey(typeName)
+                .filter(MagicDataType::isSupported)
+                .orElseThrow(() -> new ParseException("Unsupported Data Type: " + typeName));
     }
 
     @Nullable
-    private static byte[] resolveMask(String[] columns, MagicNumber item) {
+    private static byte[] resolveMask(String[] columns, int dataTypeLength) {
         int ix = columns[1].indexOf("&");
         if (ix > 0) {
             byte[] maskValues = MagicMath.stringToByteArray(columns[1].substring(ix + 1));
-            return MagicMath.setLength(maskValues, item.dataTypeLength);
+            return MagicMath.setLength(maskValues, dataTypeLength);
         }
         return null;
     }
 
-    // -----------------------------------------------------------------------
-    // COLUMN C: [UNARY_OPERATOR][Some value like 0x00]
-    // -----------------------------------------------------------------------
-    private static byte[] resolveValue(String[] columns, MagicNumber item) {
+    private static byte[] resolveValue(String[] columns, MagicDataType dataType, int dataTypeLength) {
         String subject = columns[2];
 
-        if (item.dataType == MagicNumber.TYPE_STRING && !(subject.length() == 1 && subject.charAt(0) == 'x')) {
+        if (dataType == MagicDataType.STRING && !isAnyValuePlaceholder(subject)) {
             return MagicMath.parseEscapedString(subject);
-        } else if (subject.length() == 1 && subject.charAt(0) == 'x') {
-            item.substitute = true;
+        } else if (isAnyValuePlaceholder(subject)) {
             return new byte[0];
         }
 
@@ -416,18 +397,22 @@ public class MagicNumberFactory {
         if (unaryLen > 0) {
             subject = subject.substring(unaryLen);
         }
-        if (subject.toUpperCase(Locale.getDefault()).endsWith("L")) {
+        if (subject.toUpperCase(Locale.ROOT).endsWith("L")) {
             subject = subject.substring(0, subject.length() - 1);
         }
         byte[] valueArray = MagicMath.stringToByteArray(subject);
-        valueArray = MagicMath.setLength(valueArray, item.dataTypeLength);
+        valueArray = MagicMath.setLength(valueArray, dataTypeLength);
 
-        if (item.dataType == MagicNumber.TYPE_LELONG) {
+        if (dataType == MagicDataType.LELONG) {
             MagicMath.longEndianSwap(valueArray, 0);
-        } else if (item.dataType == MagicNumber.TYPE_LESHORT) {
+        } else if (dataType == MagicDataType.LESHORT) {
             MagicMath.shortEndianSwap(valueArray, 0);
         }
         return valueArray;
+    }
+
+    private static boolean isAnyValuePlaceholder(String subject) {
+        return subject.length() == 1 && subject.charAt(0) == 'x';
     }
 
     private static int unaryPrefixLength(@Nullable String s) {
@@ -456,31 +441,9 @@ public class MagicNumberFactory {
         return 0;
     }
 
-    private static int getDataTypeByteLength(MagicNumber item) {
-        int dataTypeId = item.dataType;
-        switch (dataTypeId) {
-            case MagicNumber.TYPE_STRING:
-                return (item.value == null) ? -1 : item.value.length;
-            case MagicNumber.TYPE_BYTE:
-                return 1;
-            case MagicNumber.TYPE_SHORT:
-            case MagicNumber.TYPE_BESHORT:
-            case MagicNumber.TYPE_LESHORT:
-                return 2;
-            case MagicNumber.TYPE_LONG:
-            case MagicNumber.TYPE_BELONG:
-            case MagicNumber.TYPE_LELONG:
-            case MagicNumber.TYPE_BEDATE:
-            case MagicNumber.TYPE_LEDATE:
-                return 4;
-            default:
-                return -1;
-        }
-    }
-
-    private static char resolveUnary(String[] columns, MagicNumber item) throws ParseException {
+    private static char resolveUnary(String[] columns, MagicDataType dataType) throws ParseException {
         int unaryLen = unaryPrefixLength(columns[2]);
-        if (item.dataType == MagicNumber.TYPE_STRING || unaryLen == 0) {
+        if (dataType == MagicDataType.STRING || unaryLen == 0) {
             return MagicNumber.MAGICOPERATOR_DEFAULT;
         } else if (unaryLen == 1) {
             return columns[2].charAt(0);
@@ -493,32 +456,14 @@ public class MagicNumberFactory {
         }
     }
 
+    /**
+     * Finds the text name of a data type using its old legacy numeric ID.
+     *
+     * @param legacyTypeId the historical numeric type ID
+     * @return the text key name, or null if unknown
+     */
     @Nullable
-    public static String resolveReverseDataType(int dataTypeId) {
-        initTypeMap();
-        for (Map.Entry<String, Integer> entry : typeMap.entrySet()) {
-            if (entry.getValue() == dataTypeId) {
-                return entry.getKey();
-            }
-        }
-        return null;
-    }
-
-    private static void initTypeMap() {
-        if (typeMap != null) {
-            return;
-        }
-        typeMap = new TreeMap<>();
-        typeMap.put(MagicNumber.TYPE_KEY_BYTE, MagicNumber.TYPE_BYTE);
-        typeMap.put(MagicNumber.TYPE_KEY_SHORT, MagicNumber.TYPE_SHORT);
-        typeMap.put(MagicNumber.TYPE_KEY_LONG, MagicNumber.TYPE_LONG);
-        typeMap.put(MagicNumber.TYPE_KEY_STRING, MagicNumber.TYPE_STRING);
-        typeMap.put(MagicNumber.TYPE_KEY_DATE, MagicNumber.TYPE_DATE);
-        typeMap.put(MagicNumber.TYPE_KEY_BESHORT, MagicNumber.TYPE_BESHORT);
-        typeMap.put(MagicNumber.TYPE_KEY_BELONG, MagicNumber.TYPE_BELONG);
-        typeMap.put(MagicNumber.TYPE_KEY_BEDATE, MagicNumber.TYPE_BEDATE);
-        typeMap.put(MagicNumber.TYPE_KEY_LESHORT, MagicNumber.TYPE_LESHORT);
-        typeMap.put(MagicNumber.TYPE_KEY_LELONG, MagicNumber.TYPE_LELONG);
-        typeMap.put(MagicNumber.TYPE_KEY_LEDATE, MagicNumber.TYPE_LEDATE);
+    public static String resolveReverseDataType(int legacyTypeId) {
+        return MagicDataType.fromLegacyId(legacyTypeId).map(MagicDataType::getKey).orElse(null);
     }
 }

--- a/src/main/java/emissary/util/magic/package-info.java
+++ b/src/main/java/emissary/util/magic/package-info.java
@@ -1,4 +1,258 @@
 /**
- * Utilities for {@link emissary.util.UnixFile} magic identification
+ * Tools for identifying file types using standard configuration rules.
+ *
+ * <p>
+ * This package provides a Java-based reader and evaluator for file-type rules (inspired by standard UNIX magic files).
+ * {@link MagicNumberFactory} converts configuration lines into ready-to-use rule objects, {@link MagicMath} handles the
+ * math conversions, and {@link emissary.util.MagicNumberUtil}/{@link emissary.util.UnixFile} check actual files against
+ * these rules.
+ * </p>
+ *
+ * <p>
+ * This parser is designed to handle a specific set of rules from standard file identification databases, though it
+ * doesn't support every single advanced feature available in modern UNIX systems. Below is an overview of how the rules
+ * are structured, what features are supported, and how the parser behaves.
+ * </p>
+ *
+ * <h2>Rule Structure</h2>
+ *
+ * <pre>
+ * &gt;&gt;&amp;0x1E       belong&amp;0xfe00f0f0    &gt;0x3030    MS Windows shortcut, Version %d
+ * --depth+off-- ----type---mask----   -op-value-  -------description--------
+ * </pre>
+ *
+ * <h2>Feature Support Overview</h2>
+ *
+ * <table border="1">
+ * <caption>Feature comparison</caption>
+ * <tr>
+ * <th>Feature</th>
+ * <th>Standard UNIX file(1)</th>
+ * <th>This Package</th>
+ * <th>Example</th>
+ * </tr>
+ *
+ * <tr>
+ * <td colspan="4"><b>Column A - Location and Depth</b></td>
+ * </tr>
+ * <tr>
+ * <td>Exact position (decimal, hex, octal)</td>
+ * <td>Yes</td>
+ * <td>Yes</td>
+ * <td>{@code 0x18}, {@code 26}, {@code 036}</td>
+ * </tr>
+ * <tr>
+ * <td>Nesting depth using leading greater-than symbols ({@code >})</td>
+ * <td>Yes</td>
+ * <td>Yes, grouped by depth levels</td>
+ * <td>{@code >>>0}</td>
+ * </tr>
+ * <tr>
+ * <td>Relative position marker ({@code &})</td>
+ * <td>Position relative to the end of the previous field</td>
+ * <td><b>Marker is read then ignored</b>; treated as a fixed position from the start of the file</td>
+ * <td>{@code >&4}</td>
+ * </tr>
+ * <tr>
+ * <td>Parenthesized position ({@code (n)})</td>
+ * <td>Yes</td>
+ * <td>Yes, parentheses are removed</td>
+ * <td>{@code >(26)}</td>
+ * </tr>
+ * <tr>
+ * <td>Position pointing to another value</td>
+ * <td>Looks up the stored value to find the new position</td>
+ * <td><b>Rejected at load time</b>; sub-rules are dropped if errors are ignored</td>
+ * <td>{@code (0x3c.l)}</td>
+ * </tr>
+ * <tr>
+ * <td>Named positions and reusable blocks</td>
+ * <td>Yes</td>
+ * <td>No</td>
+ * <td>{@code name zipcd}</td>
+ * </tr>
+ *
+ * <tr>
+ * <td colspan="4"><b>Column B - Data Types</b></td>
+ * </tr>
+ * <tr>
+ * <td>Basic types (byte, short, long, text)</td>
+ * <td>Yes</td>
+ * <td>Yes</td>
+ * <td>{@code string PK\003\004}</td>
+ * </tr>
+ * <tr>
+ * <td>Byte order variants (big-endian and little-endian)</td>
+ * <td>Yes</td>
+ * <td>Yes, limited to four standard variations</td>
+ * <td>{@code beshort belong leshort lelong}</td>
+ * </tr>
+ * <tr>
+ * <td>Unsigned number types</td>
+ * <td>Yes</td>
+ * <td><b>Rejected</b> ("Signed Data Types unsupported"); values are treated as unsigned anyway</td>
+ * <td>{@code ubelong&0x000f0000}</td>
+ * </tr>
+ * <tr>
+ * <td>Date and time types</td>
+ * <td>Yes</td>
+ * <td><b>Rejected</b></td>
+ * <td>{@code bedate-0x7C25B080}</td>
+ * </tr>
+ * <tr>
+ * <td>Large numbers and decimals (quad, float, double)</td>
+ * <td>Yes</td>
+ * <td><b>Rejected</b></td>
+ * <td>{@code lequad x}</td>
+ * </tr>
+ * <tr>
+ * <td>Specialized types (guid, clear, indirect, etc.)</td>
+ * <td>Yes</td>
+ * <td><b>Rejected</b></td>
+ * <td>{@code default x}</td>
+ * </tr>
+ * <tr>
+ * <td>Bounded text search ({@code search/N})</td>
+ * <td>Searches up to N bytes</td>
+ * <td><b>Rejected</b></td>
+ * <td>{@code search/256 self}</td>
+ * </tr>
+ * <tr>
+ * <td>Regular expressions ({@code regex})</td>
+ * <td>Searches lines using patterns</td>
+ * <td><b>Rejected</b></td>
+ * <td>{@code regex/c =^[\ \t]{0,10}say\ ['"]}</td>
+ * </tr>
+ * <tr>
+ * <td>Text modifiers (case-insensitivity, whitespace rules)</td>
+ * <td>Yes</td>
+ * <td><b>Ignored</b>; treated as plain text</td>
+ * <td>{@code string/W}, {@code string/cW}</td>
+ * </tr>
+ * <tr>
+ * <td>Bit masks ({@code type&mask})</td>
+ * <td>Yes</td>
+ * <td>Yes, applied before checking numbers</td>
+ * <td>{@code belong&0xfe00f0f0 >0x3030}</td>
+ * </tr>
+ *
+ * <tr>
+ * <td colspan="4"><b>Column C - Comparisons and Values</b></td>
+ * </tr>
+ * <tr>
+ * <td>Standard values</td>
+ * <td>Checks for exact equality</td>
+ * <td>Checks for exact equality</td>
+ * <td>{@code 0xcafebabe}</td>
+ * </tr>
+ * <tr>
+ * <td>Comparison signs ({@code = ! > < >= <=})</td>
+ * <td>Signed comparisons</td>
+ * <td>Unsigned comparisons</td>
+ * <td>{@code beshort >=0x0301}</td>
+ * </tr>
+ * <tr>
+ * <td>Wildcard ({@code x})</td>
+ * <td>Always matches, allows pulling values into text</td>
+ * <td>Same behavior</td>
+ * <td>{@code beshort x version %d}</td>
+ * </tr>
+ * <tr>
+ * <td>Bitwise AND ({@code &})</td>
+ * <td>Checks if all specified bits are set</td>
+ * <td><b>Divergence:</b> Handled the same as a simple equals check</td>
+ * <td>{@code leshort &0x8000}</td>
+ * </tr>
+ * <tr>
+ * <td>Bitwise NOT ({@code ^})</td>
+ * <td>Checks if bits are clear</td>
+ * <td><b>Divergence:</b> Handled the same as an inequality check</td>
+ * <td>{@code belong ^0x0A0D1A00}</td>
+ * </tr>
+ * <tr>
+ * <td>Negative numbers</td>
+ * <td>Yes</td>
+ * <td>No, treated as raw bit patterns</td>
+ * <td>{@code byte >-2}</td>
+ * </tr>
+ * <tr>
+ * <td>Math operations on data</td>
+ * <td>Yes</td>
+ * <td>No</td>
+ * <td>{@code byte*2^8}</td>
+ * </tr>
+ *
+ * <tr>
+ * <td colspan="4"><b>Column D - Descriptions and Output</b></td>
+ * </tr>
+ * <tr>
+ * <td>Numeric placeholders ({@code %d %ld})</td>
+ * <td>Standard formatting</td>
+ * <td>Inserts the decimal value of the read bytes</td>
+ * <td>{@code version %d.%ld}</td>
+ * </tr>
+ * <tr>
+ * <td>Text placeholders ({@code %s %c})</td>
+ * <td>Text and character output</td>
+ * <td>Raw bytes; note that text rules always grab a single byte regardless of match size</td>
+ * <td>{@code '%s'}</td>
+ * </tr>
+ * <tr>
+ * <td>Formatting options (padding, alignment)</td>
+ * <td>Yes</td>
+ * <td>No</td>
+ * <td>{@code %-12.12s}</td>
+ * </tr>
+ * <tr>
+ * <td>Backspace characters ({@code \b})</td>
+ * <td>Joins multiple matches</td>
+ * <td>Deletes the previous character in the output text</td>
+ * <td>{@code \b%d}</td>
+ * </tr>
+ * <tr>
+ * <td>Multiple matches</td>
+ * <td>Combines all matches together</td>
+ * <td><b>Only the first match is used</b>, based on file order</td>
+ * <td>-</td>
+ * </tr>
+ * </table>
+ *
+ * <h2>Important Behavioral Differences</h2>
+ *
+ * <ol>
+ * <li><b>Sub-rule evaluation.</b> Standard tools test sub-rules only if their direct parent matches. Here, sub-rules
+ * are grouped into depth levels: a whole layer is tested if <i>any</i> rule in the previous layer matched. This means
+ * related branches can sometimes trigger together, stopping only when an entire layer fails to match.</li>
+ * <li><b>Sorting.</b> Rules are evaluated strictly in the order they appear in the file, rather than being sorted by
+ * importance.</li>
+ * <li><b>Fallback checks.</b> If no specific rule matches a file, the system checks for low-value control bytes to
+ * classify the file as either a binary file or plain text, rather than performing detailed language or character set
+ * analysis.</li>
+ * <li><b>Flexible formatting.</b> Extra spaces, tabs, and common syntax issues in the configuration files are
+ * automatically cleaned up to handle minor formatting inconsistencies smoothly.</li>
+ * <li><b>Error tolerance.</b> When error-swallowing mode is turned on, unsupported rule types are quietly skipped
+ * instead of stopping the application.</li>
+ * </ol>
+ *
+ * <h2>Examples</h2>
+ *
+ * <pre>
+ * Supported:
+ *   0   string    PK\003\004              Zip archive data
+ *   &gt;4   beshort  x                       \b, version %d        - pulls value into description text
+ *   0   belong&amp;0xffffff00        0xffd8ff00      JPEG image data          - uses bit masks for checks
+ *   &gt;0   byte&amp;0x1F                0x07            \b, LZMA compressed      - checks masked nibble values
+ *
+ * Skipped when error handling is enabled:
+ *   0   ubelong  &amp;0x000f0000     0x000e0000      Mach-O universal binary    - unsigned numbers
+ *   &gt;&amp;32 search/256 self                \b, contains embedded zip   - bounded text search
+ *   0   regex   ^#!.*python    Python script               - regular expressions
+ *   0   lequad  x                       Little-endian 64-bit        - large 8-byte numbers
+ *
+ * Parsed with minor behavioral differences:
+ *   &gt;(0x3c.l)  lelong  x   \b resource fork           - indirect position: rule is dropped entirely
+ *   &gt;&amp;4        beshort x   \b, next header            - relative marker ignored: checked at absolute position 4
+ *   0  string/W  ABCDEF   whitespace tolerant match   - modifier ignored: requires exact text spacing
+ * </pre>
  */
 package emissary.util.magic;

--- a/src/test/java/emissary/util/magic/MagicMathTest.java
+++ b/src/test/java/emissary/util/magic/MagicMathTest.java
@@ -74,6 +74,8 @@ class MagicMathTest extends UnitTest {
         assertArrayEquals(new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF}, MagicMath.stringToByteArray(4, "-1"));
         assertArrayEquals(new byte[] {0x01, (byte) 0xFF}, MagicMath.stringToByteArray(2, "0777"), "octal works here too");
         assertArrayEquals(new byte[] {0x2C}, MagicMath.stringToByteArray(1, "300"), "values too big simply lose their highest bytes");
+        assertArrayEquals(new byte[] {0x00, 0x00, 0x41, 0x42}, MagicMath.stringToByteArray(4, "0x4142"),
+                "hex values padded to the requested size like decimals are");
     }
 
     @Test
@@ -90,13 +92,14 @@ class MagicMathTest extends UnitTest {
         assertEquals("65", MagicMath.byteArrayToString(new byte[] {0x00, 0x41}, 10), "empty bytes at the front are skipped");
         assertEquals("0", MagicMath.byteArrayToString(new byte[] {0x00, 0x00}, 10), "all-empty bytes just read as zero");
         assertEquals("41", MagicMath.byteArrayToString(new byte[] {0x41}, 16));
+        assertEquals("255", MagicMath.byteArrayToString(new byte[] {(byte) 0xFF}, 10), "bytes read as unsigned values");
+        assertEquals("4294967295", MagicMath.byteArrayToString(new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF}, 10));
     }
 
     @Test
     void testBytesToDebugHexString() {
         assertEquals("0x4142", MagicMath.byteArrayToHexString(new byte[] {0x41, 0x42}));
-        assertEquals("0x41-45", MagicMath.byteArrayToHexString(new byte[] {0x41, (byte) 0xBB}),
-                "debug helper only: high-bit bytes print with a minus sign instead of proper hex digits");
+        assertEquals("0x41bb", MagicMath.byteArrayToHexString(new byte[] {0x41, (byte) 0xBB}));
     }
 
     @Test

--- a/src/test/java/emissary/util/magic/MagicNumberFactoryTest.java
+++ b/src/test/java/emissary/util/magic/MagicNumberFactoryTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -156,5 +157,18 @@ class MagicNumberFactoryTest extends UnitTest {
     void testStringSubstitution() throws ParseException {
         MagicNumber m = MagicNumberFactory.buildMagicNumber("0 string x SUBST");
         assertTrue(m.isSubstitute(), "the 'x' value should set the substitute flag");
+    }
+
+    @Test
+    void testStringSubstitutionDescribe() throws ParseException {
+        MagicNumber m = MagicNumberFactory.buildMagicNumber("0 string x %s");
+        assertEquals("A", m.describe(new byte[] {0x41}), "a %s string substitution should emit the single byte as text");
+    }
+
+    @Test
+    void testTwoByteFileStillSubstitutesSingleByte() throws ParseException {
+        MagicNumber m = MagicNumberFactory.buildMagicNumber("0 string x %s");
+        assertEquals("A", m.describe(new byte[] {0x41, 0x42}),
+                "a two-byte value must not skip the substitution even though there is no trailing byte");
     }
 }

--- a/src/test/java/emissary/util/magic/MagicNumberFactoryTest.java
+++ b/src/test/java/emissary/util/magic/MagicNumberFactoryTest.java
@@ -155,6 +155,6 @@ class MagicNumberFactoryTest extends UnitTest {
     @Test
     void testStringSubstitution() throws ParseException {
         MagicNumber m = MagicNumberFactory.buildMagicNumber("0 string x SUBST");
-        assertTrue(m.substitute, "the 'x' value should set the substitute flag");
+        assertTrue(m.isSubstitute(), "the 'x' value should set the substitute flag");
     }
 }


### PR DESCRIPTION
- [ ]  builds on #1524 

Fixes
1. A byte like 0xBB was printing as -45 instead of bb. The fix treats each byte as the 0-255 value it really is and prints the proper two-digit hex.
2. When a magic rule's description pulls actual bytes out of the file (e.g. %d for a version number), it was interpreting the bytes as a signed number. So FF FF FF FF (max unsigned value) printed as -1. Now it treats them as unsigned, so it prints the big positive number.
3. The logic checked "is there 3+ bytes left?" but only actually needed 1 byte. So a 2-byte file never got its value substituted at all. Now it only requires the 1 byte it actually reads.
4. For a string rule with a %d placeholder, it was outputting the raw character (e.g. A) instead of its numeric value (65). Now %d/%ld on a string yields the number.
5. A rule like >-5 (look 5 bytes before the current spot) would try to read from a negative position and throw an error. Now it just treats that as "no match" instead of crashing.
6. When asked to produce a specific-length array, the hex path ignored the size (returned 0x41 0x42) while the decimal path respected it (padded to 00 00 41 42). Now both pad consistently to the requested size.
